### PR TITLE
Introduce quark_queue_attr{}

### DIFF
--- a/go/bin/quark-mon.go
+++ b/go/bin/quark-mon.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	qq, err := quark.OpenQueue(64)
+	qq, err := quark.OpenQueue(quark.DefaultQueueAttr(), 64)
 	if err != nil {
 		panic(err)
 	}

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm quark-mon
 .Op Fl bDktv
+.Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
 .Sh DESCRIPTION
 The
@@ -30,6 +31,11 @@ Drop priviledges to nobody and chroot to /var/empty, useful to show how quark
 can run without priviledges.
 .It Fl k
 Attempt kprobe as the backend.
+.It Fl l Ar maxlength
+Maximum lenght of the quark queue, essentially how much quark is willing to
+buffer, refer to
+.Xr quark_queue_open 3
+for further details.
 .It Fl t
 Don't supress thread events, this is only useful for debugging and will likely
 be zapped in the future.

--- a/quark_event_dump.3
+++ b/quark_event_dump.3
@@ -66,6 +66,7 @@ Zero on success, -1 in error from
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,

--- a/quark_event_lookup.3
+++ b/quark_event_lookup.3
@@ -33,6 +33,7 @@ is set to
 .Xr quark_event_dump 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,

--- a/quark_queue_block.3
+++ b/quark_queue_block.3
@@ -36,6 +36,7 @@ is set.
 .Xr quark_event_dump 3 ,
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,

--- a/quark_queue_close.3
+++ b/quark_queue_close.3
@@ -25,6 +25,7 @@ is set.
 .Xr quark_event_dump 3 ,
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,

--- a/quark_queue_default_attr.3
+++ b/quark_queue_default_attr.3
@@ -1,0 +1,28 @@
+.Dd $Mdocdate$
+.Dt QUARK_QUEUE_DEFAULT_ATTR 3
+.Os
+.Sh NAME
+.Nm quark_queue_default_attr
+.Nd fetch default attributes for
+.Xr quark_queue_open 3
+.Sh SYNOPSIS
+.In quark.h
+.Ft void
+.Fn quark_queue_default_attr "struct quark_queue_attr *attr"
+.Sh DESCRIPTION
+.Nm
+copies out default attributes for opening a quark_queue.
+.Pp
+Refer to
+.Xr quark_queue_open 3
+for an in depth explanation of each member.
+.Sh SEE ALSO
+.Xr quark_event_dump 3 ,
+.Xr quark_event_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_get_events 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark 7 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8

--- a/quark_queue_get_epollfd.3
+++ b/quark_queue_get_epollfd.3
@@ -59,6 +59,7 @@ my_own_blocking(struct quark_queue *qq)
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,

--- a/quark_queue_get_events.3
+++ b/quark_queue_get_events.3
@@ -118,6 +118,7 @@ is set.
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -56,6 +56,7 @@ reading to know if it increased.
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -8,13 +8,15 @@
 .Sh SYNOPSIS
 .In quark.h
 .Ft int
-.Fn quark_queue_open "struct quark_queue *qq" "int flags"
+.Fn quark_queue_open "struct quark_queue *qq" "struct quark_queue_attr *attr"
 .Sh DESCRIPTION
 .Nm
 initializes the
 .Vt quark_queue
 pointed to by
-.Fa qq .
+.Fa qq
+with the attributes pointed to by
+.Fa attr .
 .Pp
 A
 .Vt quark_queue
@@ -30,7 +32,7 @@ function does the following:
 .It
 Attempts to use the best backend available unless otherwise especified.
 This includes loading the EBPF programs for EBPF or the probes for KPROBES.
-Only one backend is used and it defaults to EBPF and fallsback to KPROBE.
+Only one backend is used and it defaults to EBPF and falls back to KPROBE.
 .It
 On its first call it will also initialize global host state, like BTF offsets
 and HZ.
@@ -61,17 +63,30 @@ member set to
 .Dv QUARK_EV_SNAPSHOT .
 .El
 .Pp
-.Fa flags
-is a bitmask that changes the default queue behaviour with the following values:
+Default queue behaviour can be tweaked with
+.Fa attr .
+A default configuration for tweaking can be acquired via
+.Xr quark_queue_default_attr 3 .
+In case
+.Fa attr
+is NULL, the default configuration is used.
 .Pp
-.Bl -tag -width QQ_THREAD_EVENTS -offset indent -compact
+.Fa struct quark_queue_attr
+is defined as:
+.Bd -literal -offset indent
+struct quark_queue_attr {
+	int	 flags;
+	int	 max_length;
+	...
+};
+.Ed
+.Bl -tag -width "max_length"
+.It Em flags
+Bitmask of:
+.Bl -tag -width QQ_THREAD_EVENTS
 .It Dv QQ_EBPF
-Enable the EBPF backend, in case neither
-.Dv QQ_EBPF
-or
-.Dv QQ_KPROBE
-are specified, it defaults to both.
-EBPF is attempted first and fallsback to KPROBE if it failed.
+Enable the EBPF backend.
+EBPF is attempted first and falls back to KPROBE if both were specified.
 .It Dv QQ_KPROBE
 Enable the KPROBE backend, see above.
 .It Dv QQ_THREAD_EVENTS
@@ -82,6 +97,16 @@ Don't use the internal process cache to enrich events, normally when quark
 receives an event, it will include all the cached information it had about that
 process so that the event has more context, passing this flag will get you
 "naked" events.
+.It Dv QQ_ALL_BACKENDS
+Shorthand for (QQ_EBPF | QQ_KPROBE).
+.El
+.It Em max_length
+The maximum size of the internal buffering queue in number of events.
+.Pp
+Quark buffers each event for a computed interval in order to sort and aggregate
+multiple events into one.
+The closer the queue is to being full, the smaller the interval: until quark
+decides to not buffer events at all.
 .El
 .Sh RETURN VALUES
 Zero on success, -1 otherwise and
@@ -95,18 +120,10 @@ should NOT be issued.
 .Xr quark_event_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
 .Xr quark_queue_get_epollfd 3 ,
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
 .Xr quark-mon 8
-.Sh CAVEATS
-Multiple queues are supported, but discouraged.
-Opening and closing (but not using!) queues from different
-threads must be synchronized by the caller, this is because there is global
-internal state that might change in
-.Nm
-and
-.Xr quark_queue_close 3 .
-Notably there is a single KPROBE installation shared by all queues.


### PR DESCRIPTION
Just flags is not enough, introduce `queue_attr` to open so we can really tweak things up without modifying the API too much in the future, ideally callers will just do:

quark_queue_default_attr(&attr);
attr.modify_something = 43;
quark_queue_open(&qq, &attr);

cc @mjwolf @stanek-michal 

