### PR TITLE
Compute entry leaders

### DIFF
--- a/go/quark.go
+++ b/go/quark.go
@@ -18,23 +18,25 @@ import (
 )
 
 type Proc struct {
-	CapInheritable uint64
-	CapPermitted   uint64
-	CapEffective   uint64
-	CapBset        uint64
-	CapAmbient     uint64
-	TimeBoot       uint64
-	Ppid           uint32
-	Uid            uint32
-	Gid            uint32
-	Suid           uint32
-	Sgid           uint32
-	Euid           uint32
-	Egid           uint32
-	Pgid           uint32
-	Sid            uint32
-	TtyMajor       uint32
-	TtyMinor       uint32
+	CapInheritable  uint64
+	CapPermitted    uint64
+	CapEffective    uint64
+	CapBset         uint64
+	CapAmbient      uint64
+	TimeBoot        uint64
+	Ppid            uint32
+	Uid             uint32
+	Gid             uint32
+	Suid            uint32
+	Sgid            uint32
+	Euid            uint32
+	Egid            uint32
+	Pgid            uint32
+	Sid             uint32
+	EntryLeader     uint32
+	EntryLeaderType uint32
+	TtyMajor        uint32
+	TtyMinor        uint32
 }
 
 type Exit struct {
@@ -69,6 +71,7 @@ const (
 	QQ_EBPF          = int(C.QQ_EBPF)
 	QQ_NO_SNAPSHOT   = int(C.QQ_NO_SNAPSHOT)
 	QQ_MIN_AGG       = int(C.QQ_MIN_AGG)
+	QQ_ENTRY_LEADER  = int(C.QQ_ENTRY_LEADER)
 	QQ_ALL_BACKENDS  = int(C.QQ_ALL_BACKENDS)
 
 	// Event.events
@@ -77,6 +80,16 @@ const (
 	QUARK_EV_EXIT         = int(C.QUARK_EV_EXIT)
 	QUARK_EV_SETPROCTITLE = int(C.QUARK_EV_SETPROCTITLE)
 	QUARK_EV_SNAPSHOT     = int(C.QUARK_EV_SNAPSHOT)
+
+	// EntryLeaderType
+	QUARK_ELT_UNKNOWN   = int(C.QUARK_ELT_UNKNOWN)
+	QUARK_ELT_INIT      = int(C.QUARK_ELT_INIT)
+	QUARK_ELT_KTHREAD   = int(C.QUARK_ELT_KTHREAD)
+	QUARK_ELT_SSHD      = int(C.QUARK_ELT_SSHD)
+	QUARK_ELT_SSM       = int(C.QUARK_ELT_SSM)
+	QUARK_ELT_CONTAINER = int(C.QUARK_ELT_CONTAINER)
+	QUARK_ELT_TERM      = int(C.QUARK_ELT_TERM)
+	QUARK_ELT_CONSOLE   = int(C.QUARK_ELT_CONSOLE)
 )
 
 type QueueAttr struct {
@@ -208,23 +221,25 @@ func cEventToGo(cev *C.struct_quark_event) (Event, error) {
 	qev.Events = uint64(cev.events)
 	if cev.flags&C.QUARK_F_PROC != 0 {
 		qev.Proc = &Proc{
-			CapInheritable: uint64(cev.proc_cap_inheritable),
-			CapPermitted:   uint64(cev.proc_cap_permitted),
-			CapEffective:   uint64(cev.proc_cap_effective),
-			CapBset:        uint64(cev.proc_cap_bset),
-			CapAmbient:     uint64(cev.proc_cap_ambient),
-			TimeBoot:       uint64(cev.proc_time_boot),
-			Ppid:           uint32(cev.proc_ppid),
-			Uid:            uint32(cev.proc_uid),
-			Gid:            uint32(cev.proc_gid),
-			Suid:           uint32(cev.proc_suid),
-			Sgid:           uint32(cev.proc_sgid),
-			Euid:           uint32(cev.proc_euid),
-			Egid:           uint32(cev.proc_egid),
-			Pgid:           uint32(cev.proc_pgid),
-			Sid:            uint32(cev.proc_sid),
-			TtyMajor:       uint32(cev.proc_tty_major),
-			TtyMinor:       uint32(cev.proc_tty_minor),
+			CapInheritable:  uint64(cev.proc_cap_inheritable),
+			CapPermitted:    uint64(cev.proc_cap_permitted),
+			CapEffective:    uint64(cev.proc_cap_effective),
+			CapBset:         uint64(cev.proc_cap_bset),
+			CapAmbient:      uint64(cev.proc_cap_ambient),
+			TimeBoot:        uint64(cev.proc_time_boot),
+			Ppid:            uint32(cev.proc_ppid),
+			Uid:             uint32(cev.proc_uid),
+			Gid:             uint32(cev.proc_gid),
+			Suid:            uint32(cev.proc_suid),
+			Sgid:            uint32(cev.proc_sgid),
+			Euid:            uint32(cev.proc_euid),
+			Egid:            uint32(cev.proc_egid),
+			Pgid:            uint32(cev.proc_pgid),
+			Sid:             uint32(cev.proc_sid),
+			EntryLeader:     uint32(cev.proc_entry_leader),
+			EntryLeaderType: uint32(cev.proc_entry_leader_type),
+			TtyMajor:        uint32(cev.proc_tty_major),
+			TtyMinor:        uint32(cev.proc_tty_minor),
 		}
 	}
 	if cev.flags&C.QUARK_F_EXIT != 0 {

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl bDkstv
+.Op Fl bDekstv
 .Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
 .Sh DESCRIPTION
@@ -29,6 +29,15 @@ Attempt EBPF as the backend.
 .It Fl D
 Drop priviledges to nobody and chroot to /var/empty, useful to show how quark
 can run without priviledges.
+.It Fl e
+Include
+.Em proc_entry_leader
+and
+.Em proc_entry_type_type .
+in
+.Em quark_events .
+Entry leader is how the process entered the system, it is disabled by default as
+it is Elastic/ECS specific.
 .It Fl g
 Use minimal aggregation, fork, exec and exit will
 .Em not

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -58,7 +58,7 @@ priv_drop(void)
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: %s [-bDfkstv] [-l maxlength] [-m maxnodes]\n",
+	fprintf(stderr, "usage: %s [-bDefkstv] [-l maxlength] [-m maxnodes]\n",
 	    program_invocation_short_name);
 
 	exit(1);
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 	do_drop = 0;
 	nqevs = 32;
 
-	while ((ch = getopt(argc, argv, "bDgklm:tsv")) != -1) {
+	while ((ch = getopt(argc, argv, "bDegklm:tsv")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -90,6 +90,9 @@ main(int argc, char *argv[])
 			break;
 		case 'D':
 			do_drop = 1;
+			break;
+		case 'e':
+			qa.flags |= QQ_ENTRY_LEADER;
 			break;
 		case 'g':
 			qa.flags |= QQ_MIN_AGG;

--- a/quark.h
+++ b/quark.h
@@ -226,6 +226,24 @@ RB_HEAD(event_by_pid, quark_event);
  */
 TAILQ_HEAD(quark_event_list, quark_event);
 
+enum {
+	QUARK_TTY_UNKNOWN,
+	QUARK_TTY_PTS,
+	QUARK_TTY_TTY,
+	QUARK_TTY_CONSOLE,
+};
+
+enum {
+	QUARK_ELT_UNKNOWN,
+	QUARK_ELT_INIT,
+	QUARK_ELT_KTHREAD,
+	QUARK_ELT_SSHD,
+	QUARK_ELT_SSM,
+	QUARK_ELT_CONTAINER,
+	QUARK_ELT_TERM,
+	QUARK_ELT_CONSOLE,
+};
+
 /*
  * Main external working set, user passes this back and forth, members only have
  * a meaning if its respective flag is set, say proc_cap_inheritable should only
@@ -274,6 +292,8 @@ struct quark_event {
 	u32	proc_sid;
 	u32	proc_tty_major;
 	u32	proc_tty_minor;
+	u32	proc_entry_leader_type;
+	u32	proc_entry_leader;
 	/* QUARK_F_EXIT */
 	s32	exit_code;
 	u64	exit_time_event;
@@ -310,6 +330,7 @@ struct quark_queue_attr {
 #define QQ_EBPF			(1 << 3)
 #define QQ_NO_SNAPSHOT		(1 << 4)
 #define QQ_MIN_AGG		(1 << 5)
+#define QQ_ENTRY_LEADER		(1 << 6)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
 	int	flags;
 	int	max_length;


### PR DESCRIPTION
```
commit 0ff5476ffc8fa9bda7a7349de39bea7a72ba229a (HEAD -> leader, origin/leader)
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri Jun 7 23:05:42 2024 +0200

    Compute entry leaders, off by default. Issue #41

    This computes entry_leader and entry_meta.type from ECS:
    https://www.elastic.co/guide/en/ecs/current/ecs-process.html#field-process-entry-meta-type

    In order to properly inherit both fields, we have to traverse the process tree
    "in order of creation", this means building a walking list from pid 1,
    descending to everything else. Cloud defend does this by ordering pids, which is
    not quite right as pids can wrap around, we handle it by traversing processes
    via their actual relationship.

    There is a bug that can be observed with kprobes and docker, basically docker
    forks and exits a bunch of intermediary processes before giving us our
    container, this causes reparenting of processes, meaning their ppid changes. The
    ppid we get is racy since it depends if the parent exited before fork was
    commited or after. The actual bug is that kprobes are not updating ppid after
    fork, this is further described in #43.

    As this is all very ECS specific, it is disabled by default and you must pass
    QQ_ENTRY_LEADER to enable the computation.

    The hooks in raw_event_to_quark_event() might not be completely right,
    recomputing for exec only, maybe we should recompute more.

    At any rate this seems to produce correct values for INIT, SSHD and docker (at least
    on eBPF).
    ```