### PR TITLE
Add ebpf lost event counter. Issue #38

### DIFF
--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -266,12 +266,14 @@ struct kprobe_queue {
 };
 
 static int	kprobe_queue_populate(struct quark_queue *);
+static int	kprobe_queue_update_stats(struct quark_queue *);
 static void	kprobe_queue_close(struct quark_queue *);
 
 struct quark_queue_ops queue_ops_kprobe = {
-	.open	  = kprobe_queue_open,
-	.populate = kprobe_queue_populate,
-	.close	  = kprobe_queue_close,
+	.open	      = kprobe_queue_open,
+	.populate     = kprobe_queue_populate,
+	.update_stats = kprobe_queue_update_stats,
+	.close	      = kprobe_queue_close,
 };
 
 static char *
@@ -1296,6 +1298,13 @@ kprobe_queue_populate(struct quark_queue *qq)
 	}
 
 	return (npop);
+}
+
+static int
+kprobe_queue_update_stats(struct quark_queue *qq)
+{
+	/* NADA */
+	return (0);
 }
 
 static void

--- a/quark.c
+++ b/quark.c
@@ -1597,6 +1597,7 @@ quark_queue_get_epollfd(struct quark_queue *qq)
 void
 quark_queue_get_stats(struct quark_queue *qq, struct quark_queue_stats *qs)
 {
+	qq->queue_ops->update_stats(qq);
 	*qs = qq->stats;
 }
 

--- a/quark.h
+++ b/quark.h
@@ -320,6 +320,7 @@ struct quark_queue_stats {
 struct quark_queue_ops {
 	int	(*open)(struct quark_queue *);
 	int	(*populate)(struct quark_queue *);
+	int	(*update_stats)(struct quark_queue *);
 	void	(*close)(struct quark_queue *);
 };
 


### PR DESCRIPTION
This commit includes the pending PR: https://github.com/elastic/ebpf/pull/198 Once that is merged I'll rebase this, so ignore the elastic-ebpf/* bits.

Pretty straighforward, contrary to kprobes which we get the counter on the data path, with ebpf we have to actually read it, so add a new ops for updating the counter, we should caution users to not hammer the reading, as it's real syscall.

Tested by hacking quark-mon away.