### PR TITLE
Btfhub arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,6 @@ clean:
 
 clean-all: clean
 	$(call msg,CLEAN-ALL)
-	$(Q)rm -rf docs/*.html
 	$(Q)rm -f $(SVGS)
 	$(Q)rm -rf include
 	$(Q)make -C $(LIBBPF_SRC) clean

--- a/btf.c
+++ b/btf.c
@@ -25,7 +25,6 @@ struct quark_btf_target targets[] = {
 	{ "cred.sgid",			-1 },
 	{ "cred.suid",			-1 },
 	{ "cred.uid",			-1 },
-	{ "cred.user",			-1 },
 	{ "dentry.d_name.name",		-1 },
 	{ "dentry.d_parent",		-1 },
 	{ "fs_struct.pwd.dentry",	-1 },


### PR DESCRIPTION
Btfhub table for arm64
While here, adjust a couple of things:
	- remove an unused offset
	- add missing fedora 30/31 to amd64

Preparation for upcoming changes where we try to match the best kernel, and thus
actually use the table.