### PR TITLE
Fix Go's Snapshot()

### DIFF
--- a/go/quark.go
+++ b/go/quark.go
@@ -230,10 +230,10 @@ func (queue *Queue) Block() error {
 func (queue *Queue) Snapshot() []Process {
 	var processes []Process
 	var iter C.struct_quark_process_iter
+	var qp *C.struct_quark_process
 
 	C.quark_process_iter_init(&iter, queue.quarkQueue)
-
-	for qp := C.quark_process_iter_next(&iter); qp != nil; {
+	for qp = C.quark_process_iter_next(&iter); qp != nil; qp = C.quark_process_iter_next(&iter) {
 		processes = append(processes, processToGo(qp))
 	}
 

--- a/go/quark_test.go
+++ b/go/quark_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestQuarkSnapshot(t *testing.T) {
+	queue, err := OpenQueue(DefaultQueueAttr(), 64)
+	require.NoError(t, err)
+
+	defer queue.Close()
+
+	require.NotEmpty(t, queue.Snapshot())
+}
+
 func TestQuarkLookup(t *testing.T) {
 	queue, err := OpenQueue(DefaultQueueAttr(), 64)
 	require.NoError(t, err)


### PR DESCRIPTION
Properly advance the iterator :D. I'm not sure what is the most idiomatic route here.

Fallout from the refactor at faa5b0c553a2bf243fb2c76ef8999a6d2425d615