### PR TITLE
Centos7 build target

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,0 +1,5 @@
+FROM centos:7
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
+RUN yum install -y gcc make m4 less

--- a/elftoolchain/libelf/GNUmakefile
+++ b/elftoolchain/libelf/GNUmakefile
@@ -29,7 +29,9 @@ CDIAGFLAGS+=	-Wformat-zero-length
 CDIAGFLAGS+=	-Wpointer-sign
 CDIAGFLAGS+=	-Wpointer-to-int-cast
 CDIAGFLAGS+=	-Wsign-compare
+ifndef CENTOS7
 CDIAGFLAGS+=	-Wunused-const-variable
+endif
 CDIAGFLAGS+=	-Wunused-parameter
 CDIAGFLAGS+=	-Wold-style-definition
 CDIAGFLAGS+=	-Wpointer-arith

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -125,8 +125,10 @@ struct perf_group_leader {
 /*
  * Forbid padding on samples/wire structures
  */
+#ifndef NO_PUSH_PRAGMA
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wpadded"
+#endif	/* NO_PUSH_PRAGMA */
 
 struct exec_sample {
 	struct perf_sample_data_loc	filename;
@@ -183,7 +185,9 @@ struct exec_connector_sample {
 	u64				stack[60];	/* sync with kprobe_defs */
 };
 
+#ifndef NO_PUSH_PRAGMA
 #pragma GCC diagnostic pop
+#endif	/* NO_PUSH_PRAGMA */
 
 /*
  * End samples/wire/ structures


### PR DESCRIPTION
It seems the common practice to have a "portable" archive or binary is to compile stuff in a relic linux, the oldest we are interested is centos7.

This adds a `make centos7` build target that compiles quark in a centos7 container.

To generate bpf_prog.o we would need a reasonably recent clang, which needs a newer gcc to be able to build, so we would have to compile gcc, then compile clang, to compile bpf_prog.o, we could also just use zig cc like $(OTHERPROJECT) does. But we went a different route:

Since bpf_prog.o is not used in userland, it's just the bpf program bundled that is installed in the kernel we do the following:

  1. Build bpf_prog.o and bpf_prog_skel.h in a recent ubuntu container, which
has a shiny clang.
  2. Build the rest of quark in centos7.

This will be needed for the upcoming go distribution where we will ship libquark_big.a, which will be built by CI automagically, this way libquark_big.a should work on every linux on amd64.

Still missing the bits for arm64.

Weird bits of this commit:
  - gcc 4.8.5 (centos7) doesn't support the push/pop warning pragma, it enables for the whole file, so disable it.
  - {Wimplicit-fallthrough,Wunused-const} also doesn't exist in 4.8.5.
  - We were passing the wrong argument to docker run, it should be -c "foo bar"
  - old gcc "correctly" doesn't assume std=gnu99, so we have to pass it.

The linker is happy and so are we. Proof that we require no symbol later than 2.17.

[haesbaert@centos7 ~]$ TERM=vt100 objdump -T quark-mon |grep GLIBC|sort
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.14  memcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.17  clock_gettime
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 access
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 asprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __assert_fail
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 bsearch
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 calloc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 chdir
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 chroot
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 close
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 dirname
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 err
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __errno_location
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 errx
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 exit
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fclose
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fcntl
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fdopen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 feof
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fflush
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fgets
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fmemopen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fopen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fopen64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fread
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 free
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fscanf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fseek
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 ftell
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fts_children
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fts_close
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fts_open
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fts_read
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 fts_set
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __fxstat
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __getdelim
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getenv
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 geteuid
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 get_nprocs_conf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getopt
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getpagesize
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getpid
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getpwnam
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 getrlimit64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 ioctl
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __libc_start_main
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 lseek64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 malloc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memchr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memcmp
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memmove
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memset
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 mkdir
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 mmap
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 mmap64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 munmap
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 open
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 open64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 printf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 qsort
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 read
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 realloc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 rewind
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 setgroups
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 setresgid
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 setresuid
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 setrlimit64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sigaction
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 snprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sscanf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 statfs64
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strcat
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strchr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strcmp
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __strdup
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strerror
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strlen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strncmp
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strncpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __strndup
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strnlen
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strrchr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strstr
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strtoll
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 strtoull
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 syscall
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 sysconf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 uname
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 unlink
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 vfprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 vsnprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 vsprintf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 warn
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 warnx
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 write
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 __xpg_basename
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3.2 epoll_ctl
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3.2 epoll_wait
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3.4 __xpg_strerror_r
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3   __ctype_b_loc
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3   realpath
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.4   faccessat
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.4   openat
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.4   readlinkat
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.7   __isoc99_fscanf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.7   __isoc99_sscanf
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.9   epoll_create1
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 optarg
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 __progname
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 program_invocation_short_name
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 stderr
0000000000000000      DO *UND*  0000000000000000  GLIBC_2.2.5 stdout