### PR TITLE
Plug memory leak

### DIFF
--- a/quark.c
+++ b/quark.c
@@ -102,6 +102,7 @@ raw_event_free(struct raw_event *raw)
 		break;
 	case RAW_EXEC_CONNECTOR:
 		qstr_free(&raw->exec_connector.args);
+		qstr_free(&raw->exec_connector.task.cwd);
 		break;
 	case RAW_COMM:		/* nada */
 		break;


### PR DESCRIPTION
Exec connector didn't match the allocation, found via valgrind after hitting a long path on exec.