### PR TITLE
Implement matching btfhub files with uname, makes centos7 work \o/

### DIFF
--- a/btf.c
+++ b/btf.c
@@ -255,7 +255,7 @@ quark_btf_open_hub(const char *version)
 		 */
 		for (pc = cand->kname, pv = version, score = 0;
 		     *pc != 0 && *pv != 0 && *pc == *pv;
-		     score++, pc++, pv++)
+		     pc++, pv++, score++)
 			;     /* NADA */
 
 		/*
@@ -270,7 +270,7 @@ quark_btf_open_hub(const char *version)
 		for (pc = cand->kname + strlen(cand->kname) - 1,
 			 pv = version + strlen(version) - 1;
 		     pc != cand->kname && pv != version && *pc == *pv;
-		     score++, pc--, pv--)
+		     pc--, pv--, score++)
 			;	/* NADA */
 
 		if (score > best_score) {

--- a/docs/quark-btf.8.html
+++ b/docs/quark-btf.8.html
@@ -25,24 +25,24 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-btf</code></td>
-    <td>[<code class="Fl">-bv</code>] [<var class="Ar">targets ...</var>]</td>
-  </tr>
-</table>
-<br/>
-<table class="Nm">
-  <tr>
-    <td><code class="Nm">quark-btf</code></td>
     <td>[<code class="Fl">-bv</code>] [<code class="Fl">-f</code>
-      <var class="Ar">btf_file</var>]</td>
+      <var class="Ar">btf_file</var>] [<var class="Ar">targets ...</var>]</td>
   </tr>
 </table>
 <br/>
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-btf</code></td>
-    <td>[<code class="Fl">-v</code>] [<code class="Fl">-f</code>
-      <var class="Ar">btf_file</var>] [<code class="Fl">-g</code>
-      <var class="Ar">btf_name</var>]</td>
+    <td>[<code class="Fl">-bv</code>] <code class="Fl">-l</code>
+      <var class="Ar">version</var></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-btf</code></td>
+    <td>[<code class="Fl">-v</code>] <code class="Fl">-g</code>
+      <var class="Ar">btf_file name version</var></td>
   </tr>
 </table>
 </section>
@@ -56,30 +56,42 @@ The <code class="Nm">quark-btf</code> program prints out the kernel structures
 <dl class="Bl-tag">
   <dt id="b"><a class="permalink" href="#b"><code class="Fl">-b</code></a></dt>
   <dd>Also print the offset in bits.</dd>
-  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a></dt>
-  <dd>Increase
-      <a class="permalink" href="#quark_verbose"><i class="Em" id="quark_verbose">quark_verbose</i></a>,
-      can be issued multiple times.</dd>
   <dt id="f"><a class="permalink" href="#f"><code class="Fl">-f</code></a>
     <var class="Ar">btf_file</var></dt>
   <dd>Print all offsets quark would use from
     <var class="Ar">btf_file</var>.</dd>
   <dt id="g"><a class="permalink" href="#g"><code class="Fl">-g</code></a>
-    <var class="Ar">btf_name</var></dt>
-  <dd>Generate the internal btf C structure used by quark. Must be used together
-      with <code class="Fl">-f</code> <var class="Ar">btf_file</var>.
-    <p class="Pp">This is only used to generate <span class="Pa">btfhub.c</span>
-        via <span class="Pa">genbtf.sh</span>, and since btfhub-archive never
-        changes, chances are you'll never need this.
-        <var class="Ar">btf_file</var>.</p>
-  </dd>
+    <var class="Ar">btf_file name version</var></dt>
+  <dd>Generate the internal btf C structure used by quark.
+    <dl class="Bl-tag">
+      <dt><var class="Ar">btf_file</var></dt>
+      <dd>is a the path to the btf.</dd>
+      <dt><var class="Ar">name</var></dt>
+      <dd>is a human identifier, like ubuntu-22.</dd>
+      <dt id="uname"><var class="Ar">version</var></dt>
+      <dd>is the kernel version as returned by
+          <a class="permalink" href="#uname"><i class="Em">uname
+        -r</i></a>.</dd>
+    </dl>
+    This option only used to generate <span class="Pa">btfhub.c</span> via
+      <span class="Pa">genbtf.sh</span>, chances are you'll never need
+    this.</dd>
+  <dt id="l"><a class="permalink" href="#l"><code class="Fl">-l</code></a>
+    <var class="Ar">version</var></dt>
+  <dd>Lookup the kernel
+      <a class="permalink" href="#version"><i class="Em" id="version">version</i></a>
+      in the compiled btfhub table from quark and print which kernel quark would
+      use. Matching can be partial.</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a></dt>
+  <dd>Increase
+      <a class="permalink" href="#quark_verbose"><i class="Em" id="quark_verbose">quark_verbose</i></a>,
+      can be issued multiple times.</dd>
 </dl>
 <section class="Sh">
 <h1 class="Sh" id="EXIT_STATUS"><a class="permalink" href="#EXIT_STATUS">EXIT
   STATUS</a></h1>
-<p class="Pp"><code class="Nm">quark-btf</code> exits with number of targets
-    failed if <var class="Ar">targets</var> is specified. Otherwise 0 in case of
-    success.</p>
+<p class="Pp"><code class="Nm">quark-btf</code> exits with 1 if it can't resolve
+    all BTF symbols, 0 otherwise.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
@@ -134,7 +146,7 @@ vfsmount.mnt_root            0</pre>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 4, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/genbtf.sh
+++ b/genbtf.sh
@@ -101,28 +101,28 @@ printf "const char *btfhub_archive_commit=\"%s\";\n\n" "$Commit"
 
 function do_arch
 {
-
 	if [ $1 = amd64 ]; then
-		Arch=amd64
-		Srcs="$Srcs_amd64"
+		arch=amd64
+		srcs="$Srcs_amd64"
 	elif [ $1 = arm64 ]; then
-		Arch=aarch64
-		Srcs="$Srcs_arm64"
+		arch=aarch64
+		srcs="$Srcs_arm64"
 	else
 		die "bad arch"
 	fi
 
-	printf "#ifdef __%s__\n\n" $Arch
+	printf "#ifdef __%s__\n\n" $arch
 
-	for s in $Srcs; do
+	for s in $srcs; do
 		distro=${s%/*}
 		s="$Btfhub_path/$s"
 		for k in $(find $s -name '*.tar.xz'); do
 			btf=$(basename ${k%%.tar.xz})
-			name="$distro-${btf%%.btf}"
-			name=$(echo $name | tr \\055\\056\\057 _)
+			version="${btf%%.btf}"
 			tar xf $k || die "oh noes"
-			if ./quark-btf -g $name -f $btf 2>/dev/null; then
+			name=${distro}_${version}
+			name=$(echo $name | tr \\055\\056\\057 _)
+			if ./quark-btf -g "$btf" "$distro" "$version" 2>/dev/null; then
 				echo "$name OK" 1>&2
 				if [ $1 = amd64 ]; then
 					Good_amd64+=("$name")
@@ -137,7 +137,7 @@ function do_arch
 		done
 	done
 
-	printf "#endif /* __%s__ */\n\n" $Arch
+	printf "#endif /* __%s__ */\n\n" $arch
 
 }
 

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1050,7 +1050,7 @@ kprobe_install_all(u64 qid)
 	int			 i, r;
 	struct quark_btf	*qbtf;
 
-	if ((qbtf = quark_btf_open(NULL, NULL)) == NULL) {
+	if ((qbtf = quark_btf_open()) == NULL) {
 		warnx("%s: can't initialize btf", __func__);
 		return (-1);
 	}

--- a/quark-btf.8
+++ b/quark-btf.8
@@ -7,14 +7,15 @@
 .Sh SYNOPSIS
 .Nm quark-btf
 .Op Fl bv
+.Op Fl f Ar btf_file
 .Op Ar targets ...
 .Nm quark-btf
 .Op Fl bv
-.Op Fl f Ar btf_file
+.Fl l
+.Ar version
 .Nm quark-btf
 .Op Fl v
-.Op Fl f Ar btf_file
-.Op Fl g Ar btf_name
+.Fl g Ar btf_file name version
 .Sh DESCRIPTION
 The
 .Nm
@@ -29,31 +30,38 @@ The options are as follows:
 .Bl -tag -width Dtb
 .It Fl b
 Also print the offset in bits.
+.It Fl f Ar btf_file
+Print all offsets quark would use from
+.Ar btf_file .
+.It Fl g Ar btf_file name version
+Generate the internal btf C structure used by quark.
+.Bl -tag -width btf_file
+.It Ar btf_file
+is a the path to the btf.
+.It Ar name
+is a human identifier, like ubuntu-22.
+.It Ar version
+is the kernel version as returned by
+.Em uname -r .
+.El
+This option only used to generate
+.Pa btfhub.c
+via
+.Pa genbtf.sh ,
+chances are you'll never need this.
+.It Fl l Ar version
+Lookup the kernel
+.Em version
+in the compiled btfhub table from quark and print which kernel quark would use.
+Matching can be partial.
 .It Fl v
 Increase
 .Em quark_verbose ,
 can be issued multiple times.
-.It Fl f Ar btf_file
-Print all offsets quark would use from
-.Ar btf_file .
-.It Fl g Ar btf_name
-Generate the internal btf C structure used by quark.
-Must be used together with
-.Fl f Ar btf_file .
-.Pp
-This is only used to generate
-.Pa btfhub.c
-via
-.Pa genbtf.sh ,
-and since btfhub-archive never changes, chances are you'll never need this.
-.Ar btf_file .
 .El
 .Sh EXIT STATUS
 .Nm
-exits with number of targets failed if
-.Ar targets
-is specified.
-Otherwise 0 in case of success.
+exits with 1 if it can't resolve all BTF symbols, 0 otherwise.
 .Sh EXAMPLES
 Running:
 .Dl $ quark-btf

--- a/quark-btf.c
+++ b/quark-btf.c
@@ -11,34 +11,41 @@
 
 #include "quark.h"
 
-#include <bpf/btf.h>
-#include "libbpf/include/linux/err.h"		/* IS_ERR :( */
-
-s32	btf_root_offset(struct btf *, const char *);
-
-struct target {
-	const char	*dotname;
-	ssize_t		 offset;
-};
-
-static size_t		longest;
 static int		bflag;
+static int		fflag;
+static int		gflag;
+static int		lflag;
 
 static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s [-bv] [targets...]\n",
 	    program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-bv] [-f btf_path]\n",
+	fprintf(stderr, "usage: %s [-bv] [-f btf_file]\n",
 	    program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-v] [-f btf_path] [-g btf_name]\n",
+	fprintf(stderr, "usage: %s [-bv] [-l version]\n",
+	    program_invocation_short_name);
+	fprintf(stderr, "usage: %s [-v] [-g btf_file name version]\n",
 	    program_invocation_short_name);
 
 	exit(1);
 }
 
+static size_t
+calc_longest(struct quark_btf *qbtf)
+{
+	struct quark_btf_target	*ta;
+	size_t			 longest;
+
+	for (ta = qbtf->targets, longest = 0; ta->dotname != NULL; ta++)
+		if (strlen(ta->dotname) > longest)
+			longest = strlen(ta->dotname);
+
+	return (longest);
+}
+
 static void
-printit(const char *t, ssize_t off)
+printit(const char *t, ssize_t off, size_t longest)
 {
 	printf("%-*s ", (int)longest, t);
 	if (off == -1)
@@ -51,71 +58,182 @@ printit(const char *t, ssize_t off)
 	fflush(stdout);
 }
 
-struct quark_btf sample = {
-	"kname_sample",
-	{{ "cred.cap_ambient",		-1 },
-	 { "cred.cap_bset",		-1 },
-	 { "cred.cap_effective",	-1 },
-	 { NULL,			-1 }},
-};
-
-static void
-gen_c(struct quark_btf *qbtf)
+static struct quark_btf_target *
+target_lookup(struct quark_btf *qbtf, const char *dotname)
 {
-	const char		*k;
-	char			*v, *p;
 	struct quark_btf_target	*ta;
 
-	k = qbtf->kname;
-	v = strdup(k);
-	/* Mangle invalid characters */
-	for (p = v; *p != 0; p++) {
+	for (ta = qbtf->targets; ta->dotname != NULL; ta++) {
+		if (!strcmp(ta->dotname, dotname))
+			return (ta);
+	}
+
+	return (NULL);
+}
+
+static void
+quark_btf_printit(struct quark_btf *qbtf, int argc, char *argv[])
+{
+	struct quark_btf_target	*ta;
+	size_t			 longest;
+	int			 i;
+
+	if (argc == 0)
+		longest = calc_longest(qbtf);
+	else {
+		for (i = 0, longest = 0; i < argc; i++)
+			if (strlen(argv[i]) > longest)
+				longest = strlen(argv[i]);
+	}
+
+	/* Print them all */
+	if (argc == 0) {
+		for (ta = qbtf->targets; ta->dotname != NULL; ta++)
+			printit(ta->dotname, ta->offset, longest);
+
+		return;
+	}
+
+	/* Print only the requested ones if argc */
+	for (i = 0; i < argc; i++) {
+		ta = target_lookup(qbtf, argv[i]);
+		if (ta == NULL)
+			errx(1, "dotname `%s` doesn't exist, "
+			    "did you type it correctly?", argv[i]);
+		printit(ta->dotname, ta->offset, longest);
+	}
+}
+
+static int
+gen_c(int argc, char *argv[])
+{
+	char			*p;
+	const char		*path, *distro, *version;
+	struct quark_btf	*qbtf;
+	struct quark_btf_target	*ta;
+	char			 namebuf[1024];
+	size_t			 longest;
+
+	if (argc != 3)
+		usage();
+
+	path = argv[0];
+	distro = argv[1];
+	version = argv[2];
+	/*
+	 * First we figure the name of the structure, this is basically an
+	 * escaped concat(distro, version)
+	 */
+	if (snprintf(namebuf, sizeof(namebuf), "%s_%s", distro, version) >=
+	    (int)sizeof(namebuf))
+		errx(1, "distro + version is too long");
+	/*
+	 * Escape invalid characters since this will be the name of the
+	 * structure
+	 */
+	for (p = namebuf; *p != 0; p++) {
 		if (*p == '.' || *p == '-' || *p == '/')
 			*p = '_';
 	}
+
+	if ((qbtf = quark_btf_open2(path, version)) == NULL)
+		err(1, "quark_btf_open");
 
 	/*
 	 * Declare the structure as static to make sure it gets referenced
 	 * later in all_btfs[].
 	 */
-	printf("static struct quark_btf %s = {\n", v);
-	printf("\t\"%s\", {\n", k);
-	for (ta = qbtf->targets; ta->dotname != NULL; ta++) {
+	longest = calc_longest(qbtf);
+	printf("static struct quark_btf %s = {\n", namebuf);
+	printf("\t\"%s\", {\n", version);
+	for (ta = qbtf->targets; /* NADA */; ta++) {
+		const char	*dotname;
+		size_t		 off;
+
 		printf("\t{ ");
-		printf("\"%s\",", ta->dotname);
+		if (ta->dotname != NULL) {
+			off = 1;
+			dotname = ta->dotname;
+			printf("\"%s\",", ta->dotname);
+		} else {
+			off = 3;
+			dotname = "NULL";
+			printf("NULL,");
+		}
 		printf("%-*s%-5zd },\n",
-		    (int)longest - (int)strlen(ta->dotname) + 1, " ",
+		    (int)longest - (int)strlen(dotname) + (int)off, " ",
 		    ta->offset);
+
+		if (ta->dotname == NULL)
+			break;
 	}
 	printf("\t}\n};\n\n");
 
-	free(v);
+	quark_btf_close(qbtf);
+
+	return (0);
+}
+
+static int
+hub_lookup(int argc, char *argv[])
+{
+	struct quark_btf	*qbtf;
+
+	if (argc != 1)
+		usage();
+
+	qbtf = quark_btf_open_hub(argv[0]);
+	if (qbtf == NULL)
+		errx(1, "can't match `%s` with any kernel in btfhub", optarg);
+	printf("%s\n", qbtf->kname);
+	if (quark_verbose)
+		quark_btf_printit(qbtf, 0, NULL);
+	quark_btf_close(qbtf);
+
+	return (0);
+}
+
+static int
+doit(const char *path, int argc, char *argv[])
+{
+	struct quark_btf	*qbtf;
+
+	if (path == NULL)
+		qbtf = quark_btf_open();
+	else
+		qbtf = quark_btf_open2(path, "temp");
+
+	if (qbtf == NULL)
+		err(1, "can't open btf, maybe some offsets failed");
+
+	quark_btf_printit(qbtf, argc, argv);
+	quark_btf_close(qbtf);
+
+	return (0);
 }
 
 int
 main(int argc, char *argv[])
 {
-	int			 i, ch, failed;
-	struct btf		*btf;
-	struct quark_btf	*qbtf;
-	struct quark_btf_target	*ta;
+	int			 ch;
 	const char		*path = NULL;
-	const char		*g_name = NULL;
 
-	while ((ch = getopt(argc, argv, "bf:g:v")) != -1) {
+	while ((ch = getopt(argc, argv, "bf:glv")) != -1) {
 		switch (ch) {
 		case 'b':
 			bflag = 1;
 			break;
 		case 'g':
-			if (optarg == NULL)
-				usage();
-			g_name = optarg;
+			gflag = 1;
+			break;
+		case 'l':
+			lflag = 1;
 			break;
 		case 'f':
 			if (optarg == NULL)
 				usage();
 			path = optarg;
+			fflag = 1;
 			break;
 		case 'v':
 			quark_verbose++;
@@ -128,40 +246,15 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
-	if (argc == 0) {
-		if ((qbtf = quark_btf_open(path, g_name)) == NULL)
-			err(1, "quark_btf_open");
-		for (ta = qbtf->targets, longest = 0; ta->dotname != NULL; ta++)
-			if (strlen(ta->dotname) > longest)
-				longest = strlen(ta->dotname);
-		if (g_name != NULL)
-			gen_c(qbtf);
-		else {
-			for (ta = qbtf->targets; ta->dotname != NULL; ta++)
-				printit(ta->dotname, ta->offset);
-		}
-		quark_btf_close(qbtf);
+	if ((fflag + gflag + lflag) > 1)
+		usage();
 
-		return (0);
-	}
+	/* path distro version */
+	if (gflag)
+		return (gen_c(argc, argv));
 
-	btf = btf__load_vmlinux_btf();
-	if (IS_ERR_OR_NULL(btf))
-		err(1, "btf__load_vmlinux_btf");
+	if (lflag)
+		return (hub_lookup(argc, argv));
 
-	for (i = 0; i < argc; i++)
-		if (strlen(argv[i]) > longest)
-			longest = strlen(argv[i]);
-	for (i = 0, failed = 0; i < argc; i++) {
-		s32	off;
-
-		off = btf_root_offset(btf, argv[i]);
-		if (off == -1)
-			failed = 1;
-		printit(argv[i], off);
-	}
-
-	btf__free(btf);
-
-	return (failed);
+	return (doit(path, argc, argv));
 }

--- a/quark.h
+++ b/quark.h
@@ -54,7 +54,9 @@ struct quark_btf {
 	char			*kname;
 	struct quark_btf_target	 targets[];
 };
-struct quark_btf	*quark_btf_open(const char *, const char *);
+struct quark_btf	*quark_btf_open(void);
+struct quark_btf	*quark_btf_open2(const char *, const char *);
+struct quark_btf	*quark_btf_open_hub(const char *);
 void			 quark_btf_close(struct quark_btf *);
 ssize_t			 quark_btf_offset(struct quark_btf *, const char *);
 


### PR DESCRIPTION
This looks like a big scary diff but it isnt really, it just regenerates the table and docs.

--

The major change is being able to finally work on systems that don't have BPF _and_ don't have BTF, like good'ol centos7.

In quark_btf_open_hub() we try to match what we get from uname(2) with an existing kernel in our pre-compiled btfhub database. The matching is a bit crude, but good enough to work on centos7 and hopefully every other system that falls into the same case.

We have a dumb score system that tries to match the characters from the beginning and the end of uname -r, like:

$ ./quark-btf -l 3.10.0-123.el7.x86_64
3.10.0-1062.4.3.el7.x86_64

This matches the characters `3.10.0-1` from the beginning, it then scores one point for every character matched. Then it does the same from the end of the string, matching `3.el7.x86_64`, scoring more one point for every character.

We do this for every kernel in the database and choose the highest scoring one.

--

In order to get it all working nicely some refactoring was needed in quark-btf.c and btf.c:
  - Change the name we store for the kernel in quark_btf{}, keep the escaped name for the structure, otherwise we wouldn't match on uname(2).
  - Cleanup a bunch of crap related to btf_targets.
  - Refactor gen_c() to play ball with new naming scheme.
  - Make quark-btf(8) take the same path as the library instead of reaching trough libbpf directly.
  - Make sure we stash a NULL in every btfhub entry.
  - Cleanup printing of quark-btf(8).
  - Cleanup main of quark-btf(8).
  - Fix some wrong documentation flags in quark-btf(8).
  - Implement a -l option in quark-btf(8) to lookup a kernel entry given a string.

--

Testing on centos7, my VM has:
```
[haesbaert@centos7 ~]$ uname -r
3.10.0-123.el7.x86_64
```

We don't really have that, but it matches something close:
```
[haesbaert@centos7 ~]$ ./quark-btf -l $(uname -r)
3.10.0-1062.4.3.el7.x86_64
```

And it works \o/, there is some erroneous printing that has to be cleanup, but not in dis diff:

```
[haesbaert@centos7 ~]$ sudo ./quark-mon -ks
quark-mon: open: /sys/kernel/tracing: No such file or directory
libbpf: kernel BTF is missing at '/sys/kernel/btf/vmlinux', was
CONFIG_DEBUG_INFO_BTF enabled?
libbpf: failed to find valid kernel BTF
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
quark-mon: open: /sys/kernel/tracing: No such file or directory
->1068 (FORK+EXEC+EXIT+SETPROCTITLE)
  COMM  comm=echo
  CMDL  cmdline=[ /bin/echo, hi, from, centos7 ]
  PROC  ppid=1045
  PROC  uid=1000 gid=1000 suid=1000 sgid=1000 euid=1000 egid=1000 pgid=1068 sid=1045
  PROC  cap_inheritable=0x0 cap_permitted=0x0 cap_effective=0x0
  PROC  cap_bset=0xffffffffffffffff cap_ambient=0x0
  PROC  time_boot=1727420639000617449 tty_major=136 tty_minor=1
  PROC  entry_leader_type=UNKNOWN entry_leader=0
  CWD   cwd=/home/haesbaert
  FILE  filename=/bin/echo
  EXIT  exit_code=0 exit_time=1728038088089740243
```