### PR TITLE
Hook exit in kprobes on the same spot ebpf does. Fixes #68.

### DIFF
--- a/kprobe_defs.h
+++ b/kprobe_defs.h
@@ -103,7 +103,7 @@ struct kprobe kp_wake_up_new_task = {
 };
 
 struct kprobe kp_exit = {
-	"perf_event_exit_task",
+	"taskstats_exit",
 	EXIT_THREAD_SAMPLE,
 	0,
 	{


### PR DESCRIPTION
Tested on:
 - ubuntu 20.04 @ arm64
 - centos7 @ amd64
 - rhel 8 @ amd64
 - fedora 38 @ amd64
 - fedora 39 @ amd64