### PR TITLE
Logging functions, issue #2

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -171,7 +171,7 @@ ebpf_events_to_raw(struct ebpf_event_header *ev)
 
 		break;
 	default:
-		warnx("%s unhandled type %lu", __func__, ev->type);
+		qwarnx("unhandled type %lu", ev->type);
 		goto bad;
 	}
 
@@ -218,7 +218,7 @@ bpf_queue_open(struct quark_queue *qq)
 
 	bqq->prog = bpf_prog__open();
 	if (bqq->prog == NULL) {
-		warn("bpf_prog__open");
+		qwarn("bpf_prog__open");
 		goto fail;
 	}
 
@@ -237,19 +237,19 @@ bpf_queue_open(struct quark_queue *qq)
 	error = bpf_map__set_max_entries(bqq->prog->maps.event_buffer_map,
 	    get_nprocs_conf());
 	if (error != 0) {
-		warn("bpf_map__set_max_entries");
+		qwarn("bpf_map__set_max_entries");
 		goto fail;
 	}
 
 	error = bpf_prog__load(bqq->prog);
 	if (error) {
-		warn("bpf_prog__load");
+		qwarn("bpf_prog__load");
 		goto fail;
 	}
 
 	error = bpf_prog__attach(bqq->prog);
 	if (error) {
-		warn("bpf_prog__attach");
+		qwarn("bpf_prog__attach");
 		goto fail;
 	}
 
@@ -260,7 +260,7 @@ bpf_queue_open(struct quark_queue *qq)
 	bqq->ringbuf = ring_buffer__new(bpf_map__fd(bqq->prog->maps.ringbuf),
 	    bpf_ringbuf_cb, qq, &ringbuf_opts);
 	if (bqq->ringbuf == NULL) {
-		warn("ring_buffer__new");
+		qwarn("ring_buffer__new");
 		goto fail;
 	}
 

--- a/btf.c
+++ b/btf.c
@@ -77,9 +77,7 @@ btf_alternative_name(struct btf *btf, const char *new_name)
 		if (strcmp(p->new, new_name))
 			continue;
 
-		if (quark_verbose)
-			warnx("%s: found alternative for %s as %s",
-			    __func__, p->new, p->old);
+		qwarnx("found alternative for %s as %s", p->new, p->old);
 		return (p->old);
 	}
 
@@ -122,8 +120,7 @@ btf_offsetof(struct btf *btf, struct btf_type const *t, const char *mname)
 	for (i = 0; i < vlen; i++, m++) {
 		mname1 = btf__name_by_offset(btf, m->name_off);
 		if (IS_ERR_OR_NULL(mname1)) {
-			warnx("%s: btf__name_by_offset(%d)",
-			    __func__, m->name_off);
+			qwarnx("btf__name_by_offset(%d)", m->name_off);
 			continue;
 		}
 		if (strcmp(mname, mname1))
@@ -313,11 +310,11 @@ quark_btf_open2(const char *path, const char *kname)
 			/*
 			 * Be stingy with printing things that always fail
 			 */
-			if (quark_verbose ||
+			if (quark_verbose >= QUARK_VL_DEBUG ||
 			    (strcmp(ta->dotname, "signal_struct.pids") &&
-			    strcmp(ta->dotname, "task_struct.pids")))
-				warnx("%s: dotname=%s failed",
-				    __func__, ta->dotname);
+			    strcmp(ta->dotname, "task_struct.pids"))) {
+				qwarnx("dotname=%s failed", ta->dotname);
+			}
 
 			failed++;
 		}
@@ -325,9 +322,9 @@ quark_btf_open2(const char *path, const char *kname)
 
 	btf__free(btf);
 
-	for (ta = qbtf->targets; quark_verbose && ta->dotname != NULL; ta++)
-		fprintf(stderr, "%s: dotname=%s off=%ld (bitoff=%ld)\n",
-		    __func__, ta->dotname, ta->offset, ta->offset * 8);
+	for (ta = qbtf->targets; ta->dotname != NULL; ta++)
+		qdebugx("dotname=%s off=%ld (bitoff=%ld)",
+		    ta->dotname, ta->offset, ta->offset * 8);
 
 	/*
 	 * task_struct.signal is only present in new kernels, while

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
 	if ((qq = calloc(1, sizeof(*qq))) == NULL)
 		err(1, "calloc");
 	if (quark_queue_open(qq, &qa) != 0)
-		errx(1, "quark_queue_open");
+		err(1, "quark_queue_open");
 	if ((qevs = calloc(nqevs, sizeof(*qevs))) == NULL)
 		err(1, "calloc");
 

--- a/quark.h
+++ b/quark.h
@@ -97,6 +97,22 @@ char	*load_file_nostat(int, size_t *);
 struct args *args_make(const struct quark_process *);
 void	 args_free(struct args *);
 
+enum quark_verbosity_levels {
+	QUARK_VL_SILENT,
+	QUARK_VL_WARN,
+	QUARK_VL_DEBUG,
+};
+
+#define	 qlog(pri, do_errno, fmt, ...)					\
+	qlog_func(pri, do_errno, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define	 qlogx(pri, do_errno, fmt, ...)					\
+	qlog_func(pri, do_errno, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define	 qwarn(fmt, ...) qlog(QUARK_VL_WARN, 1, fmt, ##__VA_ARGS__)
+#define	 qwarnx(fmt, ...) qlog(QUARK_VL_WARN, 0, fmt, ##__VA_ARGS__)
+#define	 qdebug(fmt, ...) qlog(QUARK_VL_DEBUG, 1, fmt, ##__VA_ARGS__)
+#define	 qdebugx(fmt, ...) qlog(QUARK_VL_DEBUG, 0, fmt, ##__VA_ARGS__)
+void	 qlog_func(int, int, const char *, int, const char *, ...) __attribute__((format(printf, 5,6)));
+
 /*
  * Time helpers
  */

--- a/qutil.c
+++ b/qutil.c
@@ -334,7 +334,7 @@ qlog_func(int pri, int do_errno, const char *func, int lineno,
 		    program_invocation_short_name, func, lineno);
 		vfprintf(stderr, fmt, ap);
 		if (do_errno)
-			fprintf(stderr, "%s:", strerror(saved_errno));
+			fprintf(stderr, ": %s", strerror(saved_errno));
 		fprintf(stderr, "\n");
 	} else {
 		if (do_errno) {


### PR DESCRIPTION
Logging functions

follows the text of the first commit, each commit details itself.

--

Implement logging functions. Issue #2
First of 3 commits.

This implements qwarn, qwarnx, qdebug and qdebugx, they behave a bit like
warn(3).

Conditionally only print depending on quark_verbose, the output has both
`program_invocation_short_name` and the `function:line` prepended. Example:

```
quark-mon: quark_btf_open2:316: dotname=task_struct.pids failed
```

The dance around allocating a new fmt in nfmt is to attempt the whole output in
one syscall, preventing interleaved output.

I chose only 3 levels of printing, since in the normal case it should be
"none/silent", as libraries shouldn't print. Then the next would be either info
or warning, but having both made no sense imho.

So it's basically:
  - SILENT, normal behaviour
  - WARNING, show me some stuff so I can see what's going wrong
  - DEBUG, print everything no one needs

`quark_verbose` can be influenced by passing `-v` multiple times in quark-mon(8)
and quark-btf(8).

Output example in trying to start quark-mon(8) without priviledges:
```
eru:quark: ./quark-mon -sk
quark-mon: quark_queue_open: Permission denied
```

with WARNING:
```
eru:quark: ./quark-mon -skv
quark-mon: open_tracing:703: open: events/sched/sched_process_exec/format:
Permission denied
quark-mon: open_tracing:695: open: /sys/kernel/debug/tracing: Permission denied
quark-mon: quark_queue_open:1734: all backends failed
quark-mon: quark_queue_open: Permission denied
```
