### PR TITLE
Add basic versioning scheme

### DIFF
--- a/docs/quark-btf.8.html
+++ b/docs/quark-btf.8.html
@@ -45,6 +45,13 @@
       <var class="Ar">btf_file name version</var></td>
   </tr>
 </table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-btf <code class="Fl">-V</code></code></td>
+    <td></td>
+  </tr>
+</table>
 </section>
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm">quark-btf</code> program prints out the kernel structures
@@ -86,6 +93,8 @@ The <code class="Nm">quark-btf</code> program prints out the kernel structures
   <dd>Increase
       <a class="permalink" href="#quark_verbose"><i class="Em" id="quark_verbose">quark_verbose</i></a>,
       can be issued multiple times.</dd>
+  <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a></dt>
+  <dd>Print version and exit.</dd>
 </dl>
 <section class="Sh">
 <h1 class="Sh" id="EXIT_STATUS"><a class="permalink" href="#EXIT_STATUS">EXIT
@@ -146,7 +155,7 @@ vfsmount.mnt_root            0</pre>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 4, 2024</td>
+    <td class="foot-date">October 14, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark-mon.8.html
+++ b/docs/quark-mon.8.html
@@ -31,6 +31,13 @@
       <var class="Ar">maxnodes</var>]</td>
   </tr>
 </table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-mon <code class="Fl">-V</code></code></td>
+    <td></td>
+  </tr>
+</table>
 </section>
 <h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The <code class="Nm">quark-mon</code> program listens to all incoming
@@ -95,6 +102,8 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
       sorted by time, and the second by pid plus time. Exits after
       <var class="Ar">maxnodes</var> has been reached. This is used purely for
       internal debugging.</dd>
+  <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a></dt>
+  <dd>Print version and exit.</dd>
 </dl>
 <section class="Sh">
 <h1 class="Sh" id="BACKEND_SELECTION"><a class="permalink" href="#BACKEND_SELECTION">BACKEND
@@ -161,7 +170,7 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 14, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark-btf.8
+++ b/quark-btf.8
@@ -16,6 +16,7 @@
 .Nm quark-btf
 .Op Fl v
 .Fl g Ar btf_file name version
+.Nm quark-btf Fl V
 .Sh DESCRIPTION
 The
 .Nm
@@ -58,6 +59,8 @@ Matching can be partial.
 Increase
 .Em quark_verbose ,
 can be issued multiple times.
+.It Fl V
+Print version and exit.
 .El
 .Sh EXIT STATUS
 .Nm

--- a/quark-btf.c
+++ b/quark-btf.c
@@ -17,6 +17,16 @@ static int		gflag;
 static int		lflag;
 
 static void
+disply_version(void)
+{
+	printf("%s-%s\n", program_invocation_short_name, QUARK_VERSION);
+	printf("License: Apache-2.0\n");
+	printf("Copyright (c) 2024 Elastic NV\n");
+
+	exit(0);
+}
+
+static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s [-bv] [targets...]\n",
@@ -27,6 +37,7 @@ usage(void)
 	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s [-v] [-g btf_file name version]\n",
 	    program_invocation_short_name);
+	fprintf(stderr, "usage: %s -V\n", program_invocation_short_name);
 
 	exit(1);
 }
@@ -218,7 +229,7 @@ main(int argc, char *argv[])
 	int			 ch;
 	const char		*path = NULL;
 
-	while ((ch = getopt(argc, argv, "bf:glv")) != -1) {
+	while ((ch = getopt(argc, argv, "bf:glvV")) != -1) {
 		switch (ch) {
 		case 'b':
 			bflag = 1;
@@ -237,6 +248,9 @@ main(int argc, char *argv[])
 			break;
 		case 'v':
 			quark_verbose++;
+			break;
+		case 'V':
+			disply_version();
 			break;
 		default:
 			usage();

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -10,6 +10,7 @@
 .Op Fl C Ar filename
 .Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
+.Nm quark-mon Fl V
 .Sh DESCRIPTION
 The
 .Nm
@@ -82,6 +83,8 @@ Exits after
 .Ar maxnodes
 has been reached.
 This is used purely for internal debugging.
+.It Fl V
+Print version and exit.
 .El
 .Sh BACKEND SELECTION
 If no backend option is specified,

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -59,11 +59,22 @@ priv_drop(void)
 }
 
 static void
+display_version(void)
+{
+	printf("%s-%s\n", program_invocation_short_name, QUARK_VERSION);
+	printf("License: Apache-2.0\n");
+	printf("Copyright (c) 2024 Elastic NV\n");
+
+	exit(0);
+}
+
+static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s [-bDefkstv] "
 	    "[-C filename ] [-l maxlength] [-m maxnodes]\n",
 	    program_invocation_short_name);
+	fprintf(stderr, "usage: %s -V\n", program_invocation_short_name);
 
 	exit(1);
 }
@@ -86,7 +97,7 @@ main(int argc, char *argv[])
 	nqevs = 32;
 	graph_by_time = graph_by_pidtime = graph_cache = NULL;
 
-	while ((ch = getopt(argc, argv, "bC:Degklm:tsv")) != -1) {
+	while ((ch = getopt(argc, argv, "bC:Degklm:tsvV")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -140,6 +151,9 @@ main(int argc, char *argv[])
 			break;
 		case 'v':
 			quark_verbose++;
+			break;
+		case 'V':
+			display_version();
 			break;
 		default:
 			usage();

--- a/quark.h
+++ b/quark.h
@@ -4,6 +4,9 @@
 #ifndef _QUARK_H_
 #define _QUARK_H_
 
+/* Version is shared between library and utilities */
+#define QUARK_VERSION "0.1a"
+
 /* Misc types */
 #include <stdio.h>
 


### PR DESCRIPTION
QUARK_VERSION should be shared by libquark, quark-btf, quark-mon and also elastic/go-quark.

A release has the form "MAJOR.MINOR", we break ABI *freely*, so a MINOR can break ABI. MAJOR denotes a major milestone, or some cool stuff that was added.

Quark is not meant to be distributed as a shared object, therefore it makes no sense for us to be careful with ABI breakages, users should be building quark together with their application. We should document them in a CHANGES file for every release.

The suffix "a" is added to the version we are working on, so when we're about to release: remove the suffix; release; bump with suffix.

tip for review: ignore the html part as it's autogenerated.

cc @mjwolf 