### PR TITLE
Stash the active backend in quark_queue_stats{}

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,9 @@
+Quark Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~
+  This file documents breaking and/or other changes that might require
+  user interaction. Examples include: a user facing structure change; a
+  new library call; a change in behaviour.
+
+Changes from 0.1 to 0.2
+~~~~~~~~~~~~~~~~~~~~~~~
+  o quark_queue_stats{} got a "backend" member.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -292,6 +292,7 @@ bpf_queue_open(struct quark_queue *qq)
 		goto fail;
 
 	qq->queue_ops = &queue_ops_bpf;
+	qq->stats.backend = QQ_EBPF;
 
 	return (0);
 fail:

--- a/docs/index.html
+++ b/docs/index.html
@@ -387,7 +387,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 15, 2024</td>
+    <td class="foot-date">October 18, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -387,7 +387,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 15, 2024</td>
+    <td class="foot-date">October 18, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_get_stats.3.html
+++ b/docs/quark_queue_get_stats.3.html
@@ -41,6 +41,7 @@
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	int	backend;
 };</pre>
 </div>
 <dl class="Bl-tag">
@@ -67,6 +68,9 @@
       simply can't handle the load, the former is way more likely. It is a state
       counter representing total loss, the user should compare to an old reading
       to know if it increased.</dd>
+  <dt id="backend"><a class="permalink" href="#backend"><i class="Em">backend</i></a></dt>
+  <dd>Active queue backend, either <code class="Dv">QQ_EBPF</code> or
+      <code class="Dv">QQ_KPROBE</code>.</dd>
 </dl>
 <section class="Sh">
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
@@ -85,7 +89,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 18, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1268,6 +1268,7 @@ kprobe_queue_open(struct quark_queue *qq)
 	}
 
 	qq->queue_ops = &queue_ops_kprobe;
+	qq->stats.backend = QQ_KPROBE;
 
 	return (0);
 

--- a/quark.h
+++ b/quark.h
@@ -335,6 +335,7 @@ struct quark_queue_stats {
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	int	backend;	/* active backend, QQ_EBPF or QQ_KPROBE */
 	/* TODO u64	peak_nodes; */
 };
 

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -23,6 +23,7 @@ struct quark_queue_stats {
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	int	backend;
 };
 .Ed
 .Bl -tag -width "non_aggregations"
@@ -50,6 +51,11 @@ fast enough or if
 simply can't handle the load, the former is way more likely.
 It is a state counter representing total loss, the user should compare to an old
 reading to know if it increased.
+.It Em backend
+Active queue backend, either
+.Dv QQ_EBPF
+or
+.Dv QQ_KPROBE .
 .El
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,


### PR DESCRIPTION
The whole idea of "the user should not even know which backend is being used", worked a bit too much.

This was prompted by a bug in beats where seccomp was blocking a syscall needed for EBPF, and so it fell back to kprobe all the time and the user had no proper way to notice this.

Related to https://github.com/elastic/beats/pull/41297

Purposedly stashed this into stats to make it hard to retrieve from quark.c, if we start doing `if (qq->backend == QQ_EBPF)` we lost the war.