### PR TITLE
Fix a kprobe breakage introduced recently

### DIFF
--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -649,7 +649,7 @@ perf_event_open_degradable(struct perf_event_attr *attr, pid_t pid, int cpu,
 
 again:
 	r = perf_event_open(attr, pid, cpu, group_fd, flags);
-	if (r == 0)
+	if (r >= 0)
 		return (r);
 	else if (r == -1 && errno != EINVAL)
 		return (-1);


### PR DESCRIPTION
Wrong return of `perf_event_open` introduced in 1e144175002c29614908e4e6972548a1abb252e6 caused degrading to "always happen", which broke my recent kernel `6.10.11-100.fc39.x86_64`.

Tested on centos7 that still works.

On an older fedora 6.5.6-300.fc39.x86_64 the breakage only made the aging broken, events would return immediatelly instead of being aged.

Discovered the hard way by writing actual tests, at least that is positive, all in all a bit embarrassing.

This warrants a new release.