### PR TITLE
Quark test goodies

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
   <li><a href="#FEATURES">FEATURES</a></li>
   <li><a href="#BUILDING">BUILDING</a></li>
   <li><a href="#LINKING">LINKING</a></li>
+  <li><a href="#TESTING">TESTING</a></li>
   <li><a href="#INCLUDED_BINARIES">INCLUDED BINARIES</a></li>
   <li><a href="#CONVENTIONS">CONVENTIONS</a></li>
   <li><a href="#BASIC_USAGE">BASIC USAGE</a></li>
@@ -246,6 +247,12 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 </div>
 </section>
 <section class="Sh">
+<h1 class="Sh" id="TESTING"><a class="permalink" href="#TESTING">TESTING</a></h1>
+<p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is the
+    main test utility ran by the CI(soon). All tests are self-contained in this
+    binary.</p>
+</section>
+<section class="Sh">
 <h1 class="Sh" id="INCLUDED_BINARIES"><a class="permalink" href="#INCLUDED_BINARIES">INCLUDED
   BINARIES</a></h1>
 <p class="Pp"><a class="Xr" href="quark-mon.8.html">quark-mon(8)</a> is a
@@ -256,6 +263,8 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 <p class="Pp"><a class="Xr" href="quark-btf.8.html">quark-btf(8)</a> is a
     program for dumping BTF information used by
   <code class="Nm">quark</code>.</p>
+<p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is a
+    program for running tests during development.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="CONVENTIONS"><a class="permalink" href="#CONVENTIONS">CONVENTIONS</a></h1>
@@ -373,7 +382,8 @@ main(void)
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="LICENSE"><a class="permalink" href="#LICENSE">LICENSE</a></h1>
@@ -387,7 +397,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 18, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark-btf.8.html
+++ b/docs/quark-btf.8.html
@@ -155,7 +155,7 @@ vfsmount.mnt_root            0</pre>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 14, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark-mon.8.html
+++ b/docs/quark-mon.8.html
@@ -165,12 +165,13 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
     <a class="Xr" href="quark_queue_get_events.3.html">quark_queue_get_events(3)</a>,
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
-    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a></p>
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 14, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark-test.8.html
+++ b/docs/quark-test.8.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
+  <title>QUARK-TEST(8)</title>
+</head>
+<body>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">QUARK-TEST(8)</td>
+    <td class="head-vol">System Manager's Manual</td>
+    <td class="head-rtitle">QUARK-TEST(8)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<p class="Pp"><code class="Nm">quark-test</code> &#x2014;
+    <span class="Nd">quark's test utility</span></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-test</code></td>
+    <td>[<code class="Fl">-bkv</code>] [<var class="Ar">tests ...</var>]</td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-test <code class="Fl">-l</code></code></td>
+    <td></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-test <code class="Fl">-N</code></code></td>
+    <td></td>
+  </tr>
+</table>
+<br/>
+<table class="Nm">
+  <tr>
+    <td><code class="Nm">quark-test <code class="Fl">-V</code></code></td>
+    <td></td>
+  </tr>
+</table>
+</section>
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The <code class="Nm">quark-test</code> program runs tests for
+  <a class="Xr" href="quark.7.html">quark(7)</a>. It is designed as one big fat
+  binary so that you can easily run it with quark's custom
+  <span class="Pa">initramfs.gz</span>. Without any arguments,
+  <code class="Nm">quark-test</code> will run all tests in both KPROBE and EBPF
+  as backend.
+<p class="Pp">Each test runs a separate sub-process in order to avoid address
+    space contaminaton between two tests. The number of failed tests is the
+    return value of <code class="Nm">quark-test</code>.</p>
+<p class="Pp">The options are as follows:</p>
+<dl class="Bl-tag">
+  <dt id="b"><a class="permalink" href="#b"><code class="Fl">-b</code></a></dt>
+  <dd>Run only EBPF tests.</dd>
+  <dt id="k"><a class="permalink" href="#k"><code class="Fl">-k</code></a></dt>
+  <dd>Run only KPROBE tests.</dd>
+  <dt id="l"><a class="permalink" href="#l"><code class="Fl">-l</code></a></dt>
+  <dd>Prints all available tests on stdout.</dd>
+  <dt id="N"><a class="permalink" href="#N"><code class="Fl">-N</code></a></dt>
+  <dd>This is a nop flag, literally, <code class="Nm">quark-test</code> will
+      just exit with 0. Some tests must fork and exec things in order to collect
+      events, this keeps the binary self contained by forking and execing itself
+      as we don't have access to system utilities in
+      <span class="Pa">initramfs.gz</span>.</dd>
+  <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a></dt>
+  <dd>Increase
+      <a class="permalink" href="#quark_verbose"><i class="Em" id="quark_verbose">quark_verbose</i></a>,
+      can be issued multiple times.</dd>
+  <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a></dt>
+  <dd>Print version and exit.</dd>
+</dl>
+<section class="Sh">
+<h1 class="Sh" id="EXIT_STATUS"><a class="permalink" href="#EXIT_STATUS">EXIT
+  STATUS</a></h1>
+<p class="Pp"><code class="Nm">quark-test</code> exits with the number of failed
+    tests, or non-zero if <code class="Nm">quark-test</code> itself fails.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
+<div class="Bd Li">
+<pre>$ quark-test -k
+
+t_probe @ kprobe: ok
+t_fork_exec_exit @ kprobe: ok
+failed tests 0
+
+$ quark-test t_fork_exec_exit
+
+t_fork_exec_exit @ ebpf: ok
+t_fork_exec_exit @ kprobe: ok
+failed tests 0</pre>
+</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
+    <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
+    <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
+    <a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a>,
+    <a class="Xr" href="quark_queue_get_events.3.html">quark_queue_get_events(3)</a>,
+    <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+</section>
+</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">October 25, 2024</td>
+    <td class="foot-os">Linux</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -27,6 +27,7 @@
   <li><a href="#FEATURES">FEATURES</a></li>
   <li><a href="#BUILDING">BUILDING</a></li>
   <li><a href="#LINKING">LINKING</a></li>
+  <li><a href="#TESTING">TESTING</a></li>
   <li><a href="#INCLUDED_BINARIES">INCLUDED BINARIES</a></li>
   <li><a href="#CONVENTIONS">CONVENTIONS</a></li>
   <li><a href="#BASIC_USAGE">BASIC USAGE</a></li>
@@ -246,6 +247,12 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 </div>
 </section>
 <section class="Sh">
+<h1 class="Sh" id="TESTING"><a class="permalink" href="#TESTING">TESTING</a></h1>
+<p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is the
+    main test utility ran by the CI(soon). All tests are self-contained in this
+    binary.</p>
+</section>
+<section class="Sh">
 <h1 class="Sh" id="INCLUDED_BINARIES"><a class="permalink" href="#INCLUDED_BINARIES">INCLUDED
   BINARIES</a></h1>
 <p class="Pp"><a class="Xr" href="quark-mon.8.html">quark-mon(8)</a> is a
@@ -256,6 +263,8 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 <p class="Pp"><a class="Xr" href="quark-btf.8.html">quark-btf(8)</a> is a
     program for dumping BTF information used by
   <code class="Nm">quark</code>.</p>
+<p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is a
+    program for running tests during development.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="CONVENTIONS"><a class="permalink" href="#CONVENTIONS">CONVENTIONS</a></h1>
@@ -373,7 +382,8 @@ main(void)
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="LICENSE"><a class="permalink" href="#LICENSE">LICENSE</a></h1>
@@ -387,7 +397,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 18, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_process_lookup.3.html
+++ b/docs/quark_process_lookup.3.html
@@ -60,12 +60,13 @@
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_block.3.html
+++ b/docs/quark_queue_block.3.html
@@ -63,12 +63,13 @@
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_close.3.html
+++ b/docs/quark_queue_close.3.html
@@ -53,12 +53,13 @@
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_default_attr.3.html
+++ b/docs/quark_queue_default_attr.3.html
@@ -47,12 +47,13 @@
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_get_epollfd.3.html
+++ b/docs/quark_queue_get_epollfd.3.html
@@ -87,12 +87,13 @@ my_own_blocking(struct quark_queue *qq)
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_get_events.3.html
+++ b/docs/quark_queue_get_events.3.html
@@ -189,12 +189,13 @@
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_get_stats.3.html
+++ b/docs/quark_queue_get_stats.3.html
@@ -84,12 +84,13 @@
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 18, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -163,12 +163,13 @@
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark.7.html">quark(7)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
-    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
 </section>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">September 19, 2024</td>
+    <td class="foot-date">October 25, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -143,4 +143,5 @@ for the output format description.
 .Xr quark_queue_get_events 3 ,
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,
-.Xr quark-btf 8
+.Xr quark-btf 8 ,
+.Xr quark-test 8

--- a/quark-test.8
+++ b/quark-test.8
@@ -1,0 +1,82 @@
+.Dd $Mdocdate$
+.Dt QUARK-TEST 8
+.Os
+.Sh NAME
+.Nm quark-test
+.Nd quark's test utility
+.Sh SYNOPSIS
+.Nm quark-test
+.Op Fl bkv
+.Op Ar tests ...
+.Nm quark-test Fl l
+.Nm quark-test Fl N
+.Nm quark-test Fl V
+.Sh DESCRIPTION
+The
+.Nm
+program runs tests for
+.Xr quark 7 .
+It is designed as one big fat binary so that you can easily run it with quark's
+custom
+.Pa initramfs.gz .
+Without any arguments,
+.Nm
+will run all tests in both KPROBE and EBPF as backend.
+.Pp
+Each test runs a separate sub-process in order to avoid address space
+contaminaton between two tests.
+The number of failed tests is the return value of
+.Nm .
+.Pp
+The options are as follows:
+.Bl -tag -width Dtb
+.It Fl b
+Run only EBPF tests.
+.It Fl k
+Run only KPROBE tests.
+.It Fl l
+Prints all available tests on stdout.
+.It Fl N
+This is a nop flag, literally,
+.Nm
+will just exit with 0. Some tests must fork and exec things in order to collect
+events, this keeps the binary self contained by forking and execing itself as we
+don't have access to system utilities in
+.Pa initramfs.gz .
+.It Fl v
+Increase
+.Em quark_verbose ,
+can be issued multiple times.
+.It Fl V
+Print version and exit.
+.El
+.Sh EXIT STATUS
+.Nm
+exits with the number of failed tests, or non-zero if
+.Nm
+itself fails.
+.Sh EXAMPLES
+.Bd -literal
+$ quark-test -k
+
+t_probe @ kprobe: ok
+t_fork_exec_exit @ kprobe: ok
+failed tests 0
+
+$ quark-test t_fork_exec_exit
+
+t_fork_exec_exit @ ebpf: ok
+t_fork_exec_exit @ kprobe: ok
+failed tests 0
+.Ed
+.Sh SEE ALSO
+.Xr quark_event_dump 3 ,
+.Xr quark_process_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_get_epollfd 3 ,
+.Xr quark_queue_get_events 3 ,
+.Xr quark_queue_get_stats 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8

--- a/quark-test.c
+++ b/quark-test.c
@@ -79,7 +79,7 @@ usage(void)
 	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s -l\n",
 	    program_invocation_short_name);
-	fprintf(stderr, "usage: %s -N [nop args ...]\n",
+	fprintf(stderr, "usage: %s -N\n",
 	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s -V\n",
 	    program_invocation_short_name);

--- a/quark.7
+++ b/quark.7
@@ -258,6 +258,10 @@ $ cc -o myprogram myprogram.c libquark_big.a
 OR
 $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf/libelf_pic.a zlib/libz.a
 .Ed
+.Sh TESTING
+.Xr quark-test 8
+is the main test utility ran by the CI(soon).
+All tests are self-contained in this binary.
 .Sh INCLUDED BINARIES
 .Xr quark-mon 8
 is a program that dumps
@@ -269,6 +273,9 @@ small program, it aims to demonstrate how a user could implement the same.
 .Xr quark-btf 8
 is a program for dumping BTF information used by
 .Nm .
+.Pp
+.Xr quark-test 8
+is a program for running tests during development.
 .Sh CONVENTIONS
 .Bl -bullet
 .It
@@ -388,7 +395,8 @@ describes initialization options that can be useful.
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8
 .Sh LICENSE
 .Nm
 is released under the Apache-2.0 license and contains code under BSD-2, BSD-3,

--- a/quark_process_lookup.3
+++ b/quark_process_lookup.3
@@ -37,4 +37,5 @@ is taking place, as this might free the pointed memory.
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_block.3
+++ b/quark_queue_block.3
@@ -43,4 +43,5 @@ is set.
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_close.3
+++ b/quark_queue_close.3
@@ -32,4 +32,5 @@ is set.
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_default_attr.3
+++ b/quark_queue_default_attr.3
@@ -25,4 +25,5 @@ for an in depth explanation of each member.
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_get_epollfd.3
+++ b/quark_queue_get_epollfd.3
@@ -65,4 +65,5 @@ my_own_blocking(struct quark_queue *qq)
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_get_events.3
+++ b/quark_queue_get_events.3
@@ -178,4 +178,5 @@ is set.
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -67,4 +67,5 @@ or
 .Xr quark_queue_open 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -161,4 +161,5 @@ should NOT be issued.
 .Xr quark_queue_get_stats 3 ,
 .Xr quark 7 ,
 .Xr quark-btf 8 ,
-.Xr quark-mon 8
+.Xr quark-mon 8 ,
+.Xr quark-test 8


### PR DESCRIPTION
This PR is split into two commits, the first one improves quark-test(8) while the second is purely documentation.

As usual, each commit is self contained and it might make more sense to look at them individually.

**text of the first commit:**
quark-test(8) improvements
This improves quark-test(8) with a number of tiny goodies:
 * Avoid execing "/proc/self/exe" as some kernels, as spotted by @mjwolf resolve
   the link kprobes(sched_process_exec) and some do not. Read the link ourselves.
 * Introduce a `k` flag for kprobe and `b` flag for ebpf, just like quark-mon(8).
 * Allow the user to specify which tests he wants to run as a command line
   argument `quark-test t_fork_exec`.
 * Improve test output by saving stderr. See below.

Each test already runs as a subprocess, this goes one step further by
redirecting the test output to a memstream, so when the child prints out to
stderr, we collect it and print it after we (the parent) prints "failed".

This might be tiny, but it makes me furious, this is how the output was before:

```
GOOD CASE:
eru:quark: sudo ./quark-test
t_probe @ kprobe: ok
BAD CASE:
eru:quark: ./quark-test
t_probe @ kprobe: quark-test: t_probe: quark_queue_open: Permission denied
failed
```

Now the BAD CASE is actually readable:
```
eru:quark: ./quark-test
t_probe @ kprobe: failed
quark-test: t_probe: quark_queue_open: Permission denied
```