### PR TITLE
Run quark-test in the CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - label: "build amd64 in docker"
-    key: build_docker
+    key: make_docker
     command: "make docker"
     agents:
       image: family/core-ubuntu-2204
@@ -10,6 +10,8 @@ steps:
   - label: "build amd64 in a centos7 container"
     key: make_centos7
     command: "make centos7"
+    artifact_paths:
+      - "quark-test"
     agents:
       image: family/core-ubuntu-2204
       provider: gcp
@@ -18,6 +20,16 @@ steps:
   - label: "build arm64 cross-compiled in docker"
     key: make_docker_cross_arm64
     command: "make docker-cross-arm64"
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+
+  - label: "quark-test"
+    key: test
+    command: "./.buildkite/runtest.sh"
+    depends_on:
+      - make_centos7
     agents:
       image: family/core-ubuntu-2204
       provider: gcp

--- a/.buildkite/runtest.sh
+++ b/.buildkite/runtest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function download {
+	buildkite-agent artifact download "$1" "$2"
+}
+
+if [ -z "${BUILDKITE}" ]; then
+	echo "This script doesn't appear to be running in buildkite" 1>&2
+	echo "refusing to continue" 1>&2
+	exit 1
+fi
+
+download quark-test .
+chmod +x quark-test
+
+sudo ./quark-test
+exit $?

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ clean-all: clean
 	$(call msg,CLEAN-ALL)
 	$(Q)rm -f $(SVGS)
 	$(Q)rm -rf include
-	$(Q)make -C $(LIBBPF_SRC) clean
+	$(Q)make -C $(LIBBPF_SRC) clean NO_PKG_CONFIG=y
 	$(Q)make -C $(ELFTOOLCHAIN_SRC)/libelf clean
 	$(Q)make -C $(ZLIB_SRC) clean || true
 


### PR DESCRIPTION
    Run quark-test from the centos7 build as a CI target, this is the very beginning
    and we run it only in the same machine that we make a build.
