### PR TITLE
Fix pgid/sid for RHEL8 and improve kprobe expressions

### DIFF
--- a/kprobe_defs.h
+++ b/kprobe_defs.h
@@ -30,20 +30,31 @@
 #define PWD_K(_t, _o)	"task_struct.fs fs_struct.pwd.dentry " XS(RPT(_t, _o, dentry.d_parent))
 #define PWD_S(_t, _o)	"task_struct.fs fs_struct.pwd.dentry " XS(RPT(_t, _o, dentry.d_parent)) " dentry.d_name.name +0"
 
+/*
+ * 16 is sizeof(struct hlist_node), which is in the beginning of struct
+ * pid_link. sizeof(struct pid_link) is 24, 16 for hlist_node + pid pointer.
+ * PIDTYPE_PGID is `1`, this puts us on 16 + (24 * 1) = 40 bytes.
+ */
 struct kprobe_arg ka_task_old_pgid = {
-	"pgid", XS(ARG_0), "u32", "task_struct.group_leader (task_struct.pids+40) (pid.numbers+0).upid.nr"
+	"pgid", XS(ARG_0), "u32", "task_struct.group_leader ((task_struct.pids+16)+(24*pid_type.PIDTYPE_PGID)) (pid.numbers+0).upid.nr"
 };
 
+/* 16 + 2*24 = 64 */
 struct kprobe_arg ka_task_old_sid = {
-	"sid", XS(ARG_0), "u32", "task_struct.group_leader (task_struct.pids+64) (pid.numbers+0).upid.nr"
+	"sid", XS(ARG_0), "u32", "task_struct.group_leader ((task_struct.pids+16)+(24*pid_type.PIDTYPE_SID)) (pid.numbers+0).upid.nr"
 };
 
+/*
+ * New structure is just an array of pointers, not a pid_link array like above.
+ * RHEL8 uses the new scheme in task_struct.signal, but has the old value for
+ * PIDTYPE_PGID=1, newer kernels have a PIDTYPE_TGID=1 and PIDTYPE_PGID=2.
+ */
 struct kprobe_arg ka_task_new_pgid = {
-	"pgid", XS(ARG_0), "u32", "task_struct.group_leader task_struct.signal (signal_struct.pids+16) (pid.numbers+0).upid.nr"
+	"pgid", XS(ARG_0), "u32", "task_struct.group_leader task_struct.signal (signal_struct.pids+(8*pid_type.PIDTYPE_PGID)) (pid.numbers+0).upid.nr"
 };
 
 struct kprobe_arg ka_task_new_sid = {
-	"sid", XS(ARG_0), "u32", "task_struct.group_leader task_struct.signal (signal_struct.pids+24) (pid.numbers+0).upid.nr"
+	"sid", XS(ARG_0), "u32", "task_struct.group_leader task_struct.signal (signal_struct.pids+(8*pid_type.PIDTYPE_SID)) (pid.numbers+0).upid.nr"
 };
 
 


### PR DESCRIPTION
RHEL8 has `pids` in signal_struct{} but has the old value for PIDTYPE_PGID.

This bug is _also_ in ebpf and in elastic/ebpf, probably since forever as it's pretty hard to detect. I'll put another PR for elastic/ebpf. This fixes kprobe only and ebpf will still fail with:
```
[haesbaert@rocky8 quark]$ sudo ./quark-test
t_probe @ ebpf: ok
t_probe @ kprobe: ok
t_fork_exec_exit @ ebpf: failed
quark-test: quark-test.c:198: t_fork_exec_exit: Assertion `(pid_t)qp->proc_pgid == getpgid(0)' failed.
t_fork_exec_exit @ kprobe: ok
failed tests 1
````

old kernels: https://elixir.bootlin.com/linux/v3.10.108/source/include/linux/pid.h#L69
newer kernels: https://elixir.bootlin.com/linux/v6.12-rc4/source/include/linux/pid_types.h#L10

There are basically two changes, the whole `pids` thing moved from `task_struct` to `signal_struct`, _and_ PIDTYPE_PGID and PIDTYPE_SID got bumped in newer kernels. The bug is because we always assumed both changes occurred together, then comes RHEL, which moved `pids` to `signal_struct` but didn't bump PIDTYPE_PGID.

The fix is teaching quark about enums@BTF and improving the expression parser to accept recursive arithmetics.

This also cleans up the parser a bit, I'm not proud of it, but it looks a bit better than before.

Discovered by running the upcoming "test-this-on-all-kernels" script.