### PR TITLE
Improve output for tests

### DIFF
--- a/init.c
+++ b/init.c
@@ -110,8 +110,8 @@ main(int argc, char *argv[])
 	if (WIFEXITED(status))
 		printf("%s exited with %d\n", argv[0], WEXITSTATUS(status));
 	else if (WIFSIGNALED(status))
-		printf("%s exited with signal %d (SIG%s)\n", argv[0],
-		    WTERMSIG(status), sigabbrev_np(WTERMSIG(status)));
+		printf("%s exited with signal %d (%s)\n", argv[0],
+		    WTERMSIG(status), strsignal(WTERMSIG(status)));
 	else if (WCOREDUMP(status))
 		printf("%s core dumped\n", argv[0]);
 	else

--- a/quark-test.c
+++ b/quark-test.c
@@ -628,6 +628,11 @@ run_test(const struct test *t, struct quark_queue_attr *qa)
 		color(x);
 	}
 	fflush(stdout);
+	if (WIFSIGNALED(status))
+		fprintf(stderr, "exited with signal %d (%s)\n",
+		    WTERMSIG(status), strsignal(WTERMSIG(status)));
+	else if (WCOREDUMP(status))
+		fprintf(stderr, "core dumped\n");
 
 	/*
 	 * Children exited, close the stream and print it out.


### PR DESCRIPTION
when testing a pornographic amount of kernels, it's useful to get a line right before the first test saying which kernel is being run.

also properly print more error conditions