### PR TITLE
Add kernel tests and improve testing infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,8 @@ clean-docs:
 	test-kernel
 
 .NOTPARALLEL:			\
+	clean			\
+	clean-all		\
 	centos7			\
 	centos7-image		\
 	centos7-shell		\

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,8 @@ LIBBPF_SRC:= libbpf/src
 LIBBPF_STATIC:= $(LIBBPF_SRC)/libbpf.a
 LIBBPF_DEPS:=	$(wildcard libbpf/src/*.[ch])		\
 		$(wildcard libbpf/include/*.[ch])	\
-		$(ELFTOOLCHAIN_FILES)
+		$(ELFTOOLCHAIN_FILES)			\
+		$(ELFTOOLCHAIN_STATIC)
 LIBBPF_EXTRA_CFLAGS:= -DQUARK
 LIBBPF_EXTRA_CFLAGS+= -fPIC
 LIBBPF_EXTRA_CFLAGS+= -I../../elftoolchain/libelf

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,14 @@ include: $(LIBBPF_DEPS)
 
 svg: $(SVGS)
 
+test: quark-test
+	sudo ./quark-test
+
+test-kernel: initramfs.gz
+	./ktest-all.sh
+
+test-all: test test-kernel
+
 initramfs:
 	mkdir initramfs
 
@@ -399,7 +407,10 @@ clean-docs:
 	docker-cross-arm64	\
 	docker-image		\
 	docker-shell		\
-	eebpf-sync
+	eebpf-sync		\
+	test			\
+	test-all		\
+	test-kernel
 
 .NOTPARALLEL:			\
 	centos7			\
@@ -409,6 +420,9 @@ clean-docs:
 	docker-cross-arm64	\
 	docker-image		\
 	docker-shell		\
-	initramfs.gz
+	initramfs.gz		\
+	test			\
+	test-all		\
+	test-kernel
 
 .SUFFIXES:

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,7 @@ clean-all: clean
 	$(call msg,CLEAN-ALL)
 	$(Q)rm -f $(SVGS)
 	$(Q)rm -rf include
+	$(Q)rm -f initramfs.gz
 	$(Q)make -C $(LIBBPF_SRC) clean NO_PKG_CONFIG=y
 	$(Q)make -C $(ELFTOOLCHAIN_SRC)/libelf clean
 	$(Q)make -C $(ZLIB_SRC) clean || true

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,10 +169,9 @@ $ ls -1 /tmp | wc -l</pre>
 <p class="Pp" id="git">Make sure to clone the repository recursively:
     <a class="permalink" href="#git"><i class="Em">git clone
     --recursive</i></a>.</p>
-<p class="Pp" id="make"><a class="permalink" href="#make"><i class="Em">make</i></a>
-    builds the repository, including <span class="Pa">quark-mon</span>,
-    <span class="Pa">libquark_big.a</span> and a
-    <span class="Pa">libquark.a</span>.</p>
+<p class="Pp"><i class="Em">make</i> builds the repository, including
+    <span class="Pa">quark-mon</span>, <span class="Pa">libquark_big.a</span>
+    and a <span class="Pa">libquark.a</span>.</p>
 <p class="Pp"><span class="Pa">libquark_big.a</span> includes all needed
     dependencies in one big archive. This includes a
     <span class="Pa">libbpf.a</span>, <span class="Pa">libelf_pic.a</span> (from
@@ -192,12 +191,23 @@ $ ls -1 /tmp | wc -l</pre>
   <dd>Builds <code class="Nm">quark</code> inside a docker container, so you
       don't have to worry about having build dependencies.</dd>
   <dt id="docker-cross-arm64"><a class="permalink" href="#docker-cross-arm64"><i class="Em">docker-cross-arm64</i></a></dt>
-  <dd>Builds <code class="Nm">quark</code> for arm64 inside a docker container,
-      only links and won't work at this time.</dd>
+  <dd>Builds <code class="Nm">quark</code> for arm64 inside a docker
+    container.</dd>
+  <dt id="centos7"><a class="permalink" href="#centos7"><i class="Em">centos7</i></a></dt>
+  <dd>Builds <code class="Nm">quark</code> inside a centos7 docker container,
+      useful for linking against ancient glibc-2.17.</dd>
+  <dt id="test"><a class="permalink" href="#test"><i class="Em">test</i></a></dt>
+  <dd>Builds and runs
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a>.</dd>
+  <dt id="test-kernel"><a class="permalink" href="#test-kernel"><i class="Em">test-kernel</i></a></dt>
+  <dd>Runs <a class="Xr" href="quark-test.8.html">quark-test(8)</a> over all
+      kernels in <span class="Pa">kernel_images/</span>.</dd>
+  <dt id="test-all"><a class="permalink" href="#test-all"><i class="Em">test-all</i></a></dt>
+  <dd>Shortcut for test + test-kernels.</dd>
   <dt id="btfhub"><a class="permalink" href="#btfhub"><i class="Em">btfhub</i></a></dt>
   <dd>Regenerates <span class="Pa">btfhub.c</span>. Usage:
     <div class="Bd Pp Li">
-    <pre>make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive</pre>
+    <pre>$ make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive</pre>
     </div>
   </dd>
   <dt id="clean-all"><a class="permalink" href="#clean-all"><i class="Em">clean-all</i></a></dt>
@@ -222,14 +232,9 @@ $ ls -1 /tmp | wc -l</pre>
     </div>
   </dd>
   <dt id="initramfs.gz"><a class="permalink" href="#initramfs.gz"><i class="Em">initramfs.gz</i></a></dt>
-  <dd>Build a initramfs file containing all quark binaries so that it can be run
-      as the init process on boot, useful for testing any kernel under qemu,
-      notice how you can pass parameters normally to quark-mon:
-    <div class="Bd Pp Li">
-    <pre>$ make initramfs.gz
-$ qemu-system-x86_64 -initrd initramfs.gz -kernel linux-image-x86_64-5.10.92-2 -nographic --append &quot;console=ttyS0 quark-mon -kvvv&quot;</pre>
-    </div>
-  </dd>
+  <dd>Builds an initramfs file containing all quark binaries so that it can be
+      run as the init process on boot, useful for testing any kernel under qemu.
+      See <a class="Sx" href="#TESTING">TESTING</a>.</dd>
 </dl>
 <p class="Pp" id="V=1">All the targets above can generate debug output by
     specifying <a class="permalink" href="#V=1"><i class="Em">V=1</i></a>, as
@@ -249,8 +254,17 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 <section class="Sh">
 <h1 class="Sh" id="TESTING"><a class="permalink" href="#TESTING">TESTING</a></h1>
 <p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is the
-    main test utility ran by the CI(soon). All tests are self-contained in this
-    binary.</p>
+    main test utility ran by the CI, can be invoked via <i class="Em">make
+    test</i>. All tests are self-contained in this binary.</p>
+<p class="Pp">Some included kernels can be tested in qemu via <i class="Em">make
+    test-kernel</i>. Any <code class="Nm">quark</code> utility can be run on a
+    custom kernel via the <span class="Pa">krun.sh</span> script, as in:</p>
+<div class="Bd Pp Li">
+<pre>$ make initramfs.gz
+$ ./krun.sh initramfs.gz kernel-images/amd64/linux-4.18.0-553.el8_10.x86_64 quark-test -vvv</pre>
+</div>
+<p class="Pp">Note that you can pass arguments to the utility and you have to
+    make <span class="Pa">initramfs.gz</span> first.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="INCLUDED_BINARIES"><a class="permalink" href="#INCLUDED_BINARIES">INCLUDED
@@ -397,7 +411,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 25, 2024</td>
+    <td class="foot-date">November 12, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -169,10 +169,9 @@ $ ls -1 /tmp | wc -l</pre>
 <p class="Pp" id="git">Make sure to clone the repository recursively:
     <a class="permalink" href="#git"><i class="Em">git clone
     --recursive</i></a>.</p>
-<p class="Pp" id="make"><a class="permalink" href="#make"><i class="Em">make</i></a>
-    builds the repository, including <span class="Pa">quark-mon</span>,
-    <span class="Pa">libquark_big.a</span> and a
-    <span class="Pa">libquark.a</span>.</p>
+<p class="Pp"><i class="Em">make</i> builds the repository, including
+    <span class="Pa">quark-mon</span>, <span class="Pa">libquark_big.a</span>
+    and a <span class="Pa">libquark.a</span>.</p>
 <p class="Pp"><span class="Pa">libquark_big.a</span> includes all needed
     dependencies in one big archive. This includes a
     <span class="Pa">libbpf.a</span>, <span class="Pa">libelf_pic.a</span> (from
@@ -192,12 +191,23 @@ $ ls -1 /tmp | wc -l</pre>
   <dd>Builds <code class="Nm">quark</code> inside a docker container, so you
       don't have to worry about having build dependencies.</dd>
   <dt id="docker-cross-arm64"><a class="permalink" href="#docker-cross-arm64"><i class="Em">docker-cross-arm64</i></a></dt>
-  <dd>Builds <code class="Nm">quark</code> for arm64 inside a docker container,
-      only links and won't work at this time.</dd>
+  <dd>Builds <code class="Nm">quark</code> for arm64 inside a docker
+    container.</dd>
+  <dt id="centos7"><a class="permalink" href="#centos7"><i class="Em">centos7</i></a></dt>
+  <dd>Builds <code class="Nm">quark</code> inside a centos7 docker container,
+      useful for linking against ancient glibc-2.17.</dd>
+  <dt id="test"><a class="permalink" href="#test"><i class="Em">test</i></a></dt>
+  <dd>Builds and runs
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a>.</dd>
+  <dt id="test-kernel"><a class="permalink" href="#test-kernel"><i class="Em">test-kernel</i></a></dt>
+  <dd>Runs <a class="Xr" href="quark-test.8.html">quark-test(8)</a> over all
+      kernels in <span class="Pa">kernel_images/</span>.</dd>
+  <dt id="test-all"><a class="permalink" href="#test-all"><i class="Em">test-all</i></a></dt>
+  <dd>Shortcut for test + test-kernels.</dd>
   <dt id="btfhub"><a class="permalink" href="#btfhub"><i class="Em">btfhub</i></a></dt>
   <dd>Regenerates <span class="Pa">btfhub.c</span>. Usage:
     <div class="Bd Pp Li">
-    <pre>make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive</pre>
+    <pre>$ make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive</pre>
     </div>
   </dd>
   <dt id="clean-all"><a class="permalink" href="#clean-all"><i class="Em">clean-all</i></a></dt>
@@ -222,14 +232,9 @@ $ ls -1 /tmp | wc -l</pre>
     </div>
   </dd>
   <dt id="initramfs.gz"><a class="permalink" href="#initramfs.gz"><i class="Em">initramfs.gz</i></a></dt>
-  <dd>Build a initramfs file containing all quark binaries so that it can be run
-      as the init process on boot, useful for testing any kernel under qemu,
-      notice how you can pass parameters normally to quark-mon:
-    <div class="Bd Pp Li">
-    <pre>$ make initramfs.gz
-$ qemu-system-x86_64 -initrd initramfs.gz -kernel linux-image-x86_64-5.10.92-2 -nographic --append &quot;console=ttyS0 quark-mon -kvvv&quot;</pre>
-    </div>
-  </dd>
+  <dd>Builds an initramfs file containing all quark binaries so that it can be
+      run as the init process on boot, useful for testing any kernel under qemu.
+      See <a class="Sx" href="#TESTING">TESTING</a>.</dd>
 </dl>
 <p class="Pp" id="V=1">All the targets above can generate debug output by
     specifying <a class="permalink" href="#V=1"><i class="Em">V=1</i></a>, as
@@ -249,8 +254,17 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 <section class="Sh">
 <h1 class="Sh" id="TESTING"><a class="permalink" href="#TESTING">TESTING</a></h1>
 <p class="Pp"><a class="Xr" href="quark-test.8.html">quark-test(8)</a> is the
-    main test utility ran by the CI(soon). All tests are self-contained in this
-    binary.</p>
+    main test utility ran by the CI, can be invoked via <i class="Em">make
+    test</i>. All tests are self-contained in this binary.</p>
+<p class="Pp">Some included kernels can be tested in qemu via <i class="Em">make
+    test-kernel</i>. Any <code class="Nm">quark</code> utility can be run on a
+    custom kernel via the <span class="Pa">krun.sh</span> script, as in:</p>
+<div class="Bd Pp Li">
+<pre>$ make initramfs.gz
+$ ./krun.sh initramfs.gz kernel-images/amd64/linux-4.18.0-553.el8_10.x86_64 quark-test -vvv</pre>
+</div>
+<p class="Pp">Note that you can pass arguments to the utility and you have to
+    make <span class="Pa">initramfs.gz</span> first.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="INCLUDED_BINARIES"><a class="permalink" href="#INCLUDED_BINARIES">INCLUDED
@@ -397,7 +411,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">October 25, 2024</td>
+    <td class="foot-date">November 12, 2024</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/krun.sh
+++ b/krun.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+Script=${0##*/}
+
+function usage
+{
+	echo "usage: $Script initramfs_path kernel_path cmd_line" 1>&2
+	exit 1
+}
+
+if [ $# -lt 3 ]; then
+   usage
+fi
+
+initramfs="$1"
+kernel="$2"
+shift 2
+bin="$1"
+cmdline="$*"
+
+function qemu {
+	case "$(file -b "$kernel" | awk '{print $3}')" in
+	x86)
+		qemu-system-x86_64						\
+			-m 256M							\
+			-enable-kvm						\
+			-initrd "$initramfs"					\
+			-kernel "$kernel"					\
+			-nographic						\
+			--append "console=ttyS0 quiet TERM=dumb $cmdline"
+		;;
+	ARM64)
+		qemu-system-aarch64						\
+			-m 256M							\
+			-machine virt						\
+			-cpu cortex-a57						\
+			-initrd "$initramfs"					\
+			-kernel "$kernel"					\
+			-nographic						\
+			--append "console=ttyAMA0 quiet TERM=dumb $cmdline"
+		;;
+	*)
+		echo unknown kernel image arch 1>&2; exit 1;;
+	esac
+}
+
+exitcode=1
+while read -r line
+do
+	line="$(tr -d '\r' <<< "$line")"
+	echo "$line"
+	if grep -q "^$bin exited with " <<< "$line"; then
+		exitcode="$(awk '{print $4}' <<< "$line")"
+	fi
+done < <(qemu)
+
+echo exited with "$exitcode"
+
+exit $((exitcode))

--- a/ktest-all.sh
+++ b/ktest-all.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+Script=${0##*/}
+
+set -euo pipefail
+
+kprobe_only=(linux-3.10.0-123.el7.x86_64)
+result=""
+declare -i failures=0
+
+function maybe_kflag
+{
+	for k in "${kprobe_only[@]}"; do
+		if [ "$1" = "$k" ]; then
+			echo "-k"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+for k in kernel-images/amd64/*
+do
+	kname="$(basename "$k")"
+	echo testing "$kname"
+	if ./krun.sh initramfs.gz "$k" quark-test "$(maybe_kflag "$kname")"; then
+		r="$(printf "%s: ok" "$kname")"
+	else
+		r="$(printf "%s: fail" "$kname")"
+		failures=$((failures+1))
+	fi
+	result="${result}${r}\n"
+done
+
+echo -ne "$result"
+echo failures $failures
+
+exit $failures

--- a/quark.7
+++ b/quark.7
@@ -192,7 +192,7 @@ as
 is quite big.
 .Pp
 Other useful build targets include:
-.Bl -tag -width "man-lint"
+.Bl -tag -width "docker-cross-arm64"
 .It Em clean
 Clean object files from
 .Nm .
@@ -204,13 +204,28 @@ having build dependencies.
 .It Em docker-cross-arm64
 Builds
 .Nm quark
-for arm64 inside a docker container, only links and won't work at this time.
+for arm64 inside a docker container.
+.It Em centos7
+Builds
+.Nm quark
+inside a centos7 docker container, useful for linking against
+ancient glibc-2.17.
+.It Em test
+Builds and runs
+.Xr quark-test 8 .
+.It Em test-kernel
+Runs
+.Xr quark-test 8
+over all kernels in
+.Pa kernel_images/ .
+.It Em test-all
+Shortcut for test + test-kernels.
 .It Em btfhub
 Regenerates
 .Pa btfhub.c .
 Usage:
 .Bd -literal
-make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive
+$ make btfhub BTFHUB_ARCHIVE_PATH=/my/path/to/btfhub-archive
 .Ed
 .It Em clean-all
 Clean all object files, including the ones from
@@ -237,13 +252,10 @@ Usage:
 $ make eebpf-sync EEBPF_PATH=/my/path/to/elastic/ebpf
 .Ed
 .It Em initramfs.gz
-Build a initramfs file containing all quark binaries so that it can be run as
-the init process on boot, useful for testing any kernel under qemu, notice how
-you can pass parameters normally to quark-mon:
-.Bd -literal
-$ make initramfs.gz
-$ qemu-system-x86_64 -initrd initramfs.gz -kernel linux-image-x86_64-5.10.92-2 -nographic --append "console=ttyS0 quark-mon -kvvv"
-.Ed
+Builds an initramfs file containing all quark binaries so that it can be run as
+the init process on boot, useful for testing any kernel under qemu.
+See
+.Sx TESTING .
 .El
 .Pp
 All the targets above can generate debug output by specifying
@@ -260,8 +272,25 @@ $ cc -o myprogram myprogram.c libquark.a libbpf/src/libbpf.a elftoolchain/libelf
 .Ed
 .Sh TESTING
 .Xr quark-test 8
-is the main test utility ran by the CI(soon).
+is the main test utility ran by the CI, can be invoked via
+.Em make test .
 All tests are self-contained in this binary.
+.Pp
+Some included kernels can be tested in qemu via
+.Em make test-kernel .
+Any
+.Nm quark
+utility can be run on a custom kernel via the
+.Pa krun.sh
+script, as in:
+.Bd -literal
+$ make initramfs.gz
+$ ./krun.sh initramfs.gz kernel-images/amd64/linux-4.18.0-553.el8_10.x86_64 quark-test -vvv
+.Ed
+.Pp
+Note that you can pass arguments to the utility and you have to make
+.Pa initramfs.gz
+first.
 .Sh INCLUDED BINARIES
 .Xr quark-mon 8
 is a program that dumps


### PR DESCRIPTION
main commit:
```
    This adds targets `test` `test-kernel` and `test-all` aslong with the scripts
    supporting them `krun.sh` and `ktest-all.sh`.

    `krun.sh` can be used to run a quark utility in a specified kernel:

    $ ./krun.sh initramfs.gz kernel-images/amd64/linux-6.11.4-101.fc39.x86_64 quark-test -v

    `ktest-all.sh` is just a wrapper for running all kernels in kernel-images.

    Keeping the idea of not running scripts directly, these will mostly be used via
    `test-kernel`.
```
Each commit documents itself, and they won't be squashed.