### PR TITLE
Prepare 0.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,3 +7,8 @@ Quark Breaking Changes
 Changes from 0.1 to 0.2
 ~~~~~~~~~~~~~~~~~~~~~~~
   o quark_queue_stats{} got a "backend" member.
+
+Changes from 0.2 to 0.3
+~~~~~~~~~~~~~~~~~~~~~~~
+  o quark_queue_process{} got {uts,ipc,mnt,net}_inonum members.
+  o -h on quark-{mon,test,btf} now invokes the manpage instead of usage.

--- a/quark.h
+++ b/quark.h
@@ -5,7 +5,7 @@
 #define _QUARK_H_
 
 /* Version is shared between library and utilities */
-#define QUARK_VERSION "0.3"
+#define QUARK_VERSION "0.4a"
 
 /* Misc types */
 #include <stdio.h>

--- a/quark.h
+++ b/quark.h
@@ -5,7 +5,7 @@
 #define _QUARK_H_
 
 /* Version is shared between library and utilities */
-#define QUARK_VERSION "0.3a"
+#define QUARK_VERSION "0.3"
 
 /* Misc types */
 #include <stdio.h>


### PR DESCRIPTION
Merging depends on https://github.com/elastic/quark/pull/105

Release 0.3
Notable changes:
 * A new binary, quark-test(8) for testing the suite.
 * An initramfs.gz target including init and infrastructure to run quark-test
   statically built on any kernel via qemu.
 * Quark now knows about 4 namespaces (uts,ipc,mnt,net) and they're included in
   quark_process{}.
 * Fixed pgid in RHEL8 since the enum value changes, also fixed upstream
   elastic/ebpf.