### PR TITLE
Remove remaining cases of err(3). Issue #74

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -223,8 +223,8 @@ bpf_ringbuf_cb(void *vqq, void *vdata, size_t len)
 	struct raw_event		*raw;
 
 	raw = ebpf_events_to_raw(ev);
-	if (raw != NULL)
-		raw_event_insert(qq, raw);
+	if (raw != NULL && raw_event_insert(qq, raw) == -1)
+		raw_event_free(raw);
 
 	return (0);
 }

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1467,7 +1467,10 @@ kprobe_queue_populate(struct quark_queue *qq)
 			empty_rings = 0;
 			raw = perf_event_to_raw(qq, ev);
 			if (raw != NULL) {
-				raw_event_insert(qq, raw);
+				if (raw_event_insert(qq, raw) == -1) {
+					raw_event_free(raw);
+					raw = NULL;
+				}
 				npop++;
 			}
 			perf_mmap_consume(&pgl->mmap);

--- a/quark.h
+++ b/quark.h
@@ -31,7 +31,7 @@ struct quark_queue_attr;
 struct quark_queue_stats;
 struct raw_event *raw_event_alloc(int);
 void	 raw_event_free(struct raw_event *);
-void	 raw_event_insert(struct quark_queue *, struct raw_event *);
+int	 raw_event_insert(struct quark_queue *, struct raw_event *);
 void	 quark_queue_default_attr(struct quark_queue_attr *);
 int	 quark_queue_open(struct quark_queue *, struct quark_queue_attr *);
 void	 quark_queue_close(struct quark_queue *);


### PR DESCRIPTION
- Bump retries on insert from 10 to 1000 before giving up.
- Put a timeout on drain_for_pid(), I used to manually test the changing paths, and it's good to have anyway.
- Check if clock_gettime() works in quark_queue_open(), maybe it gets EPERM due to seccomp and whatnot, sanitize return of now64(), program still survives. I just don't want to check now64() errors while they're impossible.