### PR TITLE
TCP socket events for EBPF

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,3 +16,6 @@ Changes from 0.2 to 0.3
 Changes from 0.3 to 0.4
 ~~~~~~~~~~~~~~~~~~~~~~~
   o quark_queue_get_events(3) was removed in favor of quark_queue_get_event(3).
+  o quark_event{} got a new member socket,
+    QUARK_EV_SOCK_CONN_{ESTABLISHED,CLOSED}. The probes still have
+    some issues so it's mostly experimental.

--- a/bpf_prog.c
+++ b/bpf_prog.c
@@ -10,3 +10,4 @@ struct {
 } ringbuf SEC(".maps");
 
 #include "Process/Probe.bpf.c"
+#include "Network/Probe.bpf.c"

--- a/docs/quark-mon.8.html
+++ b/docs/quark-mon.8.html
@@ -25,7 +25,7 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-mon</code></td>
-    <td>[<code class="Fl">-bDekstv</code>] [<code class="Fl">-C</code>
+    <td>[<code class="Fl">-bDekSstv</code>] [<code class="Fl">-C</code>
       <var class="Ar">filename</var>] [<code class="Fl">-l</code>
       <var class="Ar">maxlength</var>] [<code class="Fl">-m</code>
       <var class="Ar">maxnodes</var>] [<code class="Fl">-P</code>
@@ -96,6 +96,8 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
       to buffer, refer to
       <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a> for
       further details.</dd>
+  <dt id="S"><a class="permalink" href="#S"><code class="Fl">-S</code></a></dt>
+  <dd>Enable socket events (experimental).</dd>
   <dt id="s"><a class="permalink" href="#s"><code class="Fl">-s</code></a></dt>
   <dd>Don't send the initial snapshot of existing processes.</dd>
   <dt id="t"><a class="permalink" href="#t"><code class="Fl">-t</code></a></dt>
@@ -184,7 +186,7 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 4, 2025</td>
+    <td class="foot-date">February 5, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl bDekstv
+.Op Fl bDekSstv
 .Op Fl C Ar filename
 .Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
@@ -68,6 +68,8 @@ Maximum lenght of the quark queue, essentially how much quark is willing to
 buffer, refer to
 .Xr quark_queue_open 3
 for further details.
+.It Fl S
+Enable socket events (experimental).
 .It Fl s
 Don't send the initial snapshot of existing processes.
 .It Fl t

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -27,10 +27,32 @@ dump_stats(struct quark_queue *qq)
 	struct quark_queue_stats	s;
 
 	quark_queue_get_stats(qq, &s);
-	printf("%8llu insertions %8llu removals %8llu aggregations "
-	    "%8llu non-aggregations %8llu lost\n",
+	putchar('\n');
+	printf(
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s",
+	    "insertions",
+	    "removals",
+	    "aggs",
+	    "non-aggs",
+	    "lost",
+	    "gc-cols"
+	);
+	putchar('\n');
+	printf(
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu",
 	    s.insertions, s.removals, s.aggregations,
-	    s.non_aggregations, s.lost);
+	    s.non_aggregations, s.lost, s.garbage_collections);
+	putchar('\n');
 }
 
 static const char *
@@ -93,7 +115,7 @@ static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s -h\n", program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-bDefkstv] "
+	fprintf(stderr, "usage: %s [-bDefkSstv] "
 	    "[-C filename ] [-l maxlength] [-m maxnodes] [-P ppid]\n",
 	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s -V\n", program_invocation_short_name);
@@ -120,7 +142,7 @@ main(int argc, char *argv[])
 	filter_ppid = 0;
 	graph_by_time = graph_by_pidtime = graph_cache = NULL;
 
-	while ((ch = getopt(argc, argv, "bC:Deghklm:P:tsvV")) != -1) {
+	while ((ch = getopt(argc, argv, "bC:Deghklm:P:tSsvV")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -181,6 +203,9 @@ main(int argc, char *argv[])
 			break;
 		case 's':
 			qa.flags |= QQ_NO_SNAPSHOT;
+			break;
+		case 'S':
+			qa.flags |= QQ_SOCK_CONN;
 			break;
 		case 't':
 			qa.flags |= QQ_THREAD_EVENTS;


### PR DESCRIPTION
This implements basic socket events for TCP, it tracks
connect(2)/accept(2)/close(2) on respective sockets as well as builds the
initial snapshot of existing sockets by parsing /proc.

Sockets are expressed in quark_socket{} and correlate with processes. Since a
socket might be in more than one process, two fields are provided:
 - pid_origin, the pid that established the connection.
 - pid_last_use, the last pid that affected it, if another process did the final
   close, pid_origin remains the same, but pid_last_use points to the last one.

We stash the lookup of quark_process_lookup(pid_origin) in the event process
pointer, which *can* be NULL, and the socket itself is stashed in the socket
member.

quark_event{} might need some adjustments in the future.

The EBPF probes are a bit subpar and they currently have two issues:
 - A connection that never sent a byte doesn't produce an exit event.
   elastic/ebpf#217
 - Exit events happen before TCP close is issued
   elastic/ebpf#216

I don't think this is good enough and will consider it experimental until both
issues are solved, first one has a fix on the way, second one likely involves
rewriting the whole probe.

Quark sockets don't produce snapshot events, because snapshot will be removed
and the user will have to use the iterator if desired.

In order to test this, pass -S to quark-mon(8).

Co-authored-by: Nicholas Berlin <56366649+nicholasberlin@users.noreply.github.com>