### PR TITLE
Zap initial snapshots. Issue #113

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,3 +19,5 @@ Changes from 0.3 to 0.4
   o quark_event{} got a new member socket,
     QUARK_EV_SOCK_CONN_{ESTABLISHED,CLOSED}. The probes still have
     some issues so it's mostly experimental.
+  o Initial snapshot of process events is not sent anymore. User is
+    expected to retrieve them via quark_process_iter(3) if desired.

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,7 +316,7 @@ $ ./krun.sh initramfs.gz kernel-images/amd64/linux-4.18.0-553.el8_10.x86_64 quar
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-<div class="Bd Bd-indent Li">
+<div class="Bd Li">
 <pre>#include &lt;err.h&gt;
 #include &lt;quark.h&gt;
 #include &lt;stdio.h&gt;
@@ -362,6 +362,8 @@ main(void)
   <dd>lookup a process in quark's internal cache</dd>
   <dt><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a></dt>
   <dd>dump event, mainly a debugging utility.</dd>
+  <dt><a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a></dt>
+  <dd>iterate over existing processes.</dd>
   <dt><a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a></dt>
   <dd>get a descriptor suitable for blocking.</dd>
   <dt><a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a></dt>
@@ -386,6 +388,7 @@ main(void)
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
     <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
     <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
     <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
@@ -409,7 +412,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">December 1, 2024</td>
+    <td class="foot-date">February 11, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -316,7 +316,7 @@ $ ./krun.sh initramfs.gz kernel-images/amd64/linux-4.18.0-553.el8_10.x86_64 quar
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-<div class="Bd Bd-indent Li">
+<div class="Bd Li">
 <pre>#include &lt;err.h&gt;
 #include &lt;quark.h&gt;
 #include &lt;stdio.h&gt;
@@ -362,6 +362,8 @@ main(void)
   <dd>lookup a process in quark's internal cache</dd>
   <dt><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a></dt>
   <dd>dump event, mainly a debugging utility.</dd>
+  <dt><a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a></dt>
+  <dd>iterate over existing processes.</dd>
   <dt><a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a></dt>
   <dd>get a descriptor suitable for blocking.</dd>
   <dt><a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a></dt>
@@ -386,6 +388,7 @@ main(void)
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
     <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
     <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
     <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
@@ -409,7 +412,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">December 1, 2024</td>
+    <td class="foot-date">February 11, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_process_iter.3.html
+++ b/docs/quark_process_iter.3.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
+  <title>QUARK_PROCESS_ITER(3)</title>
+</head>
+<body>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">QUARK_PROCESS_ITER(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">QUARK_PROCESS_ITER(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<p class="Pp"><code class="Nm">quark_process_iter_init</code>,
+    <code class="Nm">quark_process_iter_next</code> &#x2014;
+    <span class="Nd">string process iteration operations</span></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<p class="Pp"><code class="In">#include
+  &lt;<a class="In">quark.h</a>&gt;</code></p>
+<p class="Pp"><var class="Ft">void</var>
+  <br/>
+  <code class="Fn">quark_process_iter_init</code>(<var class="Fa" style="white-space: nowrap;">struct
+    quark_process_iter *</var>,
+    <var class="Fa" style="white-space: nowrap;">struct quark_queue
+  *qq</var>);</p>
+<p class="Pp"><var class="Ft">const quark_process *</var>
+  <br/>
+  <code class="Fn">quark_process_iter_next</code>(<var class="Fa" style="white-space: nowrap;">struct
+    quark_process_iter *</var>);</p>
+</section>
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+Initialize and iterate over the internal cache of processes, it can be used on
+  boot up to get a list of all learned processes, or else.
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
+<div class="Bd Li">
+<pre>
+struct quark_process_iter qi;
+struct quark_process *qp;
+
+quark_process_iter_init(&amp;qi, qq);
+while ((qp = quark_process_next(&amp;qi)) != NULL)
+	printf(&quot;process %d0, qp-&gt;pid);</pre>
+</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="RETURNS"><a class="permalink" href="#RETURNS">RETURNS</a></h1>
+<p class="Pp">The returned process points to internal memory and must not be
+    modified, the pointer is invalidated on any subsequent call of
+    <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<p class="Pp"><a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
+    <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
+    <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
+    <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>,
+    <a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a>,
+    <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
+    <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark.7.html">quark(7)</a>,
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a></p>
+</section>
+</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">February 11, 2025</td>
+    <td class="foot-os">Linux</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -59,11 +59,8 @@
   <li>Scrapes <span class="Pa">/proc</span> for a snapshot of the existing
       processes in the system. <code class="Nm">quark_queue_open</code> is smart
       enough to open the rings before the scraping, as to be make sure no
-      process is lost. These initial process events will be available on the
-      first call to
-      <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>
-      with the <var class="Vt">events</var> member set to
-      <code class="Dv">QUARK_EV_SNAPSHOT</code>.</li>
+      process is lost. These initial processes are available through
+      <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>.</li>
 </ul>
 <p class="Pp">Default queue behaviour can be tweaked with
     <var class="Fa">attr</var>. A default configuration for tweaking can be
@@ -96,8 +93,6 @@
       <dd>Include per-thread events, instead of per-process events. This option
           will be removed in the future, but it may be useful for
         debugging.</dd>
-      <dt id="QQ_NO_SNAPSHOT"><a class="permalink" href="#QQ_NO_SNAPSHOT"><code class="Dv">QQ_NO_SNAPSHOT</code></a></dt>
-      <dd>Don't send the initial snapshot of existing processes.</dd>
       <dt id="QQ_MIN_AGG"><a class="permalink" href="#QQ_MIN_AGG"><code class="Dv">QQ_MIN_AGG</code></a></dt>
       <dd>Don't aggregate
           <a class="permalink" href="#fork"><i class="Em" id="fork">fork</i></a>,
@@ -169,7 +164,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">December 1, 2024</td>
+    <td class="foot-date">February 11, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark-test.c
+++ b/quark-test.c
@@ -826,12 +826,12 @@ run_tests(int argc, char *argv[])
 
 	quark_queue_default_attr(&bpf_attr);
 	bpf_attr.flags &= ~QQ_ALL_BACKENDS;
-	bpf_attr.flags |= QQ_EBPF | QQ_NO_SNAPSHOT | QQ_ENTRY_LEADER;
+	bpf_attr.flags |= QQ_EBPF | QQ_ENTRY_LEADER;
 	bpf_attr.hold_time = 100;
 
 	quark_queue_default_attr(&kprobe_attr);
 	kprobe_attr.flags &= ~QQ_ALL_BACKENDS;
-	kprobe_attr.flags |= QQ_KPROBE | QQ_NO_SNAPSHOT | QQ_ENTRY_LEADER;
+	kprobe_attr.flags |= QQ_KPROBE | QQ_ENTRY_LEADER;
 	kprobe_attr.hold_time = 100;
 
 	failed = 0;

--- a/quark.7
+++ b/quark.7
@@ -349,7 +349,7 @@ returns NULL and the user is expected to call
 .Xr quark_queue_block 3
 or equivalent.
 .Sh EXAMPLES
-.Bd -literal -offset indent
+.Bd -literal
 #include <err.h>
 #include <quark.h>
 #include <stdio.h>
@@ -393,6 +393,8 @@ get event, main library call.
 lookup a process in quark's internal cache
 .It Xr quark_event_dump 3
 dump event, mainly a debugging utility.
+.It Xr quark_process_iter 3
+iterate over existing processes.
 .It Xr quark_queue_get_epollfd 3
 get a descriptor suitable for blocking.
 .It Xr quark_queue_block 3
@@ -414,6 +416,7 @@ is the easiest way to get started with
 describes initialization options that can be useful.
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,
+.Xr quark_process_iter 3 ,
 .Xr quark_process_lookup 3 ,
 .Xr quark_queue_block 3 ,
 .Xr quark_queue_close 3 ,

--- a/quark.h
+++ b/quark.h
@@ -271,9 +271,8 @@ struct quark_event {
 #define QUARK_EV_EXEC			(1 << 1)
 #define QUARK_EV_EXIT			(1 << 2)
 #define QUARK_EV_SETPROCTITLE		(1 << 3)
-#define QUARK_EV_SNAPSHOT		(1 << 4)
-#define QUARK_EV_SOCK_CONN_ESTABLISHED	(1 << 5)
-#define QUARK_EV_SOCK_CONN_CLOSED	(1 << 6)
+#define QUARK_EV_SOCK_CONN_ESTABLISHED	(1 << 4)
+#define QUARK_EV_SOCK_CONN_CLOSED	(1 << 5)
 	u64				 events;
 	const struct quark_process	*process;
 	const struct quark_socket	*socket;
@@ -433,10 +432,9 @@ struct quark_queue_attr {
 #define QQ_THREAD_EVENTS	(1 << 0)
 #define QQ_KPROBE		(1 << 1)
 #define QQ_EBPF			(1 << 2)
-#define QQ_NO_SNAPSHOT		(1 << 3)
-#define QQ_MIN_AGG		(1 << 4)
-#define QQ_ENTRY_LEADER		(1 << 5)
-#define QQ_SOCK_CONN		(1 << 6)
+#define QQ_MIN_AGG		(1 << 3)
+#define QQ_ENTRY_LEADER		(1 << 4)
+#define QQ_SOCK_CONN		(1 << 5)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
 	int	flags;
 	int	max_length;
@@ -462,8 +460,6 @@ struct quark_queue {
 	int				 max_length;
 	u64				 cache_grace_time;	/* in ns */
 	int				 hold_time;		/* in ms */
-	/* Next pid to be sent out of a snapshot */
-	int				 snap_pid;
 	int				 epollfd;
 	/* Backend related state */
 	struct quark_queue_ops		*queue_ops;

--- a/quark_process_iter.3
+++ b/quark_process_iter.3
@@ -1,0 +1,42 @@
+.Dd $Mdocdate$
+.Dt QUARK_PROCESS_ITER 3
+.Os
+.Sh NAME
+.Nm quark_process_iter_init ,
+.Nm quark_process_iter_next
+.Nd string process iteration operations
+.Sh SYNOPSIS
+.In quark.h
+.Ft void
+.Fn quark_process_iter_init "struct quark_process_iter *" "struct quark_queue *qq"
+.Ft const quark_process *
+.Fn quark_process_iter_next "struct quark_process_iter *"
+.Sh DESCRIPTION
+Initialize and iterate over the internal cache of processes, it can be used on
+boot up to get a list of all learned processes, or else.
+.Sh EXAMPLES
+.Bd -literal
+
+struct quark_process_iter qi;
+struct quark_process *qp;
+
+quark_process_iter_init(&qi, qq);
+while ((qp = quark_process_next(&qi)) != NULL)
+	printf("process %d\n", qp->pid);
+.Ed
+.Sh RETURNS
+The returned process points to internal memory and must not be modified, the
+pointer is invalidated on any subsequent call of
+.Xr quark_queue_get_event 3 .
+.Sh SEE ALSO
+.Xr quark_process_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
+.Xr quark_queue_get_epollfd 3 ,
+.Xr quark_queue_get_event 3 ,
+.Xr quark_queue_get_stats 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark 7 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -55,12 +55,8 @@ for a snapshot of the existing processes in the system.
 .Nm
 is smart enough to open the rings before the scraping, as to be make sure no
 process is lost.
-These initial process events will be available on the first call to
-.Xr quark_queue_get_event 3
-with the
-.Vt events
-member set to
-.Dv QUARK_EV_SNAPSHOT .
+These initial processes are available through
+.Xr quark_process_iter 3 .
 .El
 .Pp
 Default queue behaviour can be tweaked with
@@ -96,8 +92,6 @@ Shorthand for (QQ_EBPF | QQ_KPROBE).
 .It Dv QQ_THREAD_EVENTS
 Include per-thread events, instead of per-process events.
 This option will be removed in the future, but it may be useful for debugging.
-.It Dv QQ_NO_SNAPSHOT
-Don't send the initial snapshot of existing processes.
 .It Dv QQ_MIN_AGG
 Don't aggregate
 .Em fork ,


### PR DESCRIPTION
Zap initial snapshots. Issue #113
This removes the initial snapshot of processes that it was sent on queue bootup.
The user is now expected to use quark_queue_iter(3) to retrieve them.

This simplified the code quite a bit, and as we add more kind of events,
deciding what to send initially becomes silly. We provide decent iterators and
users rejoice.

Documentation follows on the next commit.