### PR TITLE
Catch fd leaks in all tests

### DIFF
--- a/quark-test.c
+++ b/quark-test.c
@@ -239,7 +239,7 @@ dump_open_fd(FILE *f)
 	}
 
 	closedir(dirp);		/* closes dfd */
-	fflush(stderr);
+	fflush(f);
 }
 
 struct test {

--- a/quark-test.c
+++ b/quark-test.c
@@ -905,7 +905,6 @@ const struct test all_tests[] = {
 	T(t_cache_grace),
 	T(t_min_agg),
 	T(t_stats),
-	T(t_nada),
 	{ NULL,	NULL, 0 }
 };
 #undef S


### PR DESCRIPTION
This adds a fd leak detector for the test framework. We count the number of opened file descriptors before and after each test, if the number differs, we dump all file descriptors as an error.

Output example:
```
t_probe @ ebpf................failed
FDLEAK DETECTED! 4 opened descriptors, expected 3
0 -> /dev/pts/1
1 -> /dev/pts/1
2 -> pipe:[667586]
3 -> /dev/pts/1
```

Issue #141