### PR TITLE
Bypass mode for ebpf, first steps

### DIFF
--- a/docs/quark-mon.8.html
+++ b/docs/quark-mon.8.html
@@ -25,7 +25,7 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-mon</code></td>
-    <td>[<code class="Fl">-bDekSstv</code>] [<code class="Fl">-C</code>
+    <td>[<code class="Fl">-BbDekNSstv</code>] [<code class="Fl">-C</code>
       <var class="Ar">filename</var>] [<code class="Fl">-l</code>
       <var class="Ar">maxlength</var>] [<code class="Fl">-m</code>
       <var class="Ar">maxnodes</var>] [<code class="Fl">-P</code>
@@ -57,6 +57,11 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
     until a SIGINT is received.</p>
 <p class="Pp">The options are as follows:</p>
 <dl class="Bl-tag">
+  <dt id="B"><a class="permalink" href="#B"><code class="Fl">-B</code></a></dt>
+  <dd>Test bypass mode, where EBPF events are passed up directly without any
+      processing. A
+      <a class="permalink" href="#*"><i class="Em" id="*">*</i></a> is printed
+      for each event.</dd>
   <dt id="b"><a class="permalink" href="#b"><code class="Fl">-b</code></a></dt>
   <dd>Attempt EBPF as the backend.</dd>
   <dt id="C"><a class="permalink" href="#C"><code class="Fl">-C</code></a>
@@ -96,6 +101,19 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
       to buffer, refer to
       <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a> for
       further details.</dd>
+  <dt id="m"><a class="permalink" href="#m"><code class="Fl">-m</code></a>
+    <var class="Ar">maxnodes</var></dt>
+  <dd>Don't really process events, just collect <var class="Ar">maxnodes</var>
+      in the sorting tree and output <span class="Pa">quark_by_time.dot</span>
+      and <span class="Pa">quark_by_pidtime.dot</span>. The first is events
+      sorted by time, and the second by pid plus time. Exits after
+      <var class="Ar">maxnodes</var> has been reached. This is used purely for
+      internal debugging.</dd>
+  <dt id="N"><a class="permalink" href="#N"><code class="Fl">-N</code></a></dt>
+  <dd>Enable DNS events (experimental).</dd>
+  <dt id="P"><a class="permalink" href="#P"><code class="Fl">-P</code></a>
+    <var class="Ar">ppid</var></dt>
+  <dd>Display only events where parent pid is <var class="Ar">ppid</var>.</dd>
   <dt id="S"><a class="permalink" href="#S"><code class="Fl">-S</code></a></dt>
   <dd>Enable socket events (experimental).</dd>
   <dt id="s"><a class="permalink" href="#s"><code class="Fl">-s</code></a></dt>
@@ -106,17 +124,6 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
   <dt id="v"><a class="permalink" href="#v"><code class="Fl">-v</code></a></dt>
   <dd>Increase verbosity, can be specified multiple times for more
     verbosity.</dd>
-  <dt id="m"><a class="permalink" href="#m"><code class="Fl">-m</code></a>
-    <var class="Ar">maxnodes</var></dt>
-  <dd>Don't really process events, just collect <var class="Ar">maxnodes</var>
-      in the sorting tree and output <span class="Pa">quark_by_time.dot</span>
-      and <span class="Pa">quark_by_pidtime.dot</span>. The first is events
-      sorted by time, and the second by pid plus time. Exits after
-      <var class="Ar">maxnodes</var> has been reached. This is used purely for
-      internal debugging.</dd>
-  <dt id="P"><a class="permalink" href="#P"><code class="Fl">-P</code></a>
-    <var class="Ar">ppid</var></dt>
-  <dd>Display only events where parent pid is <var class="Ar">ppid</var>.</dd>
   <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a></dt>
   <dd>Print version and exit.</dd>
 </dl>
@@ -186,7 +193,7 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 5, 2025</td>
+    <td class="foot-date">April 4, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl bDekNSstv
+.Op Fl BbDekNSstv
 .Op Fl C Ar filename
 .Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
@@ -29,6 +29,12 @@ runs until a SIGINT is received.
 .Pp
 The options are as follows:
 .Bl -tag -width Dtb
+.It Fl B
+Test bypass mode, where EBPF events are passed up directly without any
+processing.
+A
+.Em *
+is printed for each event.
 .It Fl b
 Attempt EBPF as the backend.
 .It Fl C Ar filename

--- a/quark.h
+++ b/quark.h
@@ -304,10 +304,12 @@ struct quark_event {
 #define QUARK_EV_SOCK_CONN_ESTABLISHED	(1 << 4)
 #define QUARK_EV_SOCK_CONN_CLOSED	(1 << 5)
 #define QUARK_EV_PACKET			(1 << 6)
+#define QUARK_EV_BYPASS			(1 << 7)
 	u64				 events;
 	const struct quark_process	*process;
 	const struct quark_socket	*socket;
 	struct quark_packet		*packet;
+	const void			*bypass;
 };
 
 /*
@@ -468,6 +470,7 @@ struct quark_queue_attr {
 #define QQ_ENTRY_LEADER		(1 << 4)
 #define QQ_SOCK_CONN		(1 << 5)
 #define QQ_DNS			(1 << 6)
+#define QQ_BYPASS		(1 << 7)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
 	int	flags;
 	int	max_length;


### PR DESCRIPTION
This implements a bypass mode that only works on ebpf.
In this mode, a quark_event is always QUARK_EV_BYPASS and the only member filled
is `bypass`.

The purpose of this is to make it feasible to use quark as an ebpf loader only,
letting the user tap directly into the ebpf ring.

There's no pre-processing, no caching, no allocations and so on. Bypass is
really just a direct path to access bpf's ringbuffer.
