### PR TITLE
Relocations

### DIFF
--- a/btf.c
+++ b/btf.c
@@ -169,7 +169,7 @@ btf_root_offset2(struct btf *btf, const char *dotname)
 	}
 
 	if ((off % 8) != 0)
-		err(1, "bit offset not multiple of 8");
+		return (-1);
 
 	return (off / 8);
 }
@@ -231,6 +231,8 @@ btf_enum_value(struct btf *btf, const char *dotname, ssize_t *uv)
 
 	return (-1);
 }
+
+
 
 static struct quark_btf *
 quark_btf_new(const char *new_name)

--- a/btf.c
+++ b/btf.c
@@ -232,7 +232,26 @@ btf_enum_value(struct btf *btf, const char *dotname, ssize_t *uv)
 	return (-1);
 }
 
+s32
+btf_number_of_params(struct btf *btf, const char *func)
+{
+	s32 off;
+	const struct btf_type *t;
 
+	off = btf__find_by_name_kind(btf, func, BTF_KIND_FUNC);
+	if (off < 0)
+		return (-1);
+	t = btf__type_by_id(btf, off);
+	if (t == NULL)
+		return (-1);
+	t = btf__type_by_id(btf, t->type);
+	if (t == NULL)
+		return (-1);
+	if (!btf_is_func_proto(t))
+		return (-1);
+
+	return (btf_vlen(t));
+}
 
 static struct quark_btf *
 quark_btf_new(const char *new_name)

--- a/btf.c
+++ b/btf.c
@@ -110,9 +110,9 @@ btf_offsetof(struct btf *btf, struct btf_type const *t, const char *mname)
 	const struct btf_member	*m;
 	const char		*mname1;
 
-	if (BTF_INFO_KIND(t->info) != BTF_KIND_STRUCT)
+	if (btf_kind(t) != BTF_KIND_STRUCT)
 		return (errno = EINVAL, NULL);
-	vlen = BTF_INFO_VLEN(t->info);
+	vlen = btf_vlen(t);
 	m = (const struct btf_member *)(t + 1);
 	if (!strcmp(mname, "(anon)"))
 		mname = "";
@@ -156,7 +156,7 @@ btf_root_offset2(struct btf *btf, const char *dotname)
 		m = btf_offsetof(btf, parent, child_name);
 		if (m == NULL)
 			return (-1);
-		if (BTF_INFO_KFLAG(parent->info)) {
+		if (btf_kflag(parent)) {
 			off += BTF_MEMBER_BIT_OFFSET(m->offset);
 			/* no bit_size things for now */
 			if (BTF_MEMBER_BITFIELD_SIZE(m->offset) != 0)

--- a/quark.h
+++ b/quark.h
@@ -74,6 +74,9 @@ struct quark_btf	*quark_btf_open_hub(const char *);
 void			 quark_btf_close(struct quark_btf *);
 ssize_t			 quark_btf_offset(struct quark_btf *, const char *);
 
+struct btf;
+s32		 	 btf_number_of_params(struct btf *, const char *);
+
 /* bpf_queue.c */
 int	bpf_queue_open(struct quark_queue *);
 


### PR DESCRIPTION
Relocate ret_inet_csk_accept.
Adds the basic infrastructure needed for file probes where we need to do some
relocations.

The relocation for inet_csk_accept was already missing.