### PR TITLE
Fedora tests (aka make the ci great again^W)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,50 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
+  - label: "quark-test on fedora 28 (no bpf)"
+    key: test_fedora_28
+    command: "./.buildkite/runtest_fedora.sh 28 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 29 (no bpf)"
+    key: test_fedora_29
+    command: "./.buildkite/runtest_fedora.sh 29 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 30 (no bpf)"
+    key: test_fedora_30
+    command: "./.buildkite/runtest_fedora.sh 30 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 31 (no bpf)"
+    key: test_fedora_31
+    command: "./.buildkite/runtest_fedora.sh 31 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
   - label: "quark-test on fedora 32"
     key: test_fedora_32
     command: "./.buildkite/runtest_fedora.sh 32"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -191,3 +191,14 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 42(beta)"
+    key: test_fedora_42
+    command: "./.buildkite/runtest_fedora.sh 42"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,8 @@ steps:
   - label: "build amd64 in docker"
     key: make_docker
     command: "make docker"
+    artifact_paths:
+      - "initramfs.gz"
     agents:
       image: family/core-ubuntu-2204
       provider: gcp
@@ -34,3 +36,114 @@ steps:
       image: family/core-ubuntu-2204
       provider: gcp
       machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 32"
+    key: test_fedora_32
+    command: "./.buildkite/runtest_fedora.sh 32"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 33"
+    key: test_fedora_33
+    command: "./.buildkite/runtest_fedora.sh 33"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 34"
+    key: test_fedora_34
+    command: "./.buildkite/runtest_fedora.sh 34"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 35"
+    key: test_fedora_35
+    command: "./.buildkite/runtest_fedora.sh 35"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 36"
+    key: test_fedora_36
+    command: "./.buildkite/runtest_fedora.sh 36"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 37"
+    key: test_fedora_37
+    command: "./.buildkite/runtest_fedora.sh 37"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 38"
+    key: test_fedora_38
+    command: "./.buildkite/runtest_fedora.sh 38"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 39"
+    key: test_fedora_39
+    command: "./.buildkite/runtest_fedora.sh 39"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 40"
+    key: test_fedora_40
+    command: "./.buildkite/runtest_fedora.sh 40"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on fedora 41"
+    key: test_fedora_41
+    command: "./.buildkite/runtest_fedora.sh 41"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true

--- a/.buildkite/runtest_fedora.sh
+++ b/.buildkite/runtest_fedora.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+FEDORAVER="$1"
+
+function download {
+	buildkite-agent artifact download "$1" "$2"
+}
+
+if [ -z "${BUILDKITE}" ]; then
+	echo "This script doesn't appear to be running in buildkite" 1>&2
+	echo "refusing to continue" 1>&2
+	exit 1
+fi
+
+download initramfs.gz .
+
+echo updating packages...
+sudo apt-get -qq update -y
+echo installing packages...
+sudo apt-get -qq install -y --no-install-recommends	\
+     cpio						\
+     cpu-checker					\
+     lynx 						\
+     qemu-system-x86					\
+     qemu-kvm						\
+     rpm2cpio						\
+     > /dev/null
+
+# Make sure we can run things on KVM
+sudo kvm-ok
+
+# Run Forrest Run
+sudo ./krun-fedora.sh initramfs.gz $FEDORAVER quark-test
+
+exit $?

--- a/.buildkite/runtest_fedora.sh
+++ b/.buildkite/runtest_fedora.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 FEDORAVER="$1"
+shift
 
 function download {
 	buildkite-agent artifact download "$1" "$2"
@@ -32,6 +33,6 @@ sudo apt-get -qq install -y --no-install-recommends	\
 sudo kvm-ok
 
 # Run Forrest Run
-sudo ./krun-fedora.sh initramfs.gz $FEDORAVER quark-test
+sudo ./krun-fedora.sh initramfs.gz $FEDORAVER quark-test $@
 
 exit $?

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ DOCKER_RUN_ARGS=$(QDOCKER)				\
 
 docker: docker-image clean-all
 	$(call msg,DOCKER-RUN,Dockerfile)
-	$(Q)$(DOCKER) run $(DOCKER_RUN_ARGS) /bin/bash -c "make -C $(PWD)"
+	$(Q)$(DOCKER) run $(DOCKER_RUN_ARGS) /bin/bash -c "make -C $(PWD) all initramfs.gz"
 
 docker-cross-arm64: clean-all docker-image manpages.h
 	$(call msg,DOCKER-RUN,Dockerfile)

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -348,9 +348,6 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 
 	libbpf_set_print(libbpf_print_fn);
 
-	if ((qq->flags & QQ_EBPF) == 0)
-		return (errno = ENOTSUP, -1);
-
 	if ((bqq = calloc(1, sizeof(*bqq))) == NULL)
 		return (-1);
 
@@ -510,6 +507,9 @@ fail:
 int
 bpf_queue_open(struct quark_queue *qq)
 {
+	if ((qq->flags & QQ_EBPF) == 0)
+		return (errno = ENOTSUP, -1);
+
 	if (bpf_queue_open1(qq, 1) == -1) {
 		qwarn("bpf_queue_open failed with fentry, trying kprobe");
 		return bpf_queue_open1(qq, 0);

--- a/init.c
+++ b/init.c
@@ -65,7 +65,7 @@ net_up(void)
 		err(1, "socket");
 
 	bzero(&ifr, sizeof(ifr));
-	strlcpy(ifr.ifr_name, "lo", sizeof(ifr.ifr_name));
+	strncpy(ifr.ifr_name, "lo", sizeof(ifr.ifr_name));
 	if (ioctl(fd, SIOCGIFFLAGS, &ifr) == -1)
 		err(1, "SIOCGIFFLAGS");
 	ifr.ifr_flags |= IFF_UP;

--- a/krun-fedora.sh
+++ b/krun-fedora.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT=${0##*/}
+
+function usage
+{
+	echo "usage: $SCRIPT initramfs.gz FEDORAVERSION command" 1>&2
+	exit 1
+}
+
+if [ $# -lt 3 ]; then
+	usage
+fi
+
+INITRAMFS="$1"
+FEDORAVER="$2"
+shift 2
+
+case $FEDORAVER in
+2?|3?)	URL="https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
+4?)	URL="http://ftp.fau.de/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
+*)	echo bad version "$FEDORAVER" 1>&2
+esac
+
+TMPDIR=$(mktemp -d "/tmp/$SCRIPT.XXXXXXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+RPMURL=$(lynx -dump -listonly "$URL"|grep kernel-core)
+RPMURL=${RPMURL##* }
+RPM=$(basename "$RPMURL")
+VMLINUZ=${RPM##kernel-core-}
+VMLINUZ=${VMLINUZ%%.rpm}
+VMLINUZ=$TMPDIR/lib/modules/$VMLINUZ/vmlinuz
+
+# echo URL $URL
+# echo RPMURL $RPMURL
+# echo RPM $RPM
+# echo VMLINUZ $VMLINUZ
+
+cd "$TMPDIR"
+curl -s "$RPMURL" | rpm2cpio - | cpio -idm
+cd -
+
+./krun.sh "$INITRAMFS" "$VMLINUZ" "$@"

--- a/krun-fedora.sh
+++ b/krun-fedora.sh
@@ -19,9 +19,10 @@ FEDORAVER="$2"
 shift 2
 
 case $FEDORAVER in
-2?|3?)	URL="https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
-4?)	URL="http://ftp.fau.de/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
-*)	echo bad version "$FEDORAVER" 1>&2
+2?|3?)		URL="https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
+42|rawhide)	URL="http://ftp.fau.de/fedora/linux/development/$FEDORAVER/Everything/x86_64/os/Packages/k";;
+4?)		URL="http://ftp.fau.de/fedora/linux/updates/$FEDORAVER/Everything/x86_64/Packages/k";;
+*)		echo bad version "$FEDORAVER" 1>&2
 esac
 
 TMPDIR=$(mktemp -d "/tmp/$SCRIPT.XXXXXXXXXX")

--- a/krun.sh
+++ b/krun.sh
@@ -21,13 +21,17 @@ cmdline="$*"
 function qemu {
 	case "$(file -b "$kernel" | awk '{print $3}')" in
 	x86)
+		kvm=""
+		if grep -qw vmx /proc/cpuinfo && [ -e /dev/kvm ]; then
+			kvm="-enable-kvm"
+		fi
 		qemu-system-x86_64						\
 			-m 256M							\
-			-enable-kvm						\
 			-initrd "$initramfs"					\
 			-kernel "$kernel"					\
 			-nographic						\
-			--append "console=ttyS0 quiet TERM=dumb $cmdline"
+			--append "console=ttyS0 quiet TERM=dumb $cmdline"	\
+			$kvm
 		;;
 	ARM64)
 		qemu-system-aarch64						\


### PR DESCRIPTION
This improves the CI by running quark-test on fedora versions 28-41.

krun-fedora.sh downloads the latest kernel rpm of the specified version, unpacks
and runs krun.sh on it. When Fedora updates its rpms, we end up getting the
updated version.

This also enables nested virtualization on the CI so we can run things on qemu
super fast, <1min as opposed to 5-10min in the worst case, the most important
bit is that it fixes some flaky tests that would time out.

Prompted by a question from @andrewkroh

Many thanks to @mjwolf for pointing me to the allowed GCP options in buildkite.