### PR TITLE
Get rid of cdefs.h

### DIFF
--- a/elftoolchain/libelf/elf.c
+++ b/elftoolchain/libelf/elf.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_begin.c
+++ b/elftoolchain/libelf/elf_begin.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_cntl.c
+++ b/elftoolchain/libelf/elf_cntl.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_data.c
+++ b/elftoolchain/libelf/elf_data.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <errno.h>

--- a/elftoolchain/libelf/elf_end.c
+++ b/elftoolchain/libelf/elf_end.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/elf_errmsg.c
+++ b/elftoolchain/libelf/elf_errmsg.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 #include <stdio.h>

--- a/elftoolchain/libelf/elf_errno.c
+++ b/elftoolchain/libelf/elf_errno.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_fill.c
+++ b/elftoolchain/libelf/elf_fill.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_flag.c
+++ b/elftoolchain/libelf/elf_flag.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_getarhdr.c
+++ b/elftoolchain/libelf/elf_getarhdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_getarsym.c
+++ b/elftoolchain/libelf/elf_getarsym.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_getbase.c
+++ b/elftoolchain/libelf/elf_getbase.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_getident.c
+++ b/elftoolchain/libelf/elf_getident.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <assert.h>

--- a/elftoolchain/libelf/elf_getversion.c
+++ b/elftoolchain/libelf/elf_getversion.c
@@ -24,7 +24,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_hash.c
+++ b/elftoolchain/libelf/elf_hash.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_kind.c
+++ b/elftoolchain/libelf/elf_kind.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_memory.c
+++ b/elftoolchain/libelf/elf_memory.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_next.c
+++ b/elftoolchain/libelf/elf_next.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <assert.h>

--- a/elftoolchain/libelf/elf_open.c
+++ b/elftoolchain/libelf/elf_open.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_phnum.c
+++ b/elftoolchain/libelf/elf_phnum.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/elf_rand.c
+++ b/elftoolchain/libelf/elf_rand.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/elf_rawfile.c
+++ b/elftoolchain/libelf/elf_rawfile.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/elf_scn.c
+++ b/elftoolchain/libelf/elf_scn.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 #include <sys/queue.h>
 
 #include <assert.h>

--- a/elftoolchain/libelf/elf_shnum.c
+++ b/elftoolchain/libelf/elf_shnum.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/elf_shstrndx.c
+++ b/elftoolchain/libelf/elf_shstrndx.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/elf_strptr.c
+++ b/elftoolchain/libelf/elf_strptr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 #include <sys/param.h>
 
 #include <assert.h>

--- a/elftoolchain/libelf/elf_update.c
+++ b/elftoolchain/libelf/elf_update.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 #include <sys/param.h>
 #include <sys/stat.h>
 

--- a/elftoolchain/libelf/elf_version.c
+++ b/elftoolchain/libelf/elf_version.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/gelf_cap.c
+++ b/elftoolchain/libelf/gelf_cap.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_checksum.c
+++ b/elftoolchain/libelf/gelf_checksum.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/gelf_dyn.c
+++ b/elftoolchain/libelf/gelf_dyn.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_ehdr.c
+++ b/elftoolchain/libelf/gelf_ehdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_fsize.c
+++ b/elftoolchain/libelf/gelf_fsize.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/gelf_getclass.c
+++ b/elftoolchain/libelf/gelf_getclass.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 

--- a/elftoolchain/libelf/gelf_move.c
+++ b/elftoolchain/libelf/gelf_move.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_phdr.c
+++ b/elftoolchain/libelf/gelf_phdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/gelf_rel.c
+++ b/elftoolchain/libelf/gelf_rel.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_rela.c
+++ b/elftoolchain/libelf/gelf_rela.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_shdr.c
+++ b/elftoolchain/libelf/gelf_shdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_sym.c
+++ b/elftoolchain/libelf/gelf_sym.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_syminfo.c
+++ b/elftoolchain/libelf/gelf_syminfo.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_symshndx.c
+++ b/elftoolchain/libelf/gelf_symshndx.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/gelf_xlate.c
+++ b/elftoolchain/libelf/gelf_xlate.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_allocate.c
+++ b/elftoolchain/libelf/libelf_allocate.c
@@ -28,7 +28,9 @@
  * Internal APIs
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <errno.h>

--- a/elftoolchain/libelf/libelf_ar.c
+++ b/elftoolchain/libelf/libelf_ar.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <ctype.h>

--- a/elftoolchain/libelf/libelf_ar_util.c
+++ b/elftoolchain/libelf/libelf_ar_util.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_checksum.c
+++ b/elftoolchain/libelf/libelf_checksum.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 

--- a/elftoolchain/libelf/libelf_convert.m4
+++ b/elftoolchain/libelf/libelf_convert.m4
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_data.c
+++ b/elftoolchain/libelf/libelf_data.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/libelf_ehdr.c
+++ b/elftoolchain/libelf/libelf_ehdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/libelf_elfmachine.c
+++ b/elftoolchain/libelf/libelf_elfmachine.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_extended.c
+++ b/elftoolchain/libelf/libelf_extended.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_fsize.m4
+++ b/elftoolchain/libelf/libelf_fsize.m4
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <libelf.h>
 

--- a/elftoolchain/libelf/libelf_memory.c
+++ b/elftoolchain/libelf/libelf_memory.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <ar.h>
 #include <assert.h>

--- a/elftoolchain/libelf/libelf_msize.m4
+++ b/elftoolchain/libelf/libelf_msize.m4
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_open.c
+++ b/elftoolchain/libelf/libelf_open.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/elftoolchain/libelf/libelf_phdr.c
+++ b/elftoolchain/libelf/libelf_phdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <gelf.h>

--- a/elftoolchain/libelf/libelf_shdr.c
+++ b/elftoolchain/libelf/libelf_shdr.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <gelf.h>
 #include <libelf.h>

--- a/elftoolchain/libelf/libelf_xlate.c
+++ b/elftoolchain/libelf/libelf_xlate.c
@@ -24,7 +24,9 @@
  * SUCH DAMAGE.
  */
 
+#ifndef QUARK
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <libelf.h>

--- a/freebsd_queue.h
+++ b/freebsd_queue.h
@@ -34,8 +34,6 @@
 #ifndef _SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
-#include <sys/cdefs.h>
-
 /*
  * This file defines four types of data structures: singly-linked lists,
  * singly-linked tail queues, lists and tail queues.

--- a/freebsd_tree.h
+++ b/freebsd_tree.h
@@ -31,8 +31,6 @@
 #ifndef	_SYS_TREE_H_
 #define	_SYS_TREE_H_
 
-#include <sys/cdefs.h>
-
 /*
  * This file defines data structures for different types of trees:
  * splay trees and rank-balanced trees.

--- a/quark-test.c
+++ b/quark-test.c
@@ -5,7 +5,6 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
 #include <sys/wait.h>
 
 #include <netinet/in.h>


### PR DESCRIPTION
cdefs.h is old school and marked as deprecated in musl. It seems nothing really needed, so just zap it.