### PR TITLE
Add file probes to bypass mode

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -244,9 +244,9 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
-  - label: "quark-test on rhel 8.5"
+  - label: "quark-test on rhel 8.5 (no file)"
     key: test_rhel_8_5
-    command: "./.buildkite/runtest_distro.sh rhel 8.5"
+    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file"
     depends_on:
       - make_docker
     agents:
@@ -255,9 +255,9 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
-  - label: "quark-test on rhel 8.6"
+  - label: "quark-test on rhel 8.6 (no file)"
     key: test_rhel_8_6
-    command: "./.buildkite/runtest_distro.sh rhel 8.6"
+    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file"
     depends_on:
       - make_docker
     agents:
@@ -266,9 +266,9 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
-  - label: "quark-test on rhel 8.7"
+  - label: "quark-test on rhel 8.7 (no file)"
     key: test_rhel_8_7
-    command: "./.buildkite/runtest_distro.sh rhel 8.7"
+    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file"
     depends_on:
       - make_docker
     agents:

--- a/bpf_prog.c
+++ b/bpf_prog.c
@@ -11,3 +11,4 @@ struct {
 
 #include "Process/Probe.bpf.c"
 #include "Network/Probe.bpf.c"
+#include "File/Probe.bpf.c"

--- a/docs/quark-test.8.html
+++ b/docs/quark-test.8.html
@@ -25,7 +25,8 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-test</code></td>
-    <td>[<code class="Fl">-bkv</code>] [<var class="Ar">tests ...</var>]</td>
+    <td>[<code class="Fl">-bkv</code>] [<code class="Fl">-x</code>
+      <var class="Ar">test</var>] [<var class="Ar">tests ...</var>]</td>
   </tr>
 </table>
 <br/>
@@ -89,6 +90,10 @@ The <code class="Nm">quark-test</code> program runs tests for
       can be issued multiple times.</dd>
   <dt id="V"><a class="permalink" href="#V"><code class="Fl">-V</code></a></dt>
   <dd>Print version and exit.</dd>
+  <dt id="x"><a class="permalink" href="#x"><code class="Fl">-x</code></a>
+    <var class="Ar">test</var></dt>
+  <dd>Exclude <var class="Ar">test</var> from the run, can be specified multiple
+      times.</dd>
 </dl>
 <section class="Sh">
 <h1 class="Sh" id="EXIT_STATUS"><a class="permalink" href="#EXIT_STATUS">EXIT
@@ -129,7 +134,7 @@ failed tests 0</pre>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">December 1, 2024</td>
+    <td class="foot-date">May 4, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/elastic-ebpf/GPL/Events/File/File.h
+++ b/elastic-ebpf/GPL/Events/File/File.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+
+/*
+ * Copyright (C) 2021 Elasticsearch BV
+ *
+ * This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses.
+ * You may choose either one of them if you use this software.
+ */
+
+#ifndef EBPF_EVENTPROBE_FILE_H
+#define EBPF_EVENTPROBE_FILE_H
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+
+#include "EbpfEventProto.h"
+#include "Helpers.h"
+
+/* struct inode */
+DECL_FIELD_OFFSET(inode, __i_atime);
+DECL_FIELD_OFFSET(inode, __i_mtime);
+DECL_FIELD_OFFSET(inode, __i_ctime);
+
+#define PATH_MAX 4096
+
+// include/uapi/linux/stat.h
+#define S_IFMT 00170000
+#define S_IFSOCK 0140000
+#define S_IFLNK 0120000
+#define S_IFREG 0100000
+#define S_IFBLK 0060000
+#define S_IFDIR 0040000
+#define S_IFCHR 0020000
+#define S_IFIFO 0010000
+#define S_ISUID 0004000
+#define S_ISGID 0002000
+#define S_ISVTX 0001000
+
+#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
+#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
+
+#define NANOSECONDS_IN_SECOND 1000000000
+
+static struct path *path_from_file(struct file *f)
+{
+    size_t off = bpf_core_field_offset(struct file, f_path);
+    return (struct path *)((char *)f + off);
+}
+
+static void ebpf_file_info__fill(struct ebpf_file_info *finfo, struct dentry *de)
+{
+    struct timespec64 ts;
+
+    struct inode *ino = BPF_CORE_READ(de, d_inode);
+
+    finfo->inode = BPF_CORE_READ(ino, i_ino);
+    finfo->mode  = BPF_CORE_READ(ino, i_mode);
+    finfo->size  = BPF_CORE_READ(ino, i_size);
+    finfo->uid   = BPF_CORE_READ(ino, i_uid.val);
+    finfo->gid   = BPF_CORE_READ(ino, i_gid.val);
+
+    if (FIELD_OFFSET(inode, __i_atime)) {
+        bpf_core_read(&ts, sizeof(ts), (char *)ino + FIELD_OFFSET(inode, __i_atime));
+        finfo->atime = ts.tv_sec * NANOSECONDS_IN_SECOND + ts.tv_nsec;
+    } else if (bpf_core_field_exists(ino->i_atime)) {
+        finfo->atime = BPF_CORE_READ(ino, i_atime.tv_sec) * NANOSECONDS_IN_SECOND +
+                       BPF_CORE_READ(ino, i_atime.tv_nsec);
+    }
+
+    if (FIELD_OFFSET(inode, __i_mtime)) {
+        bpf_core_read(&ts, sizeof(ts), (char *)ino + FIELD_OFFSET(inode, __i_mtime));
+        finfo->mtime = ts.tv_sec * NANOSECONDS_IN_SECOND + ts.tv_nsec;
+    } else if (bpf_core_field_exists(ino->i_mtime)) {
+        finfo->mtime = BPF_CORE_READ(ino, i_mtime.tv_sec) * NANOSECONDS_IN_SECOND +
+                       BPF_CORE_READ(ino, i_mtime.tv_nsec);
+    }
+
+    if (FIELD_OFFSET(inode, __i_ctime)) {
+        bpf_core_read(&ts, sizeof(ts), (char *)ino + FIELD_OFFSET(inode, __i_ctime));
+        finfo->ctime = ts.tv_sec * NANOSECONDS_IN_SECOND + ts.tv_nsec;
+    } else if (bpf_core_field_exists(ino->i_ctime)) {
+        finfo->ctime = BPF_CORE_READ(ino, i_ctime.tv_sec) * NANOSECONDS_IN_SECOND +
+                       BPF_CORE_READ(ino, i_ctime.tv_nsec);
+    }
+
+    if (S_ISREG(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_FILE;
+    } else if (S_ISDIR(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_DIR;
+    } else if (S_ISLNK(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_SYMLINK;
+    } else if (S_ISCHR(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_CHARACTER_DEVICE;
+    } else if (S_ISBLK(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_BLOCK_DEVICE;
+    } else if (S_ISFIFO(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_NAMED_PIPE;
+    } else if (S_ISSOCK(finfo->mode)) {
+        finfo->type = EBPF_FILE_TYPE_SOCKET;
+    } else {
+        finfo->type = EBPF_FILE_TYPE_UNKNOWN;
+    }
+}
+
+#endif // EBPF_EVENTPROBE_FILE_H

--- a/elastic-ebpf/GPL/Events/File/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/File/Probe.bpf.c
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+
+/*
+ * Copyright (C) 2021 Elasticsearch BV
+ *
+ * This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses.
+ * You may choose either one of them if you use this software.
+ */
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "File.h"
+#include "Helpers.h"
+#include "PathResolver.h"
+#include "State.h"
+#include "Varlen.h"
+
+/* vfs_unlink */
+DECL_FUNC_ARG(vfs_unlink, dentry);
+DECL_FUNC_RET(vfs_unlink);
+/* vfs_rename */
+DECL_FUNC_ARG(vfs_rename, old_dentry);
+DECL_FUNC_ARG(vfs_rename, new_dentry);
+DECL_FUNC_RET(vfs_rename);
+DECL_FUNC_ARG_EXISTS(vfs_rename, rd);
+/* do_truncate */
+DECL_FUNC_ARG(do_truncate, filp);
+DECL_FUNC_RET(do_truncate);
+
+static int do_unlinkat__enter()
+{
+    struct ebpf_events_state state = {};
+    state.unlink.step              = UNLINK_STATE_INIT;
+    if (ebpf_events_is_trusted_pid()) {
+        return 0;
+    }
+    ebpf_events_state__set(EBPF_EVENTS_STATE_UNLINK, &state);
+    return 0;
+}
+
+SEC("fentry/do_unlinkat")
+int BPF_PROG(fentry__do_unlinkat)
+{
+    return do_unlinkat__enter();
+}
+
+SEC("kprobe/do_unlinkat")
+int BPF_KPROBE(kprobe__do_unlinkat)
+{
+    return do_unlinkat__enter();
+}
+
+static int mnt_want_write__enter(struct vfsmount *mnt)
+{
+    struct ebpf_events_state *state = NULL;
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_UNLINK);
+    if (state) {
+        // Certain filesystems (eg. overlayfs) call mnt_want_write
+        // multiple times during the same execution context.
+        // Only take into account the first invocation.
+        if (state->unlink.step != UNLINK_STATE_INIT)
+            goto out;
+        state->unlink.mnt  = mnt;
+        state->unlink.step = UNLINK_STATE_MOUNT_SET;
+        goto out;
+    }
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_RENAME);
+    if (state) {
+        // Certain filesystems (eg. overlayfs) call mnt_want_write
+        // multiple times during the same execution context.
+        // Only take into account the first invocation.
+        if (state->rename.step != RENAME_STATE_INIT)
+            goto out;
+        state->rename.mnt  = mnt;
+        state->rename.step = RENAME_STATE_MOUNT_SET;
+        goto out;
+    }
+
+out:
+    return 0;
+}
+
+SEC("fentry/mnt_want_write")
+int BPF_PROG(fentry__mnt_want_write, struct vfsmount *mnt)
+{
+    return mnt_want_write__enter(mnt);
+}
+
+SEC("kprobe/mnt_want_write")
+int BPF_KPROBE(kprobe__mnt_want_write, struct vfsmount *mnt)
+{
+    return mnt_want_write__enter(mnt);
+}
+
+static int vfs_unlink__exit(int ret)
+{
+    if (ret != 0)
+        goto out;
+
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_UNLINK);
+    if (!state || state->rename.step != UNLINK_STATE_DENTRY_SET) {
+        // Omit logging as this happens in the happy path.
+        goto out;
+    }
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+
+    struct ebpf_file_delete_event *event = get_event_buffer();
+    if (!event) {
+        bpf_printk("vfs_unlink__exit: failed to reserve event\n");
+        goto out;
+    }
+
+    event->hdr.type    = EBPF_EVENT_FILE_DELETE;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
+
+    struct path p;
+    p.dentry = &state->unlink.de;
+    p.mnt    = state->unlink.mnt;
+    struct ebpf_namespace_info ns;
+    ebpf_ns__fill(&ns, task);
+    event->mntns = ns.mnt_inonum;
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
+    ebpf_file_info__fill(&event->finfo, p.dentry);
+
+    // Variable length fields
+    ebpf_vl_fields__init(&event->vl_fields);
+    struct ebpf_varlen_field *field;
+    long size;
+
+    // path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PATH);
+    size  = ebpf_resolve_path_to_string(field->data, &p, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // symlink_target_path
+    field      = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_SYMLINK_TARGET_PATH);
+    char *link = BPF_CORE_READ(p.dentry, d_inode, i_link);
+    size       = read_kernel_str_or_empty_str(field->data, PATH_MAX, link);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // pids ss cgroup path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH);
+    size  = ebpf_resolve_pids_ss_cgroup_path_to_string(field->data, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+
+    // Certain filesystems (eg. overlayfs) call vfs_unlink twice during the same
+    // execution context.
+    // In order to not emit a second event, delete the state explicitly.
+    ebpf_events_state__del(EBPF_EVENTS_STATE_UNLINK);
+
+out:
+    return 0;
+}
+
+SEC("fexit/vfs_unlink")
+int BPF_PROG(fexit__vfs_unlink)
+{
+    int ret = FUNC_RET_READ(___type(ret), vfs_unlink);
+    return vfs_unlink__exit(ret);
+}
+
+SEC("kretprobe/vfs_unlink")
+int BPF_KRETPROBE(kretprobe__vfs_unlink, int ret)
+{
+    return vfs_unlink__exit(ret);
+}
+
+static int vfs_unlink__enter(struct dentry *de)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_UNLINK);
+    if (!state || state->unlink.step != UNLINK_STATE_MOUNT_SET) {
+        // Omit logging as this happens in the happy path.
+        goto out;
+    }
+
+    if (bpf_core_read(&state->unlink.de, sizeof(struct dentry), de)) {
+        bpf_printk("vfs_unlink__enter: failed to read dentry\n");
+        goto out;
+    }
+    state->unlink.step = UNLINK_STATE_DENTRY_SET;
+
+out:
+    return 0;
+}
+
+SEC("fentry/vfs_unlink")
+int BPF_PROG(fentry__vfs_unlink)
+{
+    struct dentry *de = FUNC_ARG_READ(___type(de), vfs_unlink, dentry);
+    return vfs_unlink__enter(de);
+}
+
+SEC("kprobe/vfs_unlink")
+int BPF_KPROBE(kprobe__vfs_unlink)
+{
+    struct dentry *de;
+    if (FUNC_ARG_READ_PTREGS(de, vfs_unlink, dentry)) {
+        bpf_printk("kprobe__vfs_unlink: error reading dentry\n");
+        return 0;
+    }
+
+    return vfs_unlink__enter(de);
+}
+
+// prepare a file event and send it to ringbuf.
+// if path_prefix is non-NULL then event will only be sent to ringbuf if file path has that prefix
+static void prepare_and_send_file_event(struct file *f,
+                                        enum ebpf_event_type type,
+                                        const char *path_prefix,
+                                        int path_prefix_len)
+{
+    struct ebpf_file_create_event *event = get_event_buffer();
+    if (!event)
+        return;
+
+    event->hdr.type    = type;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    struct path p            = BPF_CORE_READ(f, f_path);
+    ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
+    struct ebpf_namespace_info ns;
+    ebpf_ns__fill(&ns, task);
+    event->mntns = ns.mnt_inonum;
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
+    ebpf_file_info__fill(&event->finfo, p.dentry);
+
+    // Variable length fields
+    ebpf_vl_fields__init(&event->vl_fields);
+    struct ebpf_varlen_field *field;
+    long size;
+
+    // symlink_target_path
+    field      = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_SYMLINK_TARGET_PATH);
+    char *link = BPF_CORE_READ(p.dentry, d_inode, i_link);
+    size       = read_kernel_str_or_empty_str(field->data, PATH_MAX, link);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // pids ss cgroup path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH);
+    size  = ebpf_resolve_pids_ss_cgroup_path_to_string(field->data, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PATH);
+    size  = ebpf_resolve_path_to_string(field->data, &p, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // skip event if prefix is specified and file path does not start with it
+    if (path_prefix) {
+        if ((path_prefix_len > 0) && (size >= path_prefix_len)) {
+            if (is_equal_prefix(field->data, path_prefix, path_prefix_len))
+                ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+        }
+    } else {
+        ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+    }
+}
+
+static int do_filp_open__exit(struct file *f)
+{
+    /*
+    'ret' fields such f_mode and f_path should be obtained via BPF_CORE_READ
+    because there's a kernel bug that causes a panic.
+    Read more: github.com/torvalds/linux/commit/588a25e92458c6efeb7a261d5ca5726f5de89184
+    */
+
+    if (IS_ERR_OR_NULL(f))
+        goto out;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+
+    fmode_t fmode = BPF_CORE_READ(f, f_mode);
+    if (fmode & (fmode_t)0x100000) { // FMODE_CREATED
+        // generate a file creation event
+        prepare_and_send_file_event(f, EBPF_EVENT_FILE_CREATE, NULL, 0);
+    } else {
+        // check if memfd file is being opened
+        struct path p              = BPF_CORE_READ(f, f_path);
+        struct dentry *curr_dentry = BPF_CORE_READ(&p, dentry);
+        struct qstr component      = BPF_CORE_READ(curr_dentry, d_name);
+        char buf_filename[8]       = {0};
+        int ret =
+            bpf_probe_read_kernel_str(buf_filename, sizeof(MEMFD_STRING), (void *)component.name);
+        if (ret <= 0) {
+            bpf_printk("could not read d_name at %p\n", component.name);
+            goto out;
+        }
+        // check if file name starts with "memfd:"
+        int is_memfd = is_equal_prefix(MEMFD_STRING, buf_filename, sizeof(MEMFD_STRING) - 1);
+        if (is_memfd) {
+            // generate a memfd file open event
+            prepare_and_send_file_event(f, EBPF_EVENT_FILE_MEMFD_OPEN, NULL, 0);
+            goto out;
+        }
+
+        struct vfsmount *curr_vfsmount = BPF_CORE_READ(&p, mnt);
+        const char *fs_type_name       = BPF_CORE_READ(curr_vfsmount, mnt_sb, s_type, name);
+
+        // check if /dev/shm shared memory file is being opened
+        // first check if fs is tmpfs
+        char buf_fsname[8] = {0};
+        ret = bpf_probe_read_kernel_str(buf_fsname, sizeof(TMPFS_STRING), (void *)fs_type_name);
+        if (ret <= 0) {
+            bpf_printk("could not read fsname at %p\n", fs_type_name);
+            goto out;
+        }
+
+        int is_tmpfs = is_equal_prefix(buf_fsname, TMPFS_STRING, sizeof(TMPFS_STRING) - 1);
+        if (is_tmpfs) {
+            // now filter for /dev/shm prefix, if there is match - send an SHMEM file open event
+            prepare_and_send_file_event(f, EBPF_EVENT_FILE_SHMEM_OPEN, DEVSHM_STRING,
+                                        sizeof(DEVSHM_STRING) - 1);
+        }
+    }
+
+out:
+    return 0;
+}
+
+SEC("fexit/do_filp_open")
+int BPF_PROG(fexit__do_filp_open,
+             int dfd,
+             struct filename *pathname,
+             const struct open_flags *op,
+             struct file *ret)
+{
+    return do_filp_open__exit(ret);
+}
+
+SEC("kretprobe/do_filp_open")
+int BPF_KRETPROBE(kretprobe__do_filp_open, struct file *ret)
+{
+    return do_filp_open__exit(ret);
+}
+
+static int do_renameat2__enter()
+{
+    struct ebpf_events_state state = {};
+    state.rename.step              = RENAME_STATE_INIT;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_RENAME, &state);
+
+    u32 zero = 0;
+    struct ebpf_events_scratch_space *ss =
+        bpf_map_lookup_elem(&elastic_ebpf_events_init_buffer, &zero);
+    if (!ss)
+        goto out;
+    ebpf_events_scratch_space__set(EBPF_EVENTS_STATE_RENAME, ss);
+
+out:
+    return 0;
+}
+
+SEC("fentry/do_renameat2")
+int BPF_PROG(fentry__do_renameat2)
+{
+    return do_renameat2__enter();
+}
+
+SEC("kprobe/do_renameat2")
+int BPF_KPROBE(kprobe__do_renameat2)
+{
+    return do_renameat2__enter();
+}
+
+static int vfs_rename__enter(struct dentry *old_dentry, struct dentry *new_dentry)
+{
+    struct ebpf_events_state *state;
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_RENAME);
+    if (!state || state->rename.step != RENAME_STATE_MOUNT_SET) {
+        // Omit logging as this happens in the happy path.
+        goto out;
+    }
+
+    struct ebpf_events_scratch_space *ss = ebpf_events_scratch_space__get(EBPF_EVENTS_STATE_RENAME);
+    if (!ss) {
+        bpf_printk("vfs_rename__enter: scratch space missing\n");
+        goto out;
+    }
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+
+    struct path p;
+    p.mnt    = state->rename.mnt;
+    p.dentry = old_dentry;
+    ebpf_resolve_path_to_string(ss->rename.old_path, &p, task);
+    p.dentry = new_dentry;
+    ebpf_resolve_path_to_string(ss->rename.new_path, &p, task);
+
+    state->rename.step = RENAME_STATE_PATHS_SET;
+    state->rename.de   = old_dentry;
+
+out:
+    return 0;
+}
+
+SEC("fentry/vfs_rename")
+int BPF_PROG(fentry__vfs_rename)
+{
+    struct dentry *old_dentry, *new_dentry;
+
+    if (FUNC_ARG_EXISTS(vfs_rename, rd)) {
+        /* Function arguments have been refactored into struct renamedata */
+        struct renamedata *rd = (struct renamedata *)ctx[0];
+        old_dentry            = rd->old_dentry;
+        new_dentry            = rd->new_dentry;
+    } else {
+        /* Dentries are accessible from ctx */
+        old_dentry = FUNC_ARG_READ(___type(old_dentry), vfs_rename, old_dentry);
+        new_dentry = FUNC_ARG_READ(___type(new_dentry), vfs_rename, new_dentry);
+    }
+
+    return vfs_rename__enter(old_dentry, new_dentry);
+}
+
+SEC("kprobe/vfs_rename")
+int BPF_KPROBE(kprobe__vfs_rename)
+{
+    struct dentry *old_dentry, *new_dentry;
+
+    if (FUNC_ARG_EXISTS(vfs_rename, rd)) {
+        /* Function arguments have been refactored into struct renamedata */
+        struct renamedata rd;
+        bpf_core_read(&rd, sizeof(rd), (void *)PT_REGS_PARM1(ctx));
+        old_dentry = rd.old_dentry;
+        new_dentry = rd.new_dentry;
+    } else {
+        /* Dentries are accessible from ctx */
+        if (FUNC_ARG_READ_PTREGS(old_dentry, vfs_rename, old_dentry)) {
+            bpf_printk("kprobe__vfs_rename: error reading old_dentry\n");
+            return 0;
+        }
+        if (FUNC_ARG_READ_PTREGS(new_dentry, vfs_rename, new_dentry)) {
+            bpf_printk("kprobe__vfs_rename: error reading new_dentry\n");
+            return 0;
+        }
+    }
+
+    return vfs_rename__enter(old_dentry, new_dentry);
+}
+
+static int vfs_rename__exit(int ret)
+{
+    if (ret)
+        goto out;
+
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_RENAME);
+    if (!state || state->rename.step != RENAME_STATE_PATHS_SET) {
+        // Omit logging as this happens in the happy path.
+        goto out;
+    }
+
+    struct ebpf_events_scratch_space *ss = ebpf_events_scratch_space__get(EBPF_EVENTS_STATE_RENAME);
+    if (!ss) {
+        bpf_printk("vfs_rename__exit: scratch space missing\n");
+        goto out;
+    }
+
+    struct ebpf_file_rename_event *event = get_event_buffer();
+    if (!event)
+        goto out;
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    // NOTE: this temp variable is necessary to keep the verifier happy
+    struct dentry *de = (struct dentry *)state->rename.de;
+
+    event->hdr.type    = EBPF_EVENT_FILE_RENAME;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
+    struct ebpf_namespace_info ns;
+    ebpf_ns__fill(&ns, task);
+    event->mntns = ns.mnt_inonum;
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
+    ebpf_file_info__fill(&event->finfo, de);
+
+    // Variable length fields
+    ebpf_vl_fields__init(&event->vl_fields);
+    struct ebpf_varlen_field *field;
+    long size;
+
+    // old path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_OLD_PATH);
+    size  = read_kernel_str_or_empty_str(field->data, PATH_MAX, ss->rename.old_path);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // new path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_NEW_PATH);
+    size  = read_kernel_str_or_empty_str(field->data, PATH_MAX, ss->rename.new_path);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // symlink_target_path
+    field      = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_SYMLINK_TARGET_PATH);
+    char *link = BPF_CORE_READ(de, d_inode, i_link);
+    size       = read_kernel_str_or_empty_str(field->data, PATH_MAX, link);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // pids ss cgroup path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH);
+    size  = ebpf_resolve_pids_ss_cgroup_path_to_string(field->data, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+
+    // Certain filesystems (eg. overlayfs) call vfs_rename twice during the same
+    // execution context.
+    // In order to not emit a second event, delete the state explicitly.
+    ebpf_events_state__del(EBPF_EVENTS_STATE_RENAME);
+
+out:
+    return 0;
+}
+
+SEC("fexit/vfs_rename")
+int BPF_PROG(fexit__vfs_rename)
+{
+    int ret = FUNC_RET_READ(___type(ret), vfs_rename);
+    return vfs_rename__exit(ret);
+}
+
+SEC("kretprobe/vfs_rename")
+int BPF_KRETPROBE(kretprobe__vfs_rename, int ret)
+{
+    return vfs_rename__exit(ret);
+}
+
+static void file_modify_event__emit(enum ebpf_file_change_type typ, struct path *path)
+{
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+
+    struct ebpf_file_modify_event *event = get_event_buffer();
+    if (!event) {
+        bpf_printk("file_modify_event__emit: failed to reserve event\n");
+        goto out;
+    }
+
+    event->hdr.type    = EBPF_EVENT_FILE_MODIFY;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->change_type = typ;
+    ebpf_pid_info__fill(&event->pids, task);
+    ebpf_cred_info__fill(&event->creds, task);
+    struct ebpf_namespace_info ns;
+    ebpf_ns__fill(&ns, task);
+    event->mntns = ns.mnt_inonum;
+    bpf_get_current_comm(event->comm, TASK_COMM_LEN);
+    struct dentry *d = BPF_CORE_READ(path, dentry);
+    ebpf_file_info__fill(&event->finfo, d);
+
+    switch (event->finfo.type) {
+    case EBPF_FILE_TYPE_FILE:
+        break;
+    default:
+        goto out;
+    }
+
+    // Variable length fields
+    ebpf_vl_fields__init(&event->vl_fields);
+    struct ebpf_varlen_field *field;
+    long size;
+
+    // path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PATH);
+    size  = ebpf_resolve_path_to_string(field->data, path, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // symlink_target_path
+    field      = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_SYMLINK_TARGET_PATH);
+    char *link = BPF_CORE_READ(path, dentry, d_inode, i_link);
+    size       = read_kernel_str_or_empty_str(field->data, PATH_MAX, link);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    // pids ss cgroup path
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH);
+    size  = ebpf_resolve_pids_ss_cgroup_path_to_string(field->data, task);
+    ebpf_vl_field__set_size(&event->vl_fields, field, size);
+
+    ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+
+out:
+    return;
+}
+
+SEC("kprobe/chmod_common")
+int BPF_KPROBE(kprobe__chmod_common, const struct path *path, umode_t mode)
+{
+    struct ebpf_events_state state = {};
+    state.chmod.path               = (struct path *)path;
+    state.chmod.mode               = mode;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_CHMOD, &state);
+    return 0;
+}
+
+static void chmod_common__exit(struct path *path, int ret)
+{
+    if (ret)
+        goto out;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+
+    file_modify_event__emit(EBPF_FILE_CHANGE_TYPE_PERMISSIONS, path);
+
+out:
+    return;
+}
+
+SEC("fexit/chmod_common")
+int BPF_PROG(fexit__chmod_common, const struct path *path, umode_t mode, int ret)
+{
+    chmod_common__exit((struct path *)path, ret);
+    return 0;
+}
+
+SEC("kretprobe/chmod_common")
+int BPF_KRETPROBE(kretprobe__chmod_common, int ret)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHMOD);
+    if (!state)
+        goto out;
+
+    chmod_common__exit(state->chmod.path, ret);
+
+out:
+    return 0;
+}
+
+SEC("kprobe/do_truncate")
+int BPF_KPROBE(kprobe__do_truncate)
+{
+    struct ebpf_events_state state = {};
+
+    struct file *filp;
+    if (FUNC_ARG_READ_PTREGS(filp, do_truncate, filp)) {
+        bpf_printk("kprobe__do_truncate: error reading filp\n");
+        return 0;
+    }
+
+    state.truncate.path = path_from_file(filp);
+    ebpf_events_state__set(EBPF_EVENTS_STATE_TRUNCATE, &state);
+
+out:
+    return 0;
+}
+
+static void do_truncate__exit(struct path *path, int ret)
+{
+    if (ret)
+        goto out;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+
+    file_modify_event__emit(EBPF_FILE_CHANGE_TYPE_CONTENT, path);
+
+out:
+    return;
+}
+
+SEC("fexit/do_truncate")
+int BPF_PROG(fexit__do_truncate)
+{
+    struct file *filp = FUNC_ARG_READ(___type(filp), do_truncate, filp);
+    int ret           = FUNC_RET_READ(___type(ret), do_truncate);
+    do_truncate__exit(path_from_file(filp), ret);
+    return 0;
+}
+
+SEC("kretprobe/do_truncate")
+int BPF_KRETPROBE(kretprobe__do_truncate, int ret)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_TRUNCATE);
+    if (!state)
+        goto out;
+
+    do_truncate__exit(state->truncate.path, ret);
+
+out:
+    return 0;
+}
+
+SEC("kprobe/vfs_write")
+int BPF_KPROBE(kprobe__vfs_write, struct file *file)
+{
+    struct ebpf_events_state state = {};
+
+    state.write.path = path_from_file(file);
+    ebpf_events_state__set(EBPF_EVENTS_STATE_WRITE, &state);
+
+    return 0;
+}
+
+SEC("kprobe/vfs_writev")
+int BPF_KPROBE(kprobe__vfs_writev, struct file *file)
+{
+    struct ebpf_events_state state = {};
+
+    state.writev.path = path_from_file(file);
+    ebpf_events_state__set(EBPF_EVENTS_STATE_WRITEV, &state);
+
+    return 0;
+}
+
+static void vfs_write__exit(struct path *path, ssize_t ret)
+{
+    if (ret <= 0)
+        goto out;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+
+    file_modify_event__emit(EBPF_FILE_CHANGE_TYPE_CONTENT, path);
+
+out:
+    return;
+}
+
+SEC("fexit/vfs_write")
+int BPF_PROG(
+    fexit__vfs_write, struct file *file, const char *buf, size_t count, loff_t *pos, ssize_t ret)
+{
+    vfs_write__exit(path_from_file(file), ret);
+    return 0;
+}
+
+SEC("fexit/vfs_writev")
+int BPF_PROG(fexit__vfs_writev,
+             struct file *file,
+             const struct iovec *vec,
+             unsigned long vlen,
+             loff_t *pos,
+             rwf_t flags,
+             ssize_t ret)
+{
+    vfs_write__exit(path_from_file(file), ret);
+    return 0;
+}
+
+SEC("kretprobe/vfs_write")
+int BPF_KRETPROBE(kretprobe__vfs_write, ssize_t ret)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITE);
+    if (!state)
+        goto out;
+
+    vfs_write__exit(state->write.path, ret);
+
+out:
+    return 0;
+}
+
+SEC("kretprobe/vfs_writev")
+int BPF_KRETPROBE(kretprobe__vfs_writev, ssize_t ret)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITEV);
+    if (!state)
+        goto out;
+
+    vfs_write__exit(state->writev.path, ret);
+
+out:
+    return 0;
+}
+
+SEC("kprobe/chown_common")
+int BPF_KPROBE(kprobe__chown_common, struct path *path, uid_t user, gid_t group)
+{
+    struct ebpf_events_state state = {};
+    state.chown.path               = path;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_CHOWN, &state);
+    return 0;
+}
+
+static void chown_common__exit(struct path *path, int ret)
+{
+    if (ret)
+        goto out;
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+
+    file_modify_event__emit(EBPF_FILE_CHANGE_TYPE_OWNER, path);
+
+out:
+    return;
+}
+
+SEC("fexit/chown_common")
+int BPF_PROG(fexit__chown_common, struct path *path, uid_t user, gid_t group, int ret)
+{
+    chown_common__exit(path, ret);
+    return 0;
+}
+
+SEC("kretprobe/chown_common")
+int BPF_KRETPROBE(kretprobe__chown_common, int ret)
+{
+    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHOWN);
+    if (!state)
+        goto out;
+
+    chown_common__exit(state->chown.path, ret);
+
+out:
+    return 0;
+}

--- a/elastic-ebpf/GPL/Events/File/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/File/Probe.bpf.c
@@ -104,7 +104,7 @@ static int vfs_unlink__exit(int ret)
         goto out;
 
     struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_UNLINK);
-    if (!state || state->rename.step != UNLINK_STATE_DENTRY_SET) {
+    if (!state || state->unlink.step != UNLINK_STATE_DENTRY_SET) {
         // Omit logging as this happens in the happy path.
         goto out;
     }

--- a/quark-test.8
+++ b/quark-test.8
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm quark-test
 .Op Fl bkv
+.Op Fl x Ar test
 .Op Ar tests ...
 .Nm quark-test
 .Fl h
@@ -53,6 +54,10 @@ Increase
 can be issued multiple times.
 .It Fl V
 Print version and exit.
+.It Fl x Ar test
+Exclude
+.Ar test
+from the run, can be specified multiple times.
 .El
 .Sh EXIT STATUS
 .Nm

--- a/quark.c
+++ b/quark.c
@@ -2352,6 +2352,11 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 		 */
 		qa->max_length = 1;
 	}
+	/*
+	 * QQ_FILE needs QQ_BYPASS for now
+	 */
+	if ((qa->flags & QQ_FILE) && !(qa->flags & QQ_BYPASS))
+		return (errno = EINVAL, -1);
 
 	if ((qa->flags & QQ_ALL_BACKENDS) == 0 ||
 	    qa->max_length <= 0 ||

--- a/quark.h
+++ b/quark.h
@@ -75,7 +75,9 @@ void			 quark_btf_close(struct quark_btf *);
 ssize_t			 quark_btf_offset(struct quark_btf *, const char *);
 
 struct btf;
-s32		 	 btf_number_of_params(struct btf *, const char *);
+s32			btf_root_offset(struct btf *, const char *, int);
+int			btf_number_of_params(struct btf *, const char *);
+int			btf_index_of_param(struct btf *, const char *, const char *);
 
 /* bpf_queue.c */
 int	bpf_queue_open(struct quark_queue *);
@@ -474,6 +476,7 @@ struct quark_queue_attr {
 #define QQ_SOCK_CONN		(1 << 5)
 #define QQ_DNS			(1 << 6)
 #define QQ_BYPASS		(1 << 7)
+#define QQ_FILE			(1 << 8)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
 	int	flags;
 	int	max_length;


### PR DESCRIPTION
This is split into 4 commits:

1. Import the file probes verbatim
2. Fix a harmless, yet correct compiler warning from the probes
3. The actual work of loading, testing and yada yada
4. Update quark-test.8.html

Commits won't be squashed.

Commit 2:

### Add QQ_FILE to QQ_BYPASS and -x option to quark-test
This loads all the file probes if QQ_FILE is specified, which is tied to
QQ_BYPASS as we don't do proper file events yet.

Main purpose is to be able to replace elastic/ebpf meanwhile, so users can rely
on the raw probes from QQ_BYPASS.

It's a ton of new probes and `chown_common` fails in RHEL 8.[5-7]. The function
is likely inlined, at any rate now it's not the time to touch it.
To make CI happy add a `-x` option to quark-test so we can exclude those tests
from the failing RHEL. The test is pretty naive for now and just checks if the
probes load or not.

The failing RHEL:
```
quark-test: libbpf: prog 'fexit__chown_common': failed to find kernel BTF type ID of 'chown_common': -ESRCH
quark-test: libbpf: prog 'fexit__chown_common': failed to prepare load attributes: -ESRCH
quark-test: libbpf: prog 'fexit__chown_common': failed to load: -ESRCH
quark-test: libbpf: failed to load object 'bpf_prog'
quark-test: libbpf: failed to load BPF skeleton 'bpf_prog': -ESRCH
quark-test: bpf_queue_open1:556: bpf_prog__load: No such process
quark-test: bpf_queue_open:632: bpf_queue_open failed with fentry, trying kprobe: No such process
quark-test: libbpf: prog 'kprobe__chown_common': failed to create kprobe 'chown_common+0x0' perf event: -ENOENT
quark-test: libbpf: prog 'kprobe__chown_common': failed to auto-attach: -ENOENT
quark-test: bpf_queue_open1:590: bpf_prog__attach: No such file or directory
quark-test: quark_queue_open:2384: all backends failed
quark-test: quark_queue_open: Operation not supported
```

Additionally this correctly relocates `iov_iter` which was already being used by
process probes, that's on me.
The relocations were kept inline with elastic/ebpf but without the sneaky macros
so I wrote equivalent helpers, the main point here is to not introduce new
behaviour (for now).