### PR TITLE
Build fixes for musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ifndef SYSLIB
 LIBQUARK_TARGET=$(LIBQUARK_STATIC_BIG)
 else
 LIBQUARK_TARGET=$(LIBQUARK_STATIC)
-EXTRA_LDFLAGS:= -lbpf
+EXTRA_LDFLAGS+= -lbpf
 endif
 
 # ZLIB
@@ -222,7 +222,7 @@ DOCKER_RUN_ARGS=$(QDOCKER)				\
 
 docker: docker-image clean-all
 	$(call msg,DOCKER-RUN,Dockerfile)
-	$(Q)$(DOCKER) run $(DOCKER_RUN_ARGS) /bin/bash -c "make -C $(PWD) all initramfs.gz"
+	$(Q)$(DOCKER) run $(DOCKER_RUN_ARGS) $(SHELL) -c "make -C $(PWD) all initramfs.gz"
 
 docker-cross-arm64: clean-all docker-image manpages.h
 	$(call msg,DOCKER-RUN,Dockerfile)
@@ -232,7 +232,7 @@ docker-cross-arm64: clean-all docker-image manpages.h
 		-e LD=aarch64-linux-gnu-ld		\
 		-e AR=aarch64-linux-gnu-ar		\
 		$(DOCKER_RUN_ARGS)			\
-		/bin/bash -c "make -C $(PWD) all initramfs.gz"
+		$(SHELL) -c "make -C $(PWD) all initramfs.gz"
 
 docker-image: clean-all
 	$(call msg,DOCKER-IMAGE,Dockerfile)
@@ -243,7 +243,7 @@ docker-image: clean-all
 		.
 
 docker-shell:
-	$(DOCKER) run -it $(DOCKER_RUN_ARGS) /bin/bash
+	$(DOCKER) run -it $(DOCKER_RUN_ARGS) $(SHELL)
 
 
 CENTOS7_RUN_ARGS=$(QDOCKER)				\
@@ -258,12 +258,12 @@ centos7: clean-all docker-image centos7-image
 	# modern Ubuntu image, we can't make those on centos7
 	$(DOCKER) run					\
 		$(DOCKER_RUN_ARGS)			\
-		/bin/bash -c "make -C $(PWD) bpf_prog.o bpf_prog_skel.h"
+		$(SHELL) -c "make -C $(PWD) bpf_prog.o bpf_prog_skel.h"
 	# Now we build the rest of the suite as it won't try to rebuild
 	# bpf_prog.o and bpf_prog_skel.h
 	$(DOCKER) run					\
 		$(CENTOS7_RUN_ARGS)			\
-		/bin/bash -c "make -j1 -C $(PWD)"
+		$(SHELL) -c "make -j1 -C $(PWD)"
 
 centos7-image: clean-all
 	$(call msg,DOCKER-IMAGE,Dockerfile.centos7)
@@ -274,7 +274,7 @@ centos7-image: clean-all
 		.
 
 centos7-shell:
-	$(DOCKER) run -it $(CENTOS7_RUN_ARGS) /bin/bash
+	$(DOCKER) run -it $(CENTOS7_RUN_ARGS) $(SHELL)
 
 include: $(LIBBPF_DEPS)
 	$(Q)make -C $(LIBBPF_SRC)			\

--- a/quark-test.c
+++ b/quark-test.c
@@ -466,7 +466,7 @@ local_connect(u16 port, int type, u16 *bound_port)
 		socklen_t	socklen;
 
 		socklen = sizeof(sin);
-		if (getsockname(fd, &sin, &socklen) == -1)
+		if (getsockname(fd, (struct sockaddr *)&sin, &socklen) == -1)
 			err(1, "getsockname");
 		*bound_port = sin.sin_port;
 	}


### PR DESCRIPTION
musl doesn't ship fts(3). On systems with musl, fts is provided in an external object which can be expressed in EXTRA_LDFLAGS, so don't overwrite EXTRA_LDFLAGS.

While here, also correctly cast sockaddr which was generating a warning on: `gcc version 14.2.0 (Alpine 14.2.0)`

Plus, consistently use $(SHELL) instead of hardcoded /bin/bash.