### PR TITLE
Add a build target for alpine, so we can ensure musl works

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,14 @@ steps:
       provider: gcp
       machineType: n2-standard-2
 
+  - label: "build amd64 in an alpine container"
+    key: make_alpine
+    command: "make alpine"
+    agents:
+      image: family/core-ubuntu-2204
+      provider: gcp
+      machineType: n2-standard-2
+
   - label: "quark-test"
     key: test
     command: "./.buildkite/runtest.sh"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,12 @@
+FROM alpine:3.21
+RUN apk add 						\
+	bash						\
+	clang						\
+        bpftool						\
+	gcc						\
+	libbsd						\
+	libbsd-dev					\
+	make						\
+	musl-fts					\
+	musl-fts-dev					\
+	m4

--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,26 @@ centos7-image: clean-all
 centos7-shell:
 	$(DOCKER) run -it $(CENTOS7_RUN_ARGS) $(SHELL)
 
+ALPINE_RUN_ARGS=$(QDOCKER)				\
+		-v $(PWD):$(PWD)			\
+		-w $(PWD)				\
+		-u $(shell id -u):$(shell id -g)	\
+		alpine-quark-builder
+
+alpine: alpine-image clean-all
+	$(call msg,ALPINE-DOCKER-RUN,Dockerfile)
+	$(Q)$(DOCKER) run 				\
+		$(ALPINE_RUN_ARGS) $(SHELL)		\
+		-c "make -C $(PWD) all initramfs.gz EXTRA_LDFLAGS=-lfts"
+
+alpine-image: clean-all
+	$(call msg,ALPINE-IMAGE,Dockerfile.alpine)
+	$(Q)$(DOCKER) build				\
+		$(QDOCKER)				\
+		-f Dockerfile.alpine			\
+		-t alpine-quark-builder			\
+		.
+
 include: $(LIBBPF_DEPS)
 	$(Q)make -C $(LIBBPF_SRC)			\
 		NO_PKG_CONFIG=y				\
@@ -332,19 +352,19 @@ quark-mon-static: quark-mon.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -DNO_PRIVDROP $(CDIAGFLAGS) \
-		-static -o $@ $< $(LIBQUARK_STATIC_BIG)
+		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
 quark-btf-static: quark-btf.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
-		-static -o $@ $< $(LIBQUARK_STATIC_BIG)
+		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
 quark-test-static: quark-test.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
-		-static -o $@ $< $(LIBQUARK_STATIC_BIG)
+		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
 man-embedder: man-embedder.c
 	$(call msg,CC,$@)

--- a/docs/index.html
+++ b/docs/index.html
@@ -196,6 +196,9 @@ $ ls -1 /tmp | wc -l</pre>
   <dt id="centos7"><a class="permalink" href="#centos7"><i class="Em">centos7</i></a></dt>
   <dd>Builds <code class="Nm">quark</code> inside a centos7 docker container,
       useful for linking against ancient glibc-2.17.</dd>
+  <dt id="alpine"><a class="permalink" href="#alpine"><i class="Em">alpine</i></a></dt>
+  <dd>Builds <code class="Nm">quark</code> inside an alpine docker container, so
+      we can track musl builds.</dd>
   <dt id="test"><a class="permalink" href="#test"><i class="Em">test</i></a></dt>
   <dd>Builds and runs
     <a class="Xr" href="quark-test.8.html">quark-test(8)</a>.</dd>
@@ -412,7 +415,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 11, 2025</td>
+    <td class="foot-date">May 4, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -196,6 +196,9 @@ $ ls -1 /tmp | wc -l</pre>
   <dt id="centos7"><a class="permalink" href="#centos7"><i class="Em">centos7</i></a></dt>
   <dd>Builds <code class="Nm">quark</code> inside a centos7 docker container,
       useful for linking against ancient glibc-2.17.</dd>
+  <dt id="alpine"><a class="permalink" href="#alpine"><i class="Em">alpine</i></a></dt>
+  <dd>Builds <code class="Nm">quark</code> inside an alpine docker container, so
+      we can track musl builds.</dd>
   <dt id="test"><a class="permalink" href="#test"><i class="Em">test</i></a></dt>
   <dd>Builds and runs
     <a class="Xr" href="quark-test.8.html">quark-test(8)</a>.</dd>
@@ -412,7 +415,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 11, 2025</td>
+    <td class="foot-date">May 4, 2025</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark.7
+++ b/quark.7
@@ -210,6 +210,10 @@ Builds
 .Nm quark
 inside a centos7 docker container, useful for linking against
 ancient glibc-2.17.
+.It Em alpine
+Builds
+.Nm quark
+inside an alpine docker container, so we can track musl builds.
 .It Em test
 Builds and runs
 .Xr quark-test 8 .


### PR DESCRIPTION
The main purpose of this is to add Alpine to the CI build to make sure we can always build against a proper libc like musl.

glibc is too laxed and has a record of breakage and/or not respecting standards.

We can't really run the tests yet as the alpine kernel wasn't shipping BTF, I've fixed it upstream, so once that makes it to the docker registry we can run the tests:

https://gitlab.alpinelinux.org/alpine/aports/-/commit/8964f46e129def63b8d62809ecad2d5bf29f5688