### PR TITLE
Cgroup

### DIFF
--- a/elastic-ebpf/GPL/Events/PathResolver.h
+++ b/elastic-ebpf/GPL/Events/PathResolver.h
@@ -235,6 +235,11 @@ static size_t ebpf_resolve_kernfs_node_to_string(char *buf, struct kernfs_node *
 
         cur += name_len & PATH_MAX_INDEX_MASK;
     }
+    if (cur == 0) {
+        buf[0] = '/';
+        buf[1] = '\0';
+        cur++;
+    }
 
     return cur + 1; // cur does not include the \0
 

--- a/quark.h
+++ b/quark.h
@@ -193,6 +193,7 @@ struct raw_task {
 	u32	 mnt_inonum;
 	u32	 net_inonum;
 	char	*cwd;
+	char	*cgroup;
 	char	 comm[16];
 };
 
@@ -382,6 +383,7 @@ struct quark_process {
 #define QUARK_F_FILENAME	(1 << 3)
 #define QUARK_F_CMDLINE		(1 << 4)
 #define QUARK_F_CWD		(1 << 5)
+#define QUARK_F_CGROUP		(1 << 6)
 	u64	 flags;
 
 	/* QUARK_F_PROC */
@@ -420,6 +422,8 @@ struct quark_process {
 	char	*cmdline;
 	/* QUARK_F_CWD */
 	char	*cwd;
+	/* QUARK_F_CGROUP */
+	char	*cgroup;
 };
 
 struct quark_process_iter {

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -118,6 +118,8 @@ struct quark_process {
 	char	*cmdline;
 	/* QUARK_F_CWD */
 	char	*cwd;
+	/* QUARK_F_CGROUP */
+	char	*cgroup;
 };
 .Ed
 .Pp
@@ -147,6 +149,9 @@ and
 are valid.
 .It Dv QUARK_F_CWD
 .Em cwd
+is valid.
+.It Dv QUARK_F_CGROUP
+.Em cgroup
 is valid.
 .El
 .El

--- a/qutil.c
+++ b/qutil.c
@@ -167,6 +167,11 @@ find_line_p(const char *path, const char *needle)
 	return (line);
 }
 
+/*
+ * Returns file content with a NUL appended, doesn't do stat so it works on
+ * /proc, if total is non-null, size of read bytes is filled, not including the
+ * appended NUL.
+ */
 char *
 load_file_nostat(int fd, size_t *total)
 {


### PR DESCRIPTION
Add cgroups to quark_process{}
Only for EBPF atm, basically the same dance we do other paths.
Currently we replace the existing cgroup with the new one for every event, but
likely this is only needed at fork, consider changing this in the future.

+++

Signal root cgroup as /, not NUL
Before this change if a process was in the root cgroup, we would get a zero
length string. If an error ocurred it would also return a zero length string.

Change it so that a successful case of a root process actually sends "/" and not
a zero length string, this way quark can know if it should signal it knows the
cgroup path or not.