### PR TITLE
Load missing memfd probes for BYPASS. Issue #170

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -546,6 +546,21 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.recvmsg4, 1);
 	}
 
+	if (qq->flags & QQ_MEMFD) {
+		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_enter_memfd_create, 1);
+		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_enter_shmget, 1);
+		bpf_program__set_autoload(p->progs.module_load, 1);
+		bpf_program__set_autoload(p->progs.kprobe__ptrace_attach, 1);
+	}
+
+	/*
+	 * These are probes that are not attached to a feature and not currently
+	 * used in quark, but we need to maintain compatibility in BYPASS.
+	 */
+	if (qq->flags & QQ_BYPASS) {
+		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_setsid, 1);
+	}
+
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
 	    get_nprocs_conf()) != 0) {
 		qwarn("bpf_map__set_max_entries");

--- a/quark-test.c
+++ b/quark-test.c
@@ -748,6 +748,23 @@ t_file(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
+/* XXX Only probe loading for now */
+static int
+t_memfd(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+
+	qa->flags &= ~QQ_ENTRY_LEADER;
+	qa->flags |= QQ_BYPASS | QQ_MEMFD;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
 static int
 t_sock_conn(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -1048,6 +1065,7 @@ struct test all_tests[] = {
 	T(t_exit_tgid),
 	T_EBPF(t_bypass),
 	T_EBPF(t_file),
+	T_EBPF(t_memfd),
 	T_EBPF(t_sock_conn),
 	T_EBPF(t_dns),
 	T(t_namespace),

--- a/quark.c
+++ b/quark.c
@@ -2310,9 +2310,10 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 		qa->max_length = 1;
 	}
 	/*
-	 * QQ_FILE needs QQ_BYPASS for now
+	 * QQ_{FILE,MEMFD} needs QQ_BYPASS for now
 	 */
-	if ((qa->flags & QQ_FILE) && !(qa->flags & QQ_BYPASS))
+	if ((qa->flags & (QQ_FILE|QQ_MEMFD))
+	    && !(qa->flags & QQ_BYPASS))
 		return (errno = EINVAL, -1);
 
 	if ((qa->flags & QQ_ALL_BACKENDS) == 0 ||

--- a/quark.h
+++ b/quark.h
@@ -477,6 +477,7 @@ struct quark_queue_attr {
 #define QQ_DNS			(1 << 6)
 #define QQ_BYPASS		(1 << 7)
 #define QQ_FILE			(1 << 8)
+#define QQ_MEMFD		(1 << 9)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
 	int	flags;
 	int	max_length;


### PR DESCRIPTION
Bind memfd probes to QQ_MEMFD, only available in QQ_BYPASS Also adds the missing setsid probe only when QQ_BYPASS is asked.