### PR TITLE
Make bpf compiler more configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ endif
 
 CLANG?= clang
 BPFTOOL?= bpftool
+BPF_CC?= $(CLANG)
+BPF_ARCH?= bpf # Zig cc calls this bpfel
 DOCKER?= docker
 
 # All EEBPF files we track for dependency
@@ -201,19 +203,16 @@ bpf_probes_skel.h: $(BPFPROG_OBJ)
 	$(Q)$(BPFTOOL) gen skeleton $(BPFPROG_OBJ) > bpf_probes_skel.h
 
 $(BPFPROG_OBJ): $(BPFPROG_DEPS)
-	$(call msg,CLANG,bpf_probes.tmp.o)
-	$(Q)$(CLANG)								\
+	$(call msg,BPF_CC,$@)
+	$(Q)$(BPF_CC)								\
 		-g -O2								\
-		-target bpf							\
+		-target $(BPF_ARCH)						\
 		-D__KERNEL__							\
 		-D__TARGET_ARCH_$(ARCH_BPF_TARGET)				\
 		$(CPPFLAGS)							\
 		$(EEBPF_INCLUDES)						\
 		-c bpf_probes.c							\
-		-o bpf_probes.tmp.o
-	$(call msg,BPFTOOL,$@)
-	$(Q)$(BPFTOOL) gen object $@ bpf_probes.tmp.o
-	$(Q)rm bpf_probes.tmp.o
+		-o $@
 
 DOCKER_RUN_ARGS=$(QDOCKER)				\
 		-v $(PWD):$(PWD)			\


### PR DESCRIPTION
Don't assume the bpf compiler is $CLANG, make it possible to configure it along with the bpf arch target, since zig calls it something else.

While here, zap bpf.prog.tmp.o since we don't need it, cuts one invocation of bpftool. Without the bpftool linking, zig also doesn't generate a warning that "seems" harmless.

With this we can compile with zig:
```
make BPF_COMPILER="zig cc" BPF_ARCH=bpfel-freestanding-none
```