### PR TITLE
Only attach the current number of active procs

### DIFF
--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1382,7 +1382,7 @@ kprobe_queue_open(struct quark_queue *qq)
 	kqq->qid = qid;
 	qq->queue_be = kqq;
 
-	for (i = 0; i < get_nprocs_conf(); i++) {
+	for (i = 0; i < get_nprocs(); i++) {
 		pgl = perf_open_group_leader(kqq, i);
 		if (pgl == NULL)
 			goto fail;


### PR DESCRIPTION
When running tests, `perf_event_open` was failing with `ENODEV`.
The following toy program reveals why:
```c
#include <sys/sysinfo.h>
#include <stdio.h>

int main()
{
    printf("%d\n", get_nprocs());
    printf("%d\n", get_nprocs_conf());
    return 0;
}
```
```bash
$ make get_nproc_test
cc     get_nproc_test.c   -o get_nproc_test      
$ ./get_nproc_test
4
128
```

There's another spot quark calls `get_nproc_conf()`. But, [it's](https://github.com/elastic/quark/blob/4d8005526290f4a7ee55224c07f920f891629946/bpf_queue.c#L565) about a maximum bpf map size and I believe to be appropriate.