### PR TITLE
bpf_probes be mad

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -415,6 +415,11 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	}
 
 	/*
+	 * Maps and other state
+	 */
+	p->rodata->consumer_pid = getpid();
+
+	/*
 	 * Unload everything since it has way more than we want
 	 */
 	for (i = 0; i < p->skeleton->prog_cnt; i++) {

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -711,3 +711,14 @@ bpf_queue_close(struct quark_queue *qq)
 	/* Closed in ring_buffer__free() */
 	qq->epollfd = -1;
 }
+
+struct bpf_probes *
+quark_get_bpf_probes(struct quark_queue *qq)
+{
+	struct bpf_queue *bqq = qq->queue_be;
+
+	if (!(qq->flags & QQ_EBPF) || !(qq->flags & QQ_BYPASS))
+		return (errno = EINVAL, NULL);
+
+	return (bqq->probes);
+}

--- a/quark.h
+++ b/quark.h
@@ -83,7 +83,8 @@ int			btf_number_of_params(struct btf *, const char *);
 int			btf_index_of_param(struct btf *, const char *, const char *);
 
 /* bpf_queue.c */
-int	bpf_queue_open(struct quark_queue *);
+int			 bpf_queue_open(struct quark_queue *);
+struct bpf_probes	*quark_get_bpf_probes(struct quark_queue *);
 
 /* kprobe_queue.c */
 int	kprobe_queue_open(struct quark_queue *);


### PR DESCRIPTION
Allow bypass to reach around bpf_probes
Not everything has been(or will) be ported from elastic/ebpf into quark, but we
still have applications that need to manipulate bpf maps, so allow them to have
direct access and do their thing.

+++

Fill rodata->consumer_pid
Whooopsy, affects only one tty probe, likely harmless.