### PR TITLE
Change quark-test to use /bin/true instead of itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ quark-btf-static
 quark-test
 quark-test-static
 init
+true
 libquark.a
 libquark_big.a
 bpf_probes_skel.h

--- a/Makefile
+++ b/Makefile
@@ -345,17 +345,23 @@ test-valgrind: quark-test
 # | grep -v "^--.*WARNING: unhandled eBPF command"
 
 initramfs:
-	mkdir initramfs
+	mkdir -p initramfs/bin
 
-initramfs.gz: init quark-mon-static quark-btf-static quark-test-static initramfs
+initramfs.gz: init quark-mon-static quark-btf-static quark-test-static true initramfs
 	$(call assert_no_syslib)
 	cp init initramfs/
 	cp quark-mon-static initramfs/quark-mon
 	cp quark-btf-static initramfs/quark-btf
 	cp quark-test-static initramfs/quark-test
+	cp quark-test-static initramfs/quark-test
+	cp true initramfs/bin
 	cd initramfs && find . -print0 | cpio -0 -ov --format=newc | gzip -9 > ../$@
 
 init: init.c
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) -static -o $@ $^
+
+true: true.c
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) -static -o $@ $^
 

--- a/init.c
+++ b/init.c
@@ -18,6 +18,7 @@
 #include <netinet/ip.h>
 
 #include <err.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -102,11 +103,13 @@ main(int argc, char *argv[])
 
 	/* child */
 	if (pid == 0) {
-		if (mkdir("/tmp", 0777) != 0)
+		if (setenv("PATH", "/bin", 1) != 0)
+			err(1, "setenv PATH");
+		if (mkdir("/tmp", 0777) == -1)
 			err(1, "mkdir /tmp");
-		if (mkdir("/proc", 0666) != 0)
+		if (mkdir("/proc", 0666) == -1)
 			err(1, "mkdir /proc");
-		if (mkdir("/sys", 0666) != 0)
+		if (mkdir("/sys", 0666) == -1)
 			err(1, "mkdir /sys");
 
 		if (mount(NULL, "/tmp", "tmpfs", 0, NULL) == -1)

--- a/quark-test.8
+++ b/quark-test.8
@@ -12,7 +12,6 @@
 .Nm quark-test
 .Fl h
 .Nm quark-test Fl l
-.Nm quark-test Fl N
 .Nm quark-test Fl V
 .Sh DESCRIPTION
 The
@@ -44,13 +43,6 @@ Display this manpage.
 Run only KPROBE tests.
 .It Fl l
 Prints all available tests on stdout.
-.It Fl N
-This is a nop flag, literally,
-.Nm
-will just exit with 0. Some tests must fork and exec things in order to collect
-events, this keeps the binary self contained by forking and execing itself as we
-don't have access to system utilities in
-.Pa initramfs.gz .
 .It Fl v
 Increase
 .Em quark_verbose ,

--- a/quark-test.c
+++ b/quark-test.c
@@ -105,19 +105,6 @@ color(int color)
 	return (ret);
 }
 
-static char *
-binpath(const char *bin)
-{
-	static char	name[PATH_MAX];
-
-	if (bin != NULL && realpath(bin, name) == NULL)
-		err(1, "can't initialize binpath");
-	else if (bin == NULL && name[0] == 0)
-		err(1, "binpath not initialized");
-
-	return (name);
-}
-
 static int
 backend_of_attr(struct quark_queue_attr *qa)
 {
@@ -320,8 +307,6 @@ usage(void)
 	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s -l\n",
 	    program_invocation_short_name);
-	fprintf(stderr, "usage: %s -N\n",
-	    program_invocation_short_name);
 	fprintf(stderr, "usage: %s -V\n",
 	    program_invocation_short_name);
 
@@ -334,8 +319,7 @@ fork_exec_nop(void)
 	pid_t		child;
 	int		status;
 	char *const	argv[] = {
-		binpath(NULL),
-		"-N",
+		"true",
 		"this",
 		"is",
 		"nop!",
@@ -346,7 +330,7 @@ fork_exec_nop(void)
 		err(1, "fork");
 	else if (child == 0) {
 		/* child */
-		return (execv(binpath(NULL), argv));
+		return (execvp("true", argv));
 	}
 
 	/* parent */
@@ -665,8 +649,9 @@ t_fork_exec_exit(const struct test *t, struct quark_queue_attr *qa)
 	assert(qp->proc_tty_minor != 0);
 #endif
 	/* check strings */
-	assert(!strcmp(qp->comm, program_invocation_short_name));
-	assert(!strcmp(qp->filename, binpath(NULL)));
+	assert(!strcmp(qp->comm, "true"));
+	assert(!strcmp(qp->filename, "/bin/true") ||
+	    !strcmp(qp->filename, "/usr/bin/true"));
 	/* check args */
 	quark_cmdline_iter_init(&qcmdi, qp->cmdline, qp->cmdline_len);
 	argc = 0;
@@ -681,18 +666,15 @@ t_fork_exec_exit(const struct test *t, struct quark_queue_attr *qa)
 
 		switch (argc) {
 		case 0:
-			assert(!strcmp(arg, binpath(NULL)));
+			assert(!strcmp(arg, "true"));
 			break;
 		case 1:
-			assert(!strcmp(arg, "-N"));
-			break;
-		case 2:
 			assert(!strcmp(arg, "this"));
 			break;
-		case 3:
+		case 2:
 			assert(!strcmp(arg, "is"));
 			break;
-		case 4:
+		case 3:
 			assert(!strcmp(arg, "nop!"));
 			break;
 		default:
@@ -700,7 +682,7 @@ t_fork_exec_exit(const struct test *t, struct quark_queue_attr *qa)
 		}
 		argc++;
 	}
-	assert(argc == 5);
+	assert(argc == 4);
 	assert(qp->cmdline_len == expected_args_len);
 
 	if (getcwd(path, sizeof(path)) == NULL)
@@ -1471,9 +1453,7 @@ main(int argc, char *argv[])
 	int		  ch, failed, x;
 	struct test	 *t;
 
-	binpath(argv[0]);
-
-	while ((ch = getopt(argc, argv, "1bhklNvVx:")) != -1) {
+	while ((ch = getopt(argc, argv, "1bhklvVx:")) != -1) {
 		switch (ch) {
 		case '1':
 			noforkflag = 1;
@@ -1492,9 +1472,6 @@ main(int argc, char *argv[])
 			break;
 		case 'l':
 			display_tests();
-			break;	/* NOTREACHED */
-		case 'N':
-			exit(0);
 			break;	/* NOTREACHED */
 		case 'v':
 			quark_verbose++;

--- a/true.c
+++ b/true.c
@@ -1,0 +1,5 @@
+int
+main(int argc, char *argv[])
+{
+	return (0);
+}


### PR DESCRIPTION
Basically our tests fork and exec itself with a -N (nop) option, we then look at process events and check if it's what we wanted.

This all worked great before as we used to figure out who we were by readlink(/proc/self/exe), but then I introduced the valgrind tests, where /proc/self/exe is some valgrind binary, not "us" (documented in bbf265bb864edece8e857db9f22cd7df57479a0b), so I changed the way we figure "us" by doing realpath(argv0), which is also bad.

The problem with realpath(argv0) is that it's not sufficient if quark-test was executed via some PATH directory, just copy quark-test into $HOME/bin, and then cd /tmp && quark-test and it will fail, as binpath() won't find it.

So stop this madness, use /bin/true for nop, instead of execing ourselves, which involves us also adding a /bin/true to the initramfs, so one is provided.