### PR TITLE
Resolve relative exec filename in bpf probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ test-valgrind: quark-test
 initramfs:
 	mkdir -p initramfs/bin
 
-initramfs.gz: init quark-mon-static quark-btf-static quark-test-static true initramfs
+initramfs.gz: init quark-mon-static quark-btf-static quark-test-static initramfs
 	$(call assert_no_syslib)
 	cp init initramfs/
 	cp quark-mon-static initramfs/quark-mon
@@ -375,7 +375,7 @@ quark-btf: quark-btf.c manpages.h $(LIBQUARK_TARGET)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
 		-o $@ $< $(LIBQUARK_TARGET) $(EXTRA_LDFLAGS)
 
-quark-test: quark-test.c manpages.h $(LIBQUARK_TARGET)
+quark-test: quark-test.c manpages.h $(LIBQUARK_TARGET) true
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
 		-o $@ $< $(LIBQUARK_TARGET) $(EXTRA_LDFLAGS)
@@ -392,7 +392,7 @@ quark-btf-static: quark-btf.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
 		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
-quark-test-static: quark-test.c manpages.h $(LIBQUARK_STATIC_BIG)
+quark-test-static: quark-test.c manpages.h $(LIBQUARK_STATIC_BIG) true
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
@@ -474,6 +474,7 @@ clean:
 		quark-btf-static	\
 		quark-test		\
 		quark-test-static	\
+		true			\
 		btf_prog_skel.h		\
 		init
 	$(Q)rm -rf initramfs

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -167,7 +167,7 @@ int BPF_PROG(sched_process_exec,
 
     // filename
     field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_FILENAME);
-    size  = read_kernel_str_or_empty_str(field->data, PATH_MAX, binprm->filename);
+    size  = ebpf_resolve_path_to_string(field->data, &p, task);
     ebpf_vl_field__set_size(&event->vl_fields, field, size);
 
     ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);


### PR DESCRIPTION
The filename resolution within elastic/ebpf's exec probe can return relative paths:
```
->2804617 (FORK+EXEC+EXIT)
  COMM  comm=whoami
  CMDL  cmdline=[ ../usr/bin/whoami ]
  CWD   cwd=/tmp
  FNAM  filename=../usr/bin/whoami

->2804726 (FORK+EXEC+EXIT)
  COMM  comm=whoami
  CMDL  cmdline=[ ../usr/share/../bin/whoami ]
  CWD   cwd=/tmp
  FNAM  filename=../usr/share/../bin/whoami
```

This PR updates the probes to resolve the path using the internal function `ebpf_resolve_path_to_string` instead of copying the contents of `binprm->filename`.

Additionally, an ebpf-only test (kprobes still suffers this problem) was added.
To facilitate testing, the Makefile was modified for the `true` binary to be used for local and qemu testing.