### PR TITLE
Add an API for starting upcoming quark-kube-talker

### DIFF
--- a/quark.c
+++ b/quark.c
@@ -2431,6 +2431,7 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 	qa->max_length = 10000;
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
+	qa->kubefd = -1;		/* disabled */
 }
 
 int
@@ -2896,4 +2897,43 @@ quark_queue_get_event(struct quark_queue *qq)
 	gc_collect(qq);
 
 	return (qev);
+}
+
+int
+quark_start_kube_talker(const char *kube_config, pid_t *pid)
+{
+        int     pipefd[2];
+        char    pidbuf[16];
+
+        if (kube_config == NULL || pid == NULL)
+                return (errno = EINVAL, -1);
+
+        *pid = -1;
+        if ((pipe(pipefd)) == -1)
+                err(1, "pipe");
+        if ((*pid = fork()) == -1)
+                err(1, "fork");
+
+        /* parent */
+        if (*pid != 0) {
+                close(pipefd[1]);
+
+                return (pipefd[0]);
+        }
+
+        /* child */
+        close(pipefd[0]);
+
+        if (qclosefrom(3, pipefd[1]) == -1) {
+                qwarn("qclosefrom");
+                qwarnx("not closing child descriptors");
+        }
+
+        snprintf(pidbuf, sizeof(pidbuf), "%d", pipefd[1]);
+
+        if (execl("quark-kube-talker", "quark-kube-talker",
+            kube_config, pidbuf, (char *)NULL) == -1)
+                err(1, "execl");
+
+        return (0);             /* NOTREACHED */
 }

--- a/quark.h
+++ b/quark.h
@@ -48,6 +48,7 @@ int	 quark_queue_block(struct quark_queue *);
 const struct quark_event *quark_queue_get_event(struct quark_queue *);
 int	 quark_queue_get_epollfd(struct quark_queue *);
 void	 quark_queue_get_stats(struct quark_queue *, struct quark_queue_stats *);
+int	 quark_start_kube_talker(const char *, pid_t *);
 int	 quark_dump_process_cache_graph(struct quark_queue *, FILE *);
 int	 quark_dump_raw_event_graph(struct quark_queue *, FILE *, FILE *);
 int	 quark_event_dump(const struct quark_event *, FILE *);
@@ -99,6 +100,7 @@ struct qstr {
 ssize_t	 qread(int, void *, size_t);
 int	 qwrite(int, const void *, size_t);
 ssize_t	 qreadlinkat(int, const char *, char *, size_t);
+int      qclosefrom(int, int);
 int	 isnumber(const char *);
 ssize_t	 readlineat(int, const char *, char *, size_t);
 int	 strtou64(u64 *, const char *, int);
@@ -513,6 +515,7 @@ struct quark_queue_attr {
 	int	max_length;
 	int	cache_grace_time;	/* in ms */
 	int	hold_time;		/* in ms */
+	int	kubefd;			/* quark-kube-talker pipe, -1 disables */
 };
 
 /*

--- a/qutil.c
+++ b/qutil.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 /* Copyright (c) 2024 Elastic NV */
 
+#include <sys/resource.h>
+
 #include <ctype.h>		/* is_digit(3) */
 #include <err.h>
 #include <errno.h>
@@ -66,6 +68,27 @@ qreadlinkat(int dfd, const char *pathname, char *buf, size_t bufsiz)
 	buf[n] = 0;
 
 	return (strlen(pathname));
+}
+
+/*
+ * Like closefrom but can keep one fd open
+ */
+int
+qclosefrom(int lowfd, int keep)
+{
+	int	i;
+	long	highfd;
+
+	highfd = sysconf(_SC_OPEN_MAX);
+	if (highfd < 0 || highfd > INT_MAX)
+		highfd = INT_MAX;
+
+	for (i = lowfd; i < (int)highfd; i++) {
+		if (i != keep)
+			(void)close(i);
+	}
+
+	return (0);
 }
 
 int


### PR DESCRIPTION
This is more preparatory work for kubernetes support.

We have to be flexible, this means being able to run on an environment without multithreading, in an environment with multithreading, and in some gc runtime like golang.

The object is to have "something" that feeds a file descriptor with kubernetes events, this "something" is the upcoming quark-kube-talker.

We tell quark that kubernetes is active by setting up a quark-kube-talker (or whatever), and feeing quark_queue_open with the pipe to read from. For now, management of the filedescriptor is done by the caller, so it must start quark-kube-talker, get the fd, and close on its own.