### PR TITLE
Hanson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,14 @@ ifdef CENTOS7
 CFLAGS+= -std=gnu99 -DNO_PUSH_PRAGMA
 endif
 
-CPPFLAGS?= -D_GNU_SOURCE
+CPPFLAGS+= -D_GNU_SOURCE
+ifndef MUSL
+CPPFLAGS+= -DHAVE_GETPWENT_R
+CPPFLAGS+= -DHAVE_GETGRENT_R
+endif
+ifndef CENTOS7
+CPPFLAGS+= -DHAVE_EXPLICIT_BZERO
+endif
 ifndef SYSLIB
 CPPFLAGS+= -Iinclude
 endif
@@ -105,9 +112,11 @@ LIBQUARK_SRCS:=			\
 	bpf_queue.c		\
 	btfhub.c		\
 	compat.c		\
+	ecs.c			\
+	hanson.c		\
 	kprobe_queue.c		\
-	quark.c			\
 	qbtf.c			\
+	quark.c			\
 	qutil.c
 # CJSON
 # We build the source directly as it's just one file
@@ -347,7 +356,7 @@ test-kernel: initramfs.gz
 # positives.
 #
 test-valgrind: quark-test
-	$(SUDO) QUARK_BTF_PATH=/sys/kernel/btf/vmlinux			\
+	$(SUDO) VALGRIND=1 QUARK_BTF_PATH=/sys/kernel/btf/vmlinux	\
 		valgrind						\
 		--trace-children=no					\
 		--child-silent-after-fork=yes				\

--- a/ecs.c
+++ b/ecs.c
@@ -1,0 +1,624 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright (c) 2025 Elastic NV */
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "quark.h"
+
+static int
+is_interactive(const struct quark_process *qp)
+{
+	u32	major, minor;
+
+	major = qp->proc_tty_major;
+	minor = qp->proc_tty_minor;
+
+	if (major >= 136 && major <= 143)
+		return (1);
+	if (major == 4) {
+		if (minor <= 63)
+			return (1);
+		else if (minor <= 255)
+			return (1);
+	}
+
+	return (0);
+}
+
+static char *
+safe_basename(const char *path)
+{
+	char	*p;
+
+	p = strrchr(path, '/');
+
+	if (p != NULL && p[1] != 0)
+		return (p + 1);
+
+	return (NULL);
+}
+
+static int
+ecs_date(u64 ns, char *buf, size_t buf_len)
+{
+	struct tm	tm;
+	int		r;
+	time_t		s;
+	u64		ms;
+	char		tmp[64];
+
+	s = ns / NS_PER_S;
+	if (gmtime_r(&s, &tm) == NULL)
+		goto bad;
+
+	/* reference: 2016-05-23T08:05:34.853Z */
+	if (strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S.", &tm) == 0)
+		goto bad;
+	ms = ns % NS_PER_S;
+	ms = ms / NS_PER_MS;
+
+	r = snprintf(buf, buf_len, "%s%lluZ", tmp, ms);
+	if (r < 0 || r >= (int)buf_len)
+		goto bad;
+
+	return (0);
+bad:
+	/* So we can call this without checking error */
+	strlcpy(buf, "invalid", buf_len);
+
+	return (-1);
+}
+
+
+static int
+ecs_event_action(struct hanson *h, const struct quark_event *qev, int *first)
+{
+	int	fork, exec, exit, conn_est, conn_closed;
+	int	packet, file;
+	char	buf[64];
+	int	r;
+
+	r = 0;
+	*buf = 0;
+
+	fork = !!(qev->events & QUARK_EV_FORK);
+	exec = !!(qev->events & QUARK_EV_EXEC);
+	exit = !!(qev->events & QUARK_EV_EXIT);
+	conn_est = !!(qev->events & QUARK_EV_SOCK_CONN_ESTABLISHED);
+	conn_closed = !!(qev->events & QUARK_EV_SOCK_CONN_CLOSED);
+	packet = !!(qev->events & QUARK_EV_PACKET);
+	file = !!(qev->events & QUARK_EV_FILE);
+
+	if (fork || exec || exit) {
+		strlcat(buf, "process", sizeof(buf));
+		if (fork)
+			strlcat(buf, "-forked", sizeof(buf));
+		if (exec)
+			strlcat(buf, "-executed", sizeof(buf));
+		if (exit)
+			strlcat(buf, "-exited", sizeof(buf));
+
+	} else if (conn_est || conn_closed) {
+		strlcat(buf, "connection", sizeof(buf));
+		if (conn_est)
+			strlcat(buf, "-established", sizeof(buf));
+		if (conn_closed)
+			strlcat(buf, "-closed", sizeof(buf));
+
+	} else if (packet) {
+		strlcat(buf, "packet", sizeof(buf));
+		if (qev->packet->origin == QUARK_PACKET_ORIGIN_DNS)
+			strlcat(buf, "-dns", sizeof(buf));
+		if (qev->packet->direction == QUARK_PACKET_DIR_INGRESS)
+			strlcat(buf, "-received", sizeof(buf));
+		else if (qev->packet->direction == QUARK_PACKET_DIR_EGRESS)
+			strlcat(buf, "-sent", sizeof(buf));
+
+	} else if (file) {
+		u32 mask = qev->file->op_mask;
+
+		strlcat(buf, "file", sizeof(buf));
+		if (mask & QUARK_FILE_OP_CREATE)
+			strlcat(buf, "-created", sizeof(buf));
+		if (mask & QUARK_FILE_OP_MODIFY)
+			strlcat(buf, "-written", sizeof(buf));
+		if (mask & QUARK_FILE_OP_MOVE)
+			strlcat(buf, "-renamed", sizeof(buf));
+		if (mask & QUARK_FILE_OP_REMOVE)
+			strlcat(buf, "-deleted", sizeof(buf));
+
+	} else {
+		strlcat(buf, "unknown", sizeof(buf));
+		r = -1;
+	}
+
+	hanson_add_key_value(h, "action", buf, first);
+
+	return (r);
+}
+
+static int
+ecs_process_user(struct quark_queue *qq, struct hanson *h,
+    const struct quark_process *qp, int *first)
+{
+	struct quark_passwd	*e_pw, *r_pw, *s_pw;
+	struct quark_group	*e_gr, *r_gr, *s_gr;
+
+	/*
+	 * Fetch usernames
+	 */
+	r_pw = quark_passwd_lookup(qq, qp->proc_uid);
+
+	if (qp->proc_euid == qp->proc_uid)
+		e_pw = r_pw;
+	else
+		e_pw = quark_passwd_lookup(qq, qp->proc_euid);
+
+	if (qp->proc_suid == qp->proc_uid)
+		s_pw = r_pw;
+	else if (qp->proc_suid == qp->proc_euid)
+		s_pw = e_pw;
+	else
+		s_pw = quark_passwd_lookup(qq, qp->proc_suid);
+
+	/*
+	 * Fetch group names
+	 */
+	r_gr = quark_group_lookup(qq, qp->proc_gid);
+
+	if (qp->proc_egid == qp->proc_gid)
+		e_gr = r_gr;
+	else
+		e_gr = quark_group_lookup(qq, qp->proc_egid);
+
+	if (qp->proc_sgid == qp->proc_gid)
+		s_gr = r_gr;
+	else if (qp->proc_sgid == qp->proc_egid)
+		s_gr = e_gr;
+	else
+		s_gr = quark_group_lookup(qq, qp->proc_sgid);
+
+
+	hanson_add_object(h, "user", first);
+	{
+		int	user_first = 1;
+
+		/*
+		 * NOTE process.user.id and process.user.group.id are
+		 * effective, not real.
+		 */
+		hanson_add_key_value_int(h, "id", qp->proc_euid,
+		    &user_first);
+		if (e_pw != NULL)
+			hanson_add_key_value(h, "name", e_pw->name,
+			    &user_first);
+
+		/* process.user.group.* */
+		hanson_add_object(h, "group", &user_first);
+		{
+			int	group_first = 1;
+
+			hanson_add_key_value_int(h, "id", qp->proc_egid,
+			    &group_first);
+			if (e_gr != NULL)
+				hanson_add_key_value(h, "name", e_gr->name,
+				    &group_first);
+		}
+		hanson_close_object(h);
+
+		/* process.real_user.*/
+		hanson_add_object(h, "real_user", &user_first);
+		{
+			int	real_first = 1;
+
+			hanson_add_key_value_int(h, "id", qp->proc_uid,
+			    &real_first);
+			if (r_pw != NULL)
+				hanson_add_key_value(h, "name", r_pw->name,
+				    &real_first);
+		}
+		hanson_close_object(h);
+
+		/* process.real_group.* */
+		hanson_add_object(h, "real_group", &user_first);
+		{
+			int	real_group_first = 1;
+
+			hanson_add_key_value_int(h, "id", qp->proc_gid,
+			    &real_group_first);
+			if (r_gr != NULL)
+				hanson_add_key_value(h, "name", r_gr->name,
+				    &real_group_first);
+		}
+		hanson_close_object(h);
+
+		/* process.saved_user.*/
+		hanson_add_object(h, "saved_user", &user_first);
+		{
+			int	saved_first = 1;
+
+			hanson_add_key_value_int(h, "id", qp->proc_suid,
+			    &saved_first);
+			if (s_pw != NULL)
+				hanson_add_key_value(h, "name", s_pw->name,
+				    &saved_first);
+
+		}
+		hanson_close_object(h);
+
+		/* process.saved_group.* */
+		hanson_add_object(h, "saved_group", &user_first);
+		{
+			int	saved_group_first = 1;
+
+			hanson_add_key_value_int(h, "id", qp->proc_sgid,
+			    &saved_group_first);
+			if (s_gr != NULL)
+				hanson_add_key_value(h, "name", s_gr->name,
+				    &saved_group_first);
+		}
+		hanson_close_object(h);
+	}
+	hanson_close_object(h);
+
+	return (0);
+}
+
+static int
+ecs_process_tty(struct hanson *h, const struct quark_process *qp, int *first)
+{
+	hanson_add_object(h, "tty", first);
+	{
+		int	tty_first = 1;
+
+		hanson_add_object(h, "char_device", &tty_first);
+		{
+			int	char_device_first = 1;
+
+			hanson_add_key_value_int(h, "major", qp->proc_tty_major,
+			    &char_device_first);
+			hanson_add_key_value_int(h, "minor", qp->proc_tty_minor,
+			    &char_device_first);
+		}
+		hanson_close_object(h);
+	}
+	hanson_close_object(h);
+
+	return (0);
+}
+
+static int
+ecs_container(struct hanson *h, const struct quark_event *qev, int *first)
+{
+	const struct quark_process	*qp;
+	struct quark_container		*container;
+	struct quark_pod		*pod;
+	struct label_node		*label;
+
+	if (qev->process == NULL || qev->process->container == NULL ||
+	    qev->process->container->pod == NULL)
+		return (-1);
+
+	qp = qev->process;
+	container = qp->container;
+	pod = container->pod;
+
+	hanson_add_key_value(h, "id", container->container_id, first);
+	hanson_add_key_value(h, "name", container->name, first);
+	/* XXX FIXME we now support more things */
+	hanson_add_key_value(h, "runtime", "fixme", first);
+
+	/* container.label.* */
+	hanson_add_object(h, "labels", first);
+	{
+		int	label_first = 1;
+
+		RB_FOREACH(label, label_tree, &pod->labels) {
+			hanson_add_key_value(h, label->key, label->value, &label_first);
+		}
+	}
+	hanson_close_object(h);
+
+	/* container image */
+	hanson_add_object(h, "image", first);
+	{
+		int	image_first = 1;
+
+		hanson_add_key_value(h, "name", container->image, &image_first);
+		/* FUTURE: hanson_add_key_value(h, "id", container->image_id, &image_first); */
+	}
+	hanson_close_object(h);
+
+	return (0);
+}
+
+static int
+ecs_orchestrator(struct hanson *h, const struct quark_event *qev, int *first)
+{
+	const struct quark_process	*qp;
+	struct quark_container		*container;
+	struct quark_pod		*pod;
+	struct label_node		*label;
+
+	if (qev->process == NULL || qev->process->container == NULL ||
+	    qev->process->container->pod == NULL)
+		return (-1);
+
+	qp = qev->process;
+	container = qp->container;
+	pod = container->pod;
+
+	hanson_add_object(h, "resource", first);
+	{
+		int	resource_first = 1;
+
+		hanson_add_key_value(h, "type", "pod", &resource_first);
+		hanson_add_key_value(h, "name", pod->name, &resource_first);
+		hanson_add_key_value(h, "namespace", pod->ns, &resource_first);
+
+		hanson_add_object(h, "labels", &resource_first);
+		{
+			int	label_first = 1;
+
+			RB_FOREACH(label, label_tree, &pod->labels) {
+				hanson_add_key_value(h,
+				    label->key, label->value, &label_first);
+			}
+		}
+		hanson_close_object(h);
+	}
+	hanson_close_object(h);
+
+	return (0);
+}
+
+static int
+ecs_process(struct quark_queue *qq, struct hanson *h,
+    const struct quark_event *qev, int *first)
+{
+	const struct quark_process	*qp;
+
+	qp = qev->process;
+
+	hanson_add_key_value_int(h, "pid", qp->pid, first);
+
+	if (qp->flags & QUARK_F_PROC) {
+		char	start_time[32];
+
+		hanson_add_key_value(h, "entity_id", (char *)qp->proc_entity_id,
+		    first);
+
+		ecs_date(qp->proc_time_boot, start_time, sizeof(start_time));
+		hanson_add_key_value(h, "start", start_time, first);
+		hanson_add_key_value_bool(h, "interactive", is_interactive(qp),
+		    first);
+		/* process.user.* */
+		ecs_process_user(qq, h, qp, first);
+		/* process.tty.* */
+		ecs_process_tty(h, qp, first);
+	}
+
+	if (qp->flags & QUARK_F_COMM)
+		hanson_add_key_value(h, "name", (char *)qp->comm, first);
+
+	if (qp->flags & QUARK_F_FILENAME)
+		hanson_add_key_value(h, "executable", qp->filename, first);
+
+	if (qp->flags & QUARK_F_CMDLINE) {
+		int	count = 0;
+
+		hanson_add_array(h, "args", first);
+		{
+			struct quark_cmdline_iter	 qcmdi;
+			const char			*arg;
+			int				 cmdline_first = 1;
+
+			quark_cmdline_iter_init(&qcmdi, qp->cmdline, qp->cmdline_len);
+			while ((arg = quark_cmdline_iter_next(&qcmdi)) != NULL) {
+				hanson_add_string(h, (char *)arg,
+				    &cmdline_first);
+				count++;
+			}
+		}
+		hanson_close_array(h);
+		hanson_add_key_value_int(h, "args_count", count, first);
+	}
+
+	if (qp->flags & QUARK_F_CWD)
+		hanson_add_key_value(h, "working_directory", qp->cwd, first);
+
+	if (qp->flags & QUARK_F_EXIT) {
+		char	end_time[32];
+
+		ecs_date(qp->exit_time_event, end_time, sizeof(end_time));
+		hanson_add_key_value(h, "end", end_time, first);
+
+		hanson_add_key_value_int(h, "exit_code", qp->exit_code, first);
+	}
+
+	return (0);
+}
+
+static int
+ecs_socket(struct hanson *h, const struct quark_event *qev, int *first)
+{
+	const struct quark_socket	*qsk;
+	char				 buf[INET6_ADDRSTRLEN];
+
+	qsk = qev->socket;
+
+	/* source.* */
+	hanson_add_object(h, "source", first);
+	{
+		int	source_first = 1;
+
+		if (inet_ntop(qsk->local.af, &qsk->local.addr6,
+		    buf, sizeof(buf)) != NULL) {
+			hanson_add_key_value(h, "address", buf, &source_first);
+			hanson_add_key_value(h, "ip", buf, &source_first);
+			hanson_add_key_value_int(h, "port", ntohs(qsk->local.port), &source_first);
+		}
+	}
+	hanson_close_object(h);
+
+	/* destination.* */
+	hanson_add_object(h, "destination", first);
+	{
+		int	destination_first = 1;
+
+		if (inet_ntop(qsk->remote.af, &qsk->remote.addr6,
+		    buf, sizeof(buf)) != NULL) {
+			hanson_add_key_value(h, "address", buf, &destination_first);
+			hanson_add_key_value(h, "ip", buf, &destination_first);
+			hanson_add_key_value_int(h, "port", ntohs(qsk->remote.port), &destination_first);
+		}
+	}
+	hanson_close_object(h);
+
+	/* network.* */
+	hanson_add_object(h, "network", first);
+	{
+		int	 network_first = 1;
+		char	*afs;
+
+		/* we only have tcp for now */
+		hanson_add_key_value(h, "transport", "tcp", &network_first);
+
+		switch(qsk->local.af) {
+		case AF_INET:
+			afs = "ipv4";
+			break;
+		case AF_INET6:
+			afs = "ipv6";
+			break;
+		default:
+			afs = "unknown";
+			break;
+		}
+
+		hanson_add_key_value(h, "type", afs, &network_first);
+		/* XXX missing direction */
+	}
+	hanson_close_object(h);
+
+	return (0);
+}
+
+static int
+ecs_file(struct quark_queue *qq, struct hanson *h,
+    const struct quark_event *qev, int *first)
+{
+	struct quark_file	*file = qev->file;
+	char			 buf[32], *ext;
+	struct quark_passwd	*pw;
+	struct quark_group	*gr;
+
+	pw = quark_passwd_lookup(qq, file->uid);
+	gr = quark_group_lookup(qq, file->gid);
+	ext = safe_basename(file->path);
+	if (ext != NULL) {
+		ext = strrchr(ext, '.');
+		if (ext != NULL && ext[1] != 0)
+			ext++;
+		else
+			ext = NULL;
+	}
+
+	hanson_add_key_value(h, "path", (char *)file->path, first);
+	if (ext != NULL)
+		hanson_add_key_value(h, "extension", ext, first);
+	hanson_add_key_value_int(h, "inode", file->inode, first);
+	hanson_add_key_value_int(h, "size", file->size, first);
+	hanson_add_key_value_int(h, "uid", file->uid, first);
+	if (pw != NULL)
+		hanson_add_key_value(h, "owner", pw->name, first);
+	hanson_add_key_value_int(h, "gid", file->gid, first);
+	if (gr != NULL)
+		hanson_add_key_value(h, "group", gr->name, first);
+
+	snprintf(buf, sizeof(buf), "0%o", file->mode);
+	hanson_add_key_value(h, "mode", buf, first);
+
+	ecs_date(file->ctime, buf, sizeof(buf));
+	hanson_add_key_value(h, "ctime", buf, first);
+	ecs_date(file->mtime, buf, sizeof(buf));
+	hanson_add_key_value(h, "mtime", buf, first);
+	ecs_date(file->atime, buf, sizeof(buf));
+	hanson_add_key_value(h, "atime", buf, first);
+
+	return (0);
+}
+
+int
+quark_event_to_ecs(struct quark_queue *qq, const struct quark_event *qev,
+    char **buf, size_t *buf_len)
+{
+	struct hanson	h;
+	int		top_first;
+
+	if (qev->events == QUARK_EV_BYPASS)
+		return (errno = EINVAL, -1);
+
+	if (hanson_open(&h) == -1)
+		return (-1);
+
+	top_first = 1;
+	hanson_add_object(&h, "event", &top_first);
+	{
+		int	event_first = 1;
+
+		ecs_event_action(&h, qev, &event_first);
+		hanson_add_key_value(&h, "kind", "event", &event_first);
+	}
+	hanson_close_object(&h);
+
+	if (qev->process != NULL) {
+		hanson_add_object(&h, "process", &top_first);
+		{
+			int	process_first = 1;
+
+			ecs_process(qq, &h, qev, &process_first);
+		}
+		hanson_close_object(&h);
+
+		if (qev->process->container != NULL) {
+			hanson_add_object(&h, "container", &top_first);
+			{
+				int	container_first = 1;
+
+				ecs_container(&h, qev, &container_first);
+			}
+			hanson_close_object(&h);
+
+			hanson_add_object(&h, "orchestrator", &top_first);
+			{
+				int	orchestrator_first = 1;
+
+				ecs_orchestrator(&h, qev, &orchestrator_first);
+			}
+			hanson_close_object(&h);
+		}
+	}
+
+	if (qev->socket != NULL)
+		ecs_socket(&h, qev, &top_first);
+
+	if (qev->file != NULL) {
+		hanson_add_object(&h, "file", &top_first);
+		{
+			int	file_first = 1;
+
+			ecs_file(qq, &h, qev, &file_first);
+		}
+		hanson_close_object(&h);
+	}
+
+	if (hanson_close(&h, buf, buf_len) == -1)
+		return (-1);
+
+	return (0);
+}

--- a/hanson.c
+++ b/hanson.c
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright (c) 2025 Elastic NV */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "quark.h"
+
+int	hanson_add_ascii(struct hanson *, int);
+
+static int
+hanson_add(struct hanson *h, void *data, size_t data_len)
+{
+	size_t	r;
+
+	r = fwrite(data, 1, data_len, h->stream);
+	if (unlikely(r != data_len || ferror(h->stream))) {
+		h->error = 1;
+		return (-1);
+	}
+
+	return (0);
+}
+
+/*
+ * Don't change to char, otherwise it will sign extend on wide characters
+ */
+static inline int
+is_escape_char(u_char c)
+{
+	int	v = 0;
+
+	switch (c) {
+	case '\\':	/* FALLTHROUGH */
+	case '\"':	/* FALLTHROUGH */
+	case '\b':	/* FALLTHROUGH */
+	case '\f':	/* FALLTHROUGH */
+	case '\n':	/* FALLTHROUGH */
+	case '\r':	/* FALLTHROUGH */
+	case '\t':	/* FALLTHROUGH */
+		v = 1;
+		break;
+	default:
+		if (c < 32)
+			v = 1;
+		break;
+	}
+
+	return (v);
+}
+
+static int
+hanson_add_string_escaped(struct hanson *h, char *s)
+{
+	int	 r = 0, len, c;
+	char	*p;
+	char	 unicode_buf[16];
+
+	for (p = s; *p != 0; p++) {
+		c = is_escape_char(*p);
+
+		if (likely(!c)) {
+			hanson_add_ascii(h, *p);
+			continue;
+		}
+
+		hanson_add_ascii(h, '\\');
+		switch (*p) {
+		case '\\':
+			r |= hanson_add_ascii(h, '\\');
+			break;
+		case '\"':
+			r |= hanson_add_ascii(h, '\"');
+			break;
+		case '\b':
+			r |= hanson_add_ascii(h, 'b');
+			break;
+		case '\f':
+			r |= hanson_add_ascii(h, 'f');
+			break;
+		case '\n':
+			r |= hanson_add_ascii(h, 'n');
+			break;
+		case '\r':
+			r |= hanson_add_ascii(h, 'r');
+			break;
+		case '\t':
+			r |= hanson_add_ascii(h, 't');
+			break;
+		default:
+			len = snprintf(unicode_buf, sizeof(unicode_buf),
+			    "u%04x", (u_char)*p);
+			if (likely(len > 0))
+				r |= hanson_add(h, unicode_buf, len);
+			else {
+				h->error = 1;
+				r = -1;
+			}
+			break;
+		}
+	}
+
+	return (r);
+}
+
+static int
+hanson_maybe_first(struct hanson *h, int *first)
+{
+	int	r = 0;
+
+	if (first != NULL) {
+		if (*first == 0)
+			r |= hanson_add_ascii(h, ',');
+		*first = 0;
+	}
+
+	return (r);
+}
+
+static int
+hanson_add_string_lead(struct hanson *h, char *s, char *lead)
+{
+	int	r = 0;
+
+	r |= hanson_add_string(h, s, NULL);
+	r |= hanson_add(h, lead, strlen(lead));
+
+	return (r);
+}
+
+int
+hanson_add_ascii(struct hanson *h, int c)
+{
+	int	r = 0;
+	char	c8;
+
+	c8 = c & 0xff;
+	r |= hanson_add(h, &c8, 1);
+
+	return (r);
+}
+
+int
+hanson_add_string(struct hanson *h, char *s, int *first)
+{
+	int	 r = 0;
+	char	*p;
+	int	 need_escape;
+	size_t	 len;
+
+	r |= hanson_maybe_first(h, first);
+	r |= hanson_add_ascii(h, '"');
+
+	need_escape = 0;
+	for (p = s, len = 0; *p != 0; p++, len++) {
+		if (is_escape_char(*p)) {
+			need_escape = 1;
+			break;
+		}
+	}
+
+	if (need_escape)
+		r |= hanson_add_string_escaped(h, s);
+	else
+		r |= hanson_add(h, s, len);
+
+	r |= hanson_add_ascii(h, '"');
+
+	return (r);
+}
+
+int
+hanson_add_integer(struct hanson *h, int64_t v)
+{
+	int		r = 0, len;
+	char		buf[32];
+
+	len = snprintf(buf, sizeof(buf), "%lld", (long long)v);
+	if (likely(len > 0))
+		r |= hanson_add(h, buf, len);
+	else {
+		h->error = 1;
+		r = -1;
+	}
+
+	return (r);
+}
+
+int
+hanson_add_boolean(struct hanson *h, int v, int *first)
+{
+	int	 r = 0;
+	char	*s = v ? "true" : "false";
+
+	r |= hanson_maybe_first(h, first);
+	r |= hanson_add(h, s, strlen(s));
+
+	return (r);
+}
+
+int
+hanson_add_key_value(struct hanson *h, char *k, char *v, int *first)
+{
+	int	r = 0;
+
+	r |= hanson_add_string(h, k, first);
+	r |= hanson_add_ascii(h, ':');
+	r |= hanson_add_string(h, v, NULL);
+
+	return (r);
+}
+
+int
+hanson_add_key_value_int(struct hanson *h, char *k, int64_t v, int *first)
+{
+	int	r = 0;
+
+	r |= hanson_add_string(h, k, first);
+	r |= hanson_add_ascii(h, ':');
+	r |= hanson_add_integer(h, v);
+
+	return (r);
+}
+
+int
+hanson_add_key_value_bool(struct hanson *h, char *k, int v, int *first)
+{
+	int	r = 0;
+
+	r |= hanson_add_string(h, k, first);
+	r |= hanson_add_ascii(h, ':');
+	r |= hanson_add_boolean(h, v, NULL);
+
+	return (r);
+}
+
+int
+hanson_add_array(struct hanson *h, char *name, int *first)
+{
+	int	r = 0;
+
+	r |= hanson_maybe_first(h, first);
+	r |= hanson_add_string_lead(h, name, ":[");
+
+	return (r);
+}
+
+int
+hanson_close_array(struct hanson *h)
+{
+	return (hanson_add_ascii(h, ']'));
+}
+
+int
+hanson_add_object(struct hanson *h, char *name, int *first)
+{
+	int	r = 0;
+
+	r |= hanson_maybe_first(h, first);
+	r |= hanson_add_string_lead(h, name, ":{");
+
+	return (r);
+}
+
+int
+hanson_close_object(struct hanson *h)
+{
+	return (hanson_add_ascii(h, '}'));
+}
+
+int
+hanson_open(struct hanson *h)
+{
+	h->error = 0;
+	h->buf_len = 0;
+	h->buf = NULL;
+	if ((h->stream = open_memstream(&h->buf, &h->buf_len)) == NULL)
+		return (-1);
+	if (hanson_add_ascii(h, '{') == -1) {
+		fclose(h->stream);
+		h->buf_len = 0;
+		h->buf = NULL;
+		h->stream = NULL;
+
+		return (-1);
+	}
+
+	return (0);
+}
+
+int
+hanson_close(struct hanson *h, char **buf, size_t *buf_len)
+{
+	int	r = 0;
+
+	r |= hanson_add_ascii(h, '}');
+	r |= hanson_add_ascii(h, 0);
+	if (fclose(h->stream) != 0)
+		h->error = 1;
+	if (h->error) {
+		free(h->buf);
+		r = -1;
+	} else {
+		*buf = h->buf;
+		*buf_len = h->buf_len;
+	}
+	h->buf = NULL;
+	h->buf_len = 0;
+
+	return (r);
+}

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl BbDeFkMNSstv
+.Op Fl BbDEeFkMNSstv
 .Op Fl C Ar filename
 .Op Fl l Ar maxlength
 .Op Fl m Ar maxnodes
@@ -52,6 +52,8 @@ dot -Tsvg filename -o filename.svg
 .It Fl D
 Drop priviledges to nobody and chroot to /var/empty, useful to show how quark
 can run without priviledges.
+.It Fl E
+Output ECS JSON to stdout (experimental).
 .It Fl e
 Include
 .Em proc_entry_leader

--- a/quark-test.c
+++ b/quark-test.c
@@ -1261,6 +1261,51 @@ t_cgroup_parse(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
+static int
+t_hanson(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct hanson	 h;
+	char		*buf;
+	size_t		 buf_len;
+	int		 top_first = 1;
+	const char	*expected =
+	    "{\"mytest\":{"
+	    ",\"esc_bslash\":\"_\\\\_\","
+	    "\"esc_dquote\":\"_\\\"_\","
+	    "\"esc_bspace\":\"_\\b_\","
+	    "\"esc_feed\":\"_\\f_\","
+	    "\"esc_nl\":\"_\\n_\","
+	    "\"esc_cr\":\"_\\r_\","
+	    "\"esc_tab\":\"_\\t_\","
+	    "\"esc_unicode\":\"_\\u0001_\""
+	    "}}";
+
+	assert(hanson_open(&h) == 0);
+
+	hanson_add_object(&h, "mytest", &top_first);
+	/* Test escaped strings */
+	hanson_add_key_value(&h, "esc_bslash", "_\\_", &top_first);
+	hanson_add_key_value(&h, "esc_dquote", "_\"_", &top_first);
+
+	hanson_add_key_value(&h, "esc_bspace", "_\b_", &top_first);
+	hanson_add_key_value(&h, "esc_feed", "_\f_", &top_first);
+	hanson_add_key_value(&h, "esc_nl", "_\n_", &top_first);
+	hanson_add_key_value(&h, "esc_cr", "_\r_", &top_first);
+	hanson_add_key_value(&h, "esc_tab", "_\t_", &top_first);
+	hanson_add_key_value(&h, "esc_unicode", "_\1_", &top_first);
+	hanson_close_object(&h);
+
+	assert(hanson_close(&h, &buf, &buf_len) == 0);
+
+	if (strcmp(buf, expected)) {
+		errx(1, "json doesn't match\n got: %s\nwant: %s\n",
+		    buf, expected);
+	}
+	free(buf);
+
+	return (0);
+}
+
 /*
  * Try to order by increasing order of complexity
  */
@@ -1285,6 +1330,7 @@ struct test all_tests[] = {
 	T(t_cache_grace),
 	T(t_min_agg),
 	T(t_stats),
+	T_EBPF(t_hanson),
 	{ NULL,	NULL, 0, 0 }
 };
 #undef S


### PR DESCRIPTION
This introduces Hanson and quark_event_to_ecs(), so we can convert a quark event
to the json ecs format.

Hanson is really just helpers for generating json, it doesn't keep structure, it
can't parse json, it's really just a serializer, it should be pretty fast since
we only do one allocation, done by open_memstream() in glibc that is 8KB which
is more than enough to hold one document, so that means one allocation per
document.

This is a step into publishing the ECS documents ourselves in elasticsearch.

While here, also build the map of usernames and groups, this is not fully
re-entrant as setpwent() and endpwent() share global state, but it's the best we
can do right now. When glibc does getpwent() it lazily dlopens nss_switch and
never closes, so valgrind think there is leak, so escape the database during
valgrind tests.