### PR TITLE
Add a probe for arch_ptrace

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -760,6 +760,7 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_enter_shmget, 1);
 		bpf_program__set_autoload(p->progs.module_load, 1);
 		bpf_program__set_autoload(p->progs.kprobe__ptrace_attach, 1);
+		bpf_program__set_autoload(p->progs.kprobe__arch_ptrace, 1);
 	}
 
 	if (qq->flags & QQ_TTY) {

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -356,6 +356,8 @@ struct ebpf_process_ptrace_event {
     struct ebpf_pid_info pids;
     uint32_t child_pid;
     int64_t request;
+    uint64_t addr;
+    uint64_t data;
 } __attribute__((packed));
 
 struct ebpf_process_load_module_event {

--- a/quark.c
+++ b/quark.c
@@ -774,7 +774,7 @@ pod_delete(struct quark_queue *qq, struct quark_pod *pod)
 	}
 
 	free(pod->name);
-	free(pod->namespace);
+	free(pod->ns);
 	free(pod->uid);
 	free(pod->phase);
 	free(pod);
@@ -1013,10 +1013,10 @@ process_kube_event(struct quark_queue *qq, cJSON *json)
 		RB_INIT(&pod->containers);
 		RB_INIT(&pod->labels);
 		pod->name = strdup(name->valuestring);
-		pod->namespace = strdup(namespace->valuestring);
+		pod->ns = strdup(namespace->valuestring);
 		pod->uid = strdup(uid->valuestring);
 		if (pod->name == NULL ||
-		    pod->namespace == NULL ||
+		    pod->ns == NULL ||
 		    pod->uid == NULL) {
 			pod_delete(qq, pod);
 			return (-1);
@@ -1848,7 +1848,7 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 
 			fl = "POD";
 			PF(fl, "name=%s namespace=%s\n",
-			    pod->name, pod->namespace);
+			    pod->name, pod->ns);
 			PF(fl, "uid=%s phase=%s\n",
 			    pod->uid, pod->phase);
 			PF(fl, "labels=");

--- a/quark.h
+++ b/quark.h
@@ -526,7 +526,7 @@ struct quark_pod {
 	RB_ENTRY(quark_pod)	 entry_by_uid;
 	int			 linked;	/* true if entry_by_uid is linked */
 	char			*name;
-	char			*namespace;
+	char			*ns;
 	char			*uid;
 	struct label_tree	 labels;
 	struct pod_containers	 containers;


### PR DESCRIPTION
This will allow for the collection the other ptrace requests. Before this commit, only PTRACE_ATTACH was collected. This commit enables the capture of, for example, PTRACE_SETREGS, and grabs the data being set as well.

https://elixir.bootlin.com/linux/v5.0.21/source/kernel/ptrace.c#L1155

Also, the struct member `namespace` was trouble for c++ despite the header being included like this:
```
    extern "C" {
        #include "quark.h"
    }
```
So, rename `namespace` to `ns`.