### PR TITLE
Add quark_sysinfo and more ECS fields

### DIFF
--- a/quark-kube-talker.go
+++ b/quark-kube-talker.go
@@ -119,6 +119,6 @@ func forward(f *os.File, pod *v1.Pod) {
 	if err != nil {
 		panic(err.Error())
 	}
-	// pretty, _ := json.MarshalIndent(obj, "", "  ")
-	// fmt.Printf("%s\n", pretty)
+	// pretty, _ := json.MarshalIndent(pod, "", "  ")
+	// fmt.Fprintf(os.Stderr, "%s\n", pretty)
 }

--- a/quark.h
+++ b/quark.h
@@ -102,18 +102,19 @@ struct qstr {
 	char	 small[64];
 };
 
-ssize_t	 qread(int, void *, size_t);
-int	 qwrite(int, const void *, size_t);
-ssize_t	 qreadlinkat(int, const char *, char *, size_t);
-int	 qclosefrom(int, int);
-int	 isnumber(const char *);
-ssize_t	 readlineat(int, const char *, char *, size_t);
-int	 strtou64(u64 *, const char *, int);
-char	*find_line(FILE *, const char *);
-char	*find_line_p(const char *, const char *);
-char	*load_file_nostat(int, size_t *);
-char	*load_file_path_nostat(const char *, size_t *);
-int	 ipv6_supported(void);
+ssize_t		 qread(int, void *, size_t);
+int		 qwrite(int, const void *, size_t);
+ssize_t		 qreadlinkat(int, const char *, char *, size_t);
+int		 qclosefrom(int, int);
+int		 isnumber(const char *);
+ssize_t		 readlineat(int, const char *, char *, size_t);
+int		 strtou64(u64 *, const char *, int);
+char		*find_line(FILE *, const char *);
+char		*find_line_p(const char *, const char *);
+char		*load_file_nostat(int, size_t *);
+char		*load_file_path_nostat(const char *, size_t *);
+int		 ipv6_supported(void);
+const char	*safe_basename(const char *);
 
 enum quark_verbosity_levels {
 	QUARK_VL_SILENT,
@@ -546,7 +547,10 @@ struct quark_container {
 	struct quark_pod		*pod;		/* backpointer to owner */
 	char				*name;
 	char				*image;
-	char				*image_id;	/* do we want this? */
+	char				*image_id;
+	char				*image_name;
+	char				*image_tag;
+	char				*image_hash;
 };
 
 /*
@@ -613,6 +617,32 @@ struct quark_group {
 	char			*name;
 };
 
+/*
+ * General system information, static and stored in quark_queue.
+ */
+struct quark_sysinfo {
+	char	 *boot_id;
+	char	 *hostname;
+	char	**ip_addrs;	/* Solely for ECS generation */
+	size_t	  ip_addrs_len;
+	char	**mac_addrs;	/* Solely for ECS generation */
+	size_t	  mac_addrs_len;
+	/* uname(2) */
+	char	 *uts_sysname;
+	char	 *uts_nodename;
+	char	 *uts_release;
+	char	 *uts_version;
+	char	 *uts_machine;
+	/* /etc/os-release */
+	char	 *os_name;
+	char	 *os_version;
+	char	 *os_release_type;
+	char	 *os_id;
+	char	 *os_version_id;
+	char	 *os_version_codename;
+	char	 *os_pretty_name;
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -663,6 +693,7 @@ struct quark_queue {
 	struct socket_by_src_dst	 socket_by_src_dst;
 	struct passwd_by_uid		 passwd_by_uid;
 	struct group_by_gid		 group_by_gid;
+	struct quark_sysinfo		 sysinfo;
 	struct quark_event		 event_storage;
 	struct quark_queue_stats	 stats;
 	const u8			(*agg_matrix)[RAW_NUM_TYPES];

--- a/qutil.c
+++ b/qutil.c
@@ -302,3 +302,16 @@ qlog_func(int pri, int do_errno, const char *func, int lineno,
 
 	va_end(ap);
 }
+
+const char *
+safe_basename(const char *path)
+{
+	char	*p;
+
+	p = strrchr(path, '/');
+
+	if (p != NULL && p[1] != 0)
+		return (p + 1);
+
+	return (NULL);
+}


### PR DESCRIPTION
This enriches ecs with the following fields.
 - process.thread.capabilities.{effective,permitted}
 - process.parent.*a
 - container.runtime
 - container.name
 - container.tag
 - container.hash
 - host.hostname
 - host.name
 - host.architecture
 - host.ip
 - host.mac
 - host.os.kernel
 - host.os.name
 - host.os.version
 - host.os.full
 - host.os.release_type

--

For capabilities, it's basically just converting the uint64_t we have into the
very-very-very large ECS representation, we build the table of capabilities to
strings manually, meaning we have to update it into the future, this is better
than having to link against libcap just to do a string conversion.

For the container.* additions, it's basically just massaging the data we already
have, so nothing new.

For host.* we need a whole lot of things, this whole lot is quark_sysinfo, we
build it on boot and then forget, in the future, we need to be able to detect
some changes and update it accordingly, for example, if ip addresses change, for
now we don't care.

We parse /etc/os-release for a bunch of host.* things.

For host.ip and host.mac we go through getifaddrs(3), this requires some
pre-processing for it to remain in the format ECS wants. The current code is
good enough for ECS, but in the future quark should have its own abstraction of
network interfaces with addresses and so on, which would not be stored as a
string.