### PR TITLE
Avoid taskstats_exit and sched_process_exit

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -637,12 +637,12 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	 */
 	bpf_program__set_autoload(p->progs.sched_process_fork, 1);
 	bpf_program__set_autoload(p->progs.sched_process_exec, 1);
-	bpf_program__set_autoload(p->progs.sched_process_exit, 1);
 
 	if (use_fentry)
-		bpf_program__set_autoload(p->progs.fentry__taskstats_exit, 1);
+		bpf_program__set_autoload(p->progs.fentry__disassociate_ctty, 1);
 	else
-		bpf_program__set_autoload(p->progs.kprobe__taskstats_exit, 1);
+		bpf_program__set_autoload(p->progs.kprobe__disassociate_ctty, 1);
+
 	/* Used in process probes, so always on */
 	if (relo_member(btf, &off, "iov_iter", "__iov") != -1)
 		p->rodata->off__iov_iter____iov__ = off;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -196,24 +196,20 @@ out:
 // The problem is taskstats_exit__enter happens before file descriptors are
 // closed in exit_files(), so instead of emiting the event here, record that we
 // saw group_dead and delay emiting the event until sched_process_exit().
-static int taskstats_exit__enter(const struct task_struct *task, int group_dead)
+//
+// UPDATE: taskstats_exit can be compiled out of the kernel based on
+// configuration. So, instead we use disassociate_ctty (guarded by CONFIG_TTY),
+// which is hopefully less common of being compiled out. disassociate_ctty is
+// called from do_exit() only when group_dead is true, and in that case,
+// the parameter, on_exit, is set to true, and we can use current to populate
+// event data. Finally, sched_process_exit() is not called after exit_files,
+// but disassociate_ctty is.
+static int disassociate_ctty__enter(int on_exit)
 {
-    struct ebpf_events_state state = {};
-
-    if (!group_dead || is_kernel_thread(task))
-        return 0;
-
-    ebpf_events_state__set(EBPF_EVENTS_STATE_GROUP_DEAD, &state);
-
-    return 0;
-}
-
-SEC("tp_btf/sched_process_exit")
-int BPF_PROG(sched_process_exit, const struct task_struct *task)
-{
+    const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     struct ebpf_process_exit_event *event;
 
-    if (ebpf_events_state__get(EBPF_EVENTS_STATE_GROUP_DEAD) == NULL)
+    if (!on_exit || is_kernel_thread(task))
         return 0;
 
     event = get_event_buffer();
@@ -248,16 +244,16 @@ int BPF_PROG(sched_process_exit, const struct task_struct *task)
     return 0;
 }
 
-SEC("fentry/taskstats_exit")
-int BPF_PROG(fentry__taskstats_exit, const struct task_struct *task, int group_dead)
+SEC("fentry/disassociate_ctty")
+int BPF_PROG(fentry__disassociate_ctty, int on_exit)
 {
-    return taskstats_exit__enter(task, group_dead);
+    return disassociate_ctty__enter(on_exit);
 }
 
-SEC("kprobe/taskstats_exit")
-int BPF_KPROBE(kprobe__taskstats_exit, const struct task_struct *task, int group_dead)
+SEC("kprobe/disassociate_ctty")
+int BPF_KPROBE(kprobe__disassociate_ctty, int on_exit)
 {
-    return taskstats_exit__enter(task, group_dead);
+    return disassociate_ctty__enter(on_exit);
 }
 
 // tracepoint/syscalls/sys_[enter/exit]_[name] tracepoints are not available

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -21,8 +21,7 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_WRITE          = 7,
     EBPF_EVENTS_STATE_WRITEV         = 8,
     EBPF_EVENTS_STATE_CHOWN          = 9,
-    EBPF_EVENTS_STATE_GROUP_DEAD     = 10,
-    EBPF_EVENTS_STATE_FS_CREATE      = 11,
+    EBPF_EVENTS_STATE_FS_CREATE      = 10,
 };
 
 struct ebpf_events_key {
@@ -93,7 +92,6 @@ struct ebpf_events_state {
         struct ebpf_events_write_state write;
         struct ebpf_events_writev_state writev;
         struct ebpf_events_chown_state chown;
-        /* struct ebpf_events_group_dead group_dead; nada */
         /* struct ebpf_events_fs_create fs_create; nada */
     };
 };


### PR DESCRIPTION
`taskstats_exit` can be compiled out based on kernel configuration. Instead use `disassociate_ctty(1)` as an indication that `group_dead` has been set. `sched_process_exit` is called before `exit_files`, so it's possible that a socket disconnect event could be emitted after a process termination. Instead use `exit_task_namespaces` to emit the exit event. We had little choice in the matter since `sched_process_exit` is executed before `disassociate_ctty`, but `sched_process_exit` was still the incorrect spot to emit an exit event and worth noting.

Another solution possibility (not taken here) was to use `exit_notify` since it has both the task and `group_dead` as parameters, and occurs after `exit_files`. We would only need one probe in that case. However, the function is static, and could *possibly* be inlined. Though that has not been observed.

UPDATE: `exit_notify` is compiled out in several of the CI kernels. So, we now depend on `TTY_CONFIG`.