### PR TITLE
Try harder to get a cgroup2 root mounting point

### DIFF
--- a/quark.h
+++ b/quark.h
@@ -112,6 +112,7 @@ int	 strtou64(u64 *, const char *, int);
 char	*find_line(FILE *, const char *);
 char	*find_line_p(const char *, const char *);
 char	*load_file_nostat(int, size_t *);
+char	*load_file_path_nostat(const char *, size_t *);
 int	 ipv6_supported(void);
 
 enum quark_verbosity_levels {

--- a/qutil.c
+++ b/qutil.c
@@ -238,6 +238,21 @@ load_file_nostat(int fd, size_t *total)
 	return (buf);
 }
 
+char *
+load_file_path_nostat(const char *path, size_t *total)
+{
+	int	 fd;
+	char	*buf;
+
+	if ((fd = open(path, O_RDONLY)) == -1)
+		return (NULL);
+
+	buf = load_file_nostat(fd, total);
+	close(fd);
+
+	return (buf);
+}
+
 int
 ipv6_supported(void)
 {


### PR DESCRIPTION
his looks up the path for cgroup2, in case it's not in /sys/fs/cgroup, but more
importantly, it makes sure /sys/fs/cgroup is a cgroup2, and if not, it attempts
to mount a temporary cgroup2 for loading the DNS probes.

On some systems, cgroup2 is not mounted by default, even though the kernel
supports it.

For DNS and/or every future cgroup probe to function, we need to fetch the
cgroup mounting point pass it to bpf_probes__load(). After that the fd is not
really needed, we can close and also unmount the temporary cgroup2 mount we
might have created.

Idea from Nick.