### PR TITLE
Make Hanson ~Super^W Fast (tm)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ CPPFLAGS+= -DHAVE_GETGRENT_R
 endif
 ifndef CENTOS7
 CPPFLAGS+= -DHAVE_EXPLICIT_BZERO
+CPPFLAGS+= -DHAVE_REALLOCARRAY
 endif
 ifndef SYSLIB
 CPPFLAGS+= -Iinclude
@@ -189,7 +190,8 @@ all:	$(LIBQUARK_TARGET)		\
 	quark-mon			\
 	quark-btf			\
 	quark-test			\
-	quark-kube-talker
+	quark-kube-talker		\
+	hanson-bench
 
 $(ZLIB_STATIC): $(ZLIB_FILES)
 	$(call assert_no_syslib)
@@ -385,6 +387,11 @@ true: true.c
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) -static -o $@ $^
 
+hanson-bench: hanson-bench.c $(LIBQUARK_TARGET)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
+		-o $@ $< $(LIBQUARK_TARGET) $(EXTRA_LDFLAGS)
+
 quark-mon: quark-mon.c manpages.h $(LIBQUARK_TARGET)
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
@@ -490,6 +497,7 @@ clean:
 	$(Q)rm -f			\
 		*.o			\
 		*.a			\
+		hanson-bench		\
 		man-embedder		\
 		manpages.h		\
 		quark-mon		\

--- a/compat.c
+++ b/compat.c
@@ -212,3 +212,38 @@ sshbuf_dump_data(const void *s, size_t len, FILE *f)
 		fprintf(f, "\n");
 	}
 }
+
+#ifndef HAVE_REALLOCARRAY
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+#endif	/* HAVE_REALLOCARRAY */

--- a/compat.h
+++ b/compat.h
@@ -70,6 +70,10 @@ long long	strtonum(const char *, long long, long long, const char **);
  */
 void		sshbuf_dump_data(const void *, size_t, FILE *);
 
+#ifndef HAVE_REALLOCARRAY
+void		*reallocarray(void *, size_t, size_t);
+#endif	/* HAVE_REALLOCARRAY */
+
 /*
  * Base64, portable version of b64_*, so we don't have to link with libresolv
  */

--- a/hanson-bench.c
+++ b/hanson-bench.c
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright (c) 2024 Elastic NV */
+
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "quark.h"
+
+const char *words[] = {
+	"Tennysonian",
+	"hexadactylic",
+	"quasi-necessary",
+	"kukupa",
+	"affirmatory",
+	"oyez",
+	"multiple-pass",
+	"burnettized",
+	"headrest",
+	"complementation",
+	"bookkeeper",
+	"Pseudo-european",
+	"Nosema",
+	"rojak",
+	"fortunetelling",
+	"OSME",
+	"three-pair",
+	"unadornable",
+	"Perieres",
+	"Camelina",
+	"yohimbi",
+	"ossetic",
+	"Yelisavetpol",
+	"infixal",
+	"spincaster",
+	"Bethylidae",
+	"Teleoceras",
+	"pedialgia",
+	"Ettinger",
+	"biogenetical",
+	"kapellmeister",
+	"grantable",
+	"gonne",
+	"perpetuities",
+	"nonentries",
+	"contours",
+	"unentangle",
+	"phthoric",
+	"multiserver",
+	"sericiculturist",
+	"jackeen",
+	"Waldman",
+	"slich",
+	"dimples",
+	"lacework",
+	"bandicoot",
+	"splenopexia",
+	"Cassidulina",
+	"egressed",
+	"malaromas",
+	"formulators",
+	"penalising",
+	"stuffier",
+	"pawk",
+	"Polad",
+	"mastix",
+	"gimbri",
+	"scarious",
+	"procreatress",
+	"undeferrable",
+	"countercompetition",
+	"superload",
+	"hypoionian",
+	"diphosphate",
+	"nonambitiousness",
+	"deleading",
+	"gasless",
+	"marabouts",
+	"geomorphic",
+	"grand-slammer",
+	"knockstone",
+	"sister",
+	"strangerdom",
+	"downlier",
+	"wet-plate",
+	"consult",
+	"palew",
+	"Orbitelariae",
+	"Grouchy",
+	"Lian",
+	"draftings",
+	"lip-blushing",
+	"nonmoderateness",
+	"outright",
+	"dowery",
+	"attendance",
+	"Sabia",
+	"Hayari",
+	"blastophore",
+	"overcapitalizes",
+	"unsartorially",
+	"Sc",
+	"homozygote",
+	"superornamental",
+	"boigid",
+	"expostulations",
+	"Squamipennes",
+	"lyreflower",
+	"accuracy",
+	"Chicora",
+	"Olwena",
+	"Exchequer",
+	"diatropism",
+	"Tizes",
+	"quasi-private",
+	"physiosophy",
+	"acyanopsia",
+	"obtruded",
+	"unsolubleness",
+	"low-born",
+	"black-stoled",
+	"Neotoma",
+	"Ashburnham",
+	"hexaplaric",
+	"nonprescriber",
+	"parisonic",
+	"negativate",
+	"cyan-",
+	"Rhaeto-romanic",
+	"consimile",
+	"sandy-flaxen",
+	"aggravation",
+	"antesignanus",
+	"nonconversableness",
+	"leasemonger",
+	"pakpak-lauin",
+	"Ciboney",
+	"caranx",
+	"chemokinesis",
+	"brere",
+	"roughleg",
+	"haunches",
+	"Berard",
+	"lactucerin",
+	"Calderca",
+	"metapostscutellum",
+	"pind",
+	"Perceval",
+	"Post-copernican",
+	"hypophyllous",
+	"Eleazar",
+	"ambuscadoed",
+	"quick-wittedly",
+	"unchaplain",
+	"Pleuronectidae",
+	"shamoys",
+	"amoebula",
+	"pass",
+	"raunchily",
+	"unregained",
+	"litteratim",
+	"asterion",
+	"haunts",
+	"Maribor",
+	"prussianising",
+	"amphibians",
+	"outbreathe",
+	"interrupter",
+	"scabrate",
+	"oilstone",
+	"semiminim",
+	"Eruca",
+	"nongravities",
+	"Cottageville",
+	"alloisomerism",
+	"guacin",
+	"nonimperious",
+	"antrustion",
+	"Moresco",
+	"Lashond",
+	"manorial",
+	"allotter",
+	"neutralization",
+	"rattan",
+	"deducer",
+	"Bevin",
+	"feeblenesses",
+	"a-borning",
+	"IRD",
+	"omentotomy",
+	"gweducks",
+	"unalienably",
+	"sophic",
+	"imputrid",
+	"ender",
+	"Brunonia",
+	"outskipped",
+	"approximately",
+	"misconceives",
+	"Silma",
+	"rutherfordium",
+	"devil-fish",
+	"cauldrife",
+	"hand-fives",
+	"suggestiveness",
+	"chinoline",
+	"Coors",
+	"thermo",
+	"Drina",
+	"Sorbonne",
+};
+
+static int
+string_bench(char **buf, size_t *buf_len)
+{
+	struct hanson	h;
+	int		i, first = 1;
+
+	if (hanson_open(&h) == -1)
+		return (-1);
+
+	hanson_add_array(&h, "string_bench", NULL);
+
+	for (i = 0; i < (int)nitems(words); i++)
+		hanson_add_string(&h, (char *)words[i], &first);
+
+	hanson_close_array(&h);
+
+	if (hanson_close(&h, buf, buf_len) == -1)
+		return (-1);
+
+	return (0);
+}
+
+static int
+int_bench(char **buf, size_t *buf_len)
+{
+	struct hanson	h;
+	int		i, first = 1;
+
+	if (hanson_open(&h) == -1)
+		return (-1);
+
+	hanson_add_array(&h, "int_bench", NULL);
+
+	/*
+	 * Add zero to 3 digit numbers
+	 */
+	for (i = 0; i < 300; i++)
+		hanson_add_integer(&h, i, &first);
+	/*
+	 * Add really long numbers, so we can average short + long numbers.
+	 * Long numbers are actually cheaper by byte, as in we get better
+	 * throughput if we use only long.
+	 */
+	for (i = 0; i < 300; i++)
+		hanson_add_integer(&h, INT64_MAX - (int64_t)i, &first);
+
+	hanson_close_array(&h);
+
+	if (hanson_close(&h, buf, buf_len) == -1)
+		return (-1);
+
+	return (0);
+}
+
+static int
+comb_bench(char **buf, size_t *buf_len)
+{
+	struct hanson	h;
+	int		i, first = 1;
+
+	if (hanson_open(&h) == -1)
+		return (-1);
+
+	hanson_add_array(&h, "comb_bench", NULL);
+
+	for (i = 0; i < (int)nitems(words); i++)
+		hanson_add_key_value_int(&h, (char *)words[i], i, &first);
+
+	hanson_close_array(&h);
+
+	if (hanson_close(&h, buf, buf_len) == -1)
+		return (-1);
+
+	return (0);
+}
+
+static void
+run_bench(int (*bench)(char **, size_t *), int iterations)
+{
+	struct timespec	 start, end;
+	double		 time_spent, doc_per_s, doc_size, mb_per_s;
+	int		 i;
+	char		*buf;
+	size_t		 buf_len;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &start) == -1)
+		err(1, "clock_gettime");
+
+	for (i = 0; i < iterations; i++) {
+		if (bench(&buf, &buf_len) == -1)
+			err(1, "failed");
+		free(buf);
+	}
+
+	if (clock_gettime(CLOCK_MONOTONIC, &end) == -1)
+		err(1, "clock_gettime");
+
+	time_spent = (double)(end.tv_sec - start.tv_sec) +
+	    (double)(end.tv_nsec - start.tv_nsec) / 1000000000.0;
+	doc_per_s = iterations / time_spent;
+	doc_size = (double)buf_len / 1000.0;
+	mb_per_s = (((double)buf_len * (double)iterations) / time_spent) /
+	    1000.0 / 1000.0;
+
+	printf("Time elapsed: %f seconds\n", time_spent);
+	printf("Documents per second: %.2f\n", doc_per_s);
+	printf("Document size: %.2fKB\n", doc_size);
+	printf("Throughput: %.2fMB/s\n", mb_per_s);
+}
+
+static void
+usage(void)
+{
+	fprintf(stderr, "usage: %s [benchmark]\n", program_invocation_short_name);
+	fprintf(stderr, "benchmarks: string* int combined\n");
+
+	exit(1);
+}
+
+int
+main(int argc, char *argv[])
+{
+	const char *bench;
+
+	if (argc == 1)
+		bench = "string";
+	else if (argc == 2)
+		bench = argv[1];
+	else
+		usage();
+
+	if (!strncmp(bench, "comb", 4))
+		run_bench(comb_bench, 1000000);
+	else if (!strcmp(bench, "string"))
+		run_bench(string_bench, 1000000);
+	else if (!strcmp(bench, "int"))
+		run_bench(int_bench, 100000);
+	else
+		usage();
+
+	return (0);
+}

--- a/hanson.c
+++ b/hanson.c
@@ -7,20 +7,73 @@
 
 #include "quark.h"
 
-int	hanson_add_ascii(struct hanson *, int);
+int	hanson_add_ascii(struct hanson *, char);
 
-static int
-hanson_add(struct hanson *h, void *data, size_t data_len)
+static inline size_t
+hanson_space_left(struct hanson *h)
 {
-	size_t	r;
+	return ((h->buf + h->buf_len) - h->buf_w);
+}
 
-	r = fwrite(data, 1, data_len, h->stream);
-	if (unlikely(r != data_len || ferror(h->stream))) {
+/*
+ * Don't make it inline or static, otherwise code grows too much, this is the
+ * slow path, we lose around 20% perf if we inline here.
+ */
+int	hanson_grow(struct hanson *h);
+
+int
+hanson_grow(struct hanson *h)
+{
+	char	*new_buf;
+
+	if (h->error)
+		return (-1);
+	new_buf = reallocarray(h->buf, h->buf_len, 2);
+	if (unlikely(new_buf == NULL)) {
 		h->error = 1;
 		return (-1);
 	}
+	h->buf_w = new_buf + (h->buf_w - h->buf);
+	h->buf = new_buf;
+	h->buf_len *= 2;	/* keep in sync with reallocarray */
 
 	return (0);
+}
+
+static inline int
+hanson_add(struct hanson *h, void *data, size_t data_len)
+{
+again:
+	if (likely(hanson_space_left(h) >= data_len)) {
+		    memcpy(h->buf_w, data, data_len);
+		    h->buf_w += data_len;
+	} else {
+		if (hanson_grow(h) == -1)
+			return (-1);
+		goto again;
+	}
+
+	return (0);
+}
+
+static inline int
+hanson_add_ascii_inline(struct hanson *h, char c) /* inline this is significant */
+{
+	return (hanson_add(h, &c, 1));
+}
+
+static inline int
+hanson_maybe_first(struct hanson *h, int *first)
+{
+	int	r = 0;
+
+	if (first != NULL) {
+		if (*first == 0)
+			r |= hanson_add_ascii_inline(h, ',');
+		*first = 0;
+	}
+
+	return (r);
 }
 
 /*
@@ -60,33 +113,33 @@ hanson_add_string_escaped(struct hanson *h, char *s)
 	for (p = s; *p != 0; p++) {
 		c = is_escape_char(*p);
 
-		if (likely(!c)) {
-			hanson_add_ascii(h, *p);
+		if (!c) {
+			hanson_add_ascii_inline(h, *p);
 			continue;
 		}
 
-		hanson_add_ascii(h, '\\');
+		hanson_add_ascii_inline(h, '\\');
 		switch (*p) {
 		case '\\':
-			r |= hanson_add_ascii(h, '\\');
+			r |= hanson_add_ascii_inline(h, '\\');
 			break;
 		case '\"':
-			r |= hanson_add_ascii(h, '\"');
+			r |= hanson_add_ascii_inline(h, '\"');
 			break;
 		case '\b':
-			r |= hanson_add_ascii(h, 'b');
+			r |= hanson_add_ascii_inline(h, 'b');
 			break;
 		case '\f':
-			r |= hanson_add_ascii(h, 'f');
+			r |= hanson_add_ascii_inline(h, 'f');
 			break;
 		case '\n':
-			r |= hanson_add_ascii(h, 'n');
+			r |= hanson_add_ascii_inline(h, 'n');
 			break;
 		case '\r':
-			r |= hanson_add_ascii(h, 'r');
+			r |= hanson_add_ascii_inline(h, 'r');
 			break;
 		case '\t':
-			r |= hanson_add_ascii(h, 't');
+			r |= hanson_add_ascii_inline(h, 't');
 			break;
 		default:
 			len = snprintf(unicode_buf, sizeof(unicode_buf),
@@ -105,20 +158,6 @@ hanson_add_string_escaped(struct hanson *h, char *s)
 }
 
 static int
-hanson_maybe_first(struct hanson *h, int *first)
-{
-	int	r = 0;
-
-	if (first != NULL) {
-		if (*first == 0)
-			r |= hanson_add_ascii(h, ',');
-		*first = 0;
-	}
-
-	return (r);
-}
-
-static int
 hanson_add_string_lead(struct hanson *h, char *s, char *lead)
 {
 	int	r = 0;
@@ -130,15 +169,9 @@ hanson_add_string_lead(struct hanson *h, char *s, char *lead)
 }
 
 int
-hanson_add_ascii(struct hanson *h, int c)
+hanson_add_ascii(struct hanson *h, char c)
 {
-	int	r = 0;
-	char	c8;
-
-	c8 = c & 0xff;
-	r |= hanson_add(h, &c8, 1);
-
-	return (r);
+	return (hanson_add_ascii_inline(h, c));
 }
 
 int
@@ -150,41 +183,55 @@ hanson_add_string(struct hanson *h, char *s, int *first)
 	size_t	 len;
 
 	r |= hanson_maybe_first(h, first);
-	r |= hanson_add_ascii(h, '"');
+	r |= hanson_add_ascii_inline(h, '"');
 
 	need_escape = 0;
 	for (p = s, len = 0; *p != 0; p++, len++) {
-		if (is_escape_char(*p)) {
+		if (unlikely(is_escape_char(*p))) {
 			need_escape = 1;
 			break;
 		}
 	}
 
-	if (need_escape)
+	if (unlikely(need_escape))
 		r |= hanson_add_string_escaped(h, s);
 	else
 		r |= hanson_add(h, s, len);
 
-	r |= hanson_add_ascii(h, '"');
+	r |= hanson_add_ascii_inline(h, '"');
 
 	return (r);
 }
 
 int
-hanson_add_integer(struct hanson *h, int64_t v)
+hanson_add_integer(struct hanson *h, int64_t vs, int *first)
 {
-	int		r = 0, len;
-	char		buf[32];
+	/* 19 characters for the number + 1 for sign + 2 for paranoia */
+	char	*p, *end, buf[22];
+	int	 negative;
+	u64	 v = vs;
 
-	len = snprintf(buf, sizeof(buf), "%lld", (long long)v);
-	if (likely(len > 0))
-		r |= hanson_add(h, buf, len);
-	else {
-		h->error = 1;
-		r = -1;
-	}
+	hanson_maybe_first(h, first);
 
-	return (r);
+	p = end = buf + sizeof(buf) - 2;
+
+	if (unlikely((int64_t)v < 0)) {
+		negative = 1;
+		v *= -1;
+	} else
+		negative = 0;
+
+	do {
+		*(--p) = (v % 10) + '0';
+		v /= 10;
+	} while (v > 0);
+
+	if (unlikely(negative))
+		*(--p) = '-';
+
+//	printf("p=%s\n", p);
+
+	return (hanson_add(h, p, end - p));
 }
 
 int
@@ -205,7 +252,7 @@ hanson_add_key_value(struct hanson *h, char *k, char *v, int *first)
 	int	r = 0;
 
 	r |= hanson_add_string(h, k, first);
-	r |= hanson_add_ascii(h, ':');
+	r |= hanson_add_ascii_inline(h, ':');
 	r |= hanson_add_string(h, v, NULL);
 
 	return (r);
@@ -217,8 +264,8 @@ hanson_add_key_value_int(struct hanson *h, char *k, int64_t v, int *first)
 	int	r = 0;
 
 	r |= hanson_add_string(h, k, first);
-	r |= hanson_add_ascii(h, ':');
-	r |= hanson_add_integer(h, v);
+	r |= hanson_add_ascii_inline(h, ':');
+	r |= hanson_add_integer(h, v, NULL);
 
 	return (r);
 }
@@ -229,7 +276,7 @@ hanson_add_key_value_bool(struct hanson *h, char *k, int v, int *first)
 	int	r = 0;
 
 	r |= hanson_add_string(h, k, first);
-	r |= hanson_add_ascii(h, ':');
+	r |= hanson_add_ascii_inline(h, ':');
 	r |= hanson_add_boolean(h, v, NULL);
 
 	return (r);
@@ -249,7 +296,7 @@ hanson_add_array(struct hanson *h, char *name, int *first)
 int
 hanson_close_array(struct hanson *h)
 {
-	return (hanson_add_ascii(h, ']'));
+	return (hanson_add_ascii_inline(h, ']'));
 }
 
 int
@@ -266,22 +313,20 @@ hanson_add_object(struct hanson *h, char *name, int *first)
 int
 hanson_close_object(struct hanson *h)
 {
-	return (hanson_add_ascii(h, '}'));
+	return (hanson_add_ascii_inline(h, '}'));
 }
 
 int
 hanson_open(struct hanson *h)
 {
-	h->error = 0;
-	h->buf_len = 0;
-	h->buf = NULL;
-	if ((h->stream = open_memstream(&h->buf, &h->buf_len)) == NULL)
+	bzero(h, sizeof(*h));
+
+	h->buf_len = 1 << 14;
+	if ((h->buf = malloc(h->buf_len)) == NULL)
 		return (-1);
-	if (hanson_add_ascii(h, '{') == -1) {
-		fclose(h->stream);
-		h->buf_len = 0;
-		h->buf = NULL;
-		h->stream = NULL;
+	h->buf_w = h->buf;
+	if (hanson_add_ascii_inline(h, '{') == -1) {
+		free(h->buf);
 
 		return (-1);
 	}
@@ -294,18 +339,17 @@ hanson_close(struct hanson *h, char **buf, size_t *buf_len)
 {
 	int	r = 0;
 
-	r |= hanson_add_ascii(h, '}');
-	r |= hanson_add_ascii(h, 0);
-	if (fclose(h->stream) != 0)
-		h->error = 1;
+	r |= hanson_add_ascii_inline(h, '}');
+	r |= hanson_add_ascii_inline(h, 0);
 	if (h->error) {
 		free(h->buf);
 		r = -1;
 	} else {
 		*buf = h->buf;
-		*buf_len = h->buf_len;
+		*buf_len = h->buf_w - h->buf;
 	}
 	h->buf = NULL;
+	h->buf_w = NULL;
 	h->buf_len = 0;
 
 	return (r);

--- a/quark-test.c
+++ b/quark-test.c
@@ -1267,10 +1267,54 @@ t_hanson(const struct test *t, struct quark_queue_attr *qa)
 	struct hanson	 h;
 	char		*buf;
 	size_t		 buf_len;
-	int		 top_first = 1;
+	int		 basic_first = 1;
+	const char	*expected =
+	    "{\"basic\":{"
+	    "\"foo\":\"bar\","
+	    "\"zero\":0,"
+	    "\"one\":1,"
+	    "\"two\":2,"
+	    "\"neg_one\":-1,"
+	    "\"int64_min\":-9223372036854775808,"
+	    "\"int64_min_plus_one\":-9223372036854775807,"
+	    "\"int64_max\":9223372036854775807"
+	    "}}";
+
+	assert(hanson_open(&h) == 0);
+
+	hanson_add_object(&h, "basic", NULL);
+	/* Test escaped strings */
+	hanson_add_key_value(&h, "foo", "bar", &basic_first);
+	hanson_add_key_value_int(&h, "zero", 0, &basic_first);
+	hanson_add_key_value_int(&h, "one", 1, &basic_first);
+	hanson_add_key_value_int(&h, "two", 2, &basic_first);
+	hanson_add_key_value_int(&h, "neg_one", -1, &basic_first);
+	hanson_add_key_value_int(&h, "int64_min", INT64_MIN, &basic_first);
+	hanson_add_key_value_int(&h, "int64_min_plus_one", -9223372036854775807LL, &basic_first);
+	hanson_add_key_value_int(&h, "int64_max", INT64_MAX, &basic_first);
+	hanson_close_object(&h);
+
+	assert(hanson_close(&h, &buf, &buf_len) == 0);
+
+	if (strcmp(buf, expected)) {
+		errx(1, "json doesn't match\n got: %s\nwant: %s\n",
+		    buf, expected);
+	}
+	free(buf);
+
+	return (0);
+}
+
+static int
+t_hanson_escape(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct hanson	 h;
+	char		*buf;
+	size_t		 buf_len;
+	int		 esc_first = 1;
 	const char	*expected =
 	    "{\"mytest\":{"
-	    ",\"esc_bslash\":\"_\\\\_\","
+	    "\"esc_bslash\":\"_\\\\_\","
 	    "\"esc_dquote\":\"_\\\"_\","
 	    "\"esc_bspace\":\"_\\b_\","
 	    "\"esc_feed\":\"_\\f_\","
@@ -1282,17 +1326,17 @@ t_hanson(const struct test *t, struct quark_queue_attr *qa)
 
 	assert(hanson_open(&h) == 0);
 
-	hanson_add_object(&h, "mytest", &top_first);
+	hanson_add_object(&h, "mytest", NULL);
 	/* Test escaped strings */
-	hanson_add_key_value(&h, "esc_bslash", "_\\_", &top_first);
-	hanson_add_key_value(&h, "esc_dquote", "_\"_", &top_first);
+	hanson_add_key_value(&h, "esc_bslash", "_\\_", &esc_first);
+	hanson_add_key_value(&h, "esc_dquote", "_\"_", &esc_first);
 
-	hanson_add_key_value(&h, "esc_bspace", "_\b_", &top_first);
-	hanson_add_key_value(&h, "esc_feed", "_\f_", &top_first);
-	hanson_add_key_value(&h, "esc_nl", "_\n_", &top_first);
-	hanson_add_key_value(&h, "esc_cr", "_\r_", &top_first);
-	hanson_add_key_value(&h, "esc_tab", "_\t_", &top_first);
-	hanson_add_key_value(&h, "esc_unicode", "_\1_", &top_first);
+	hanson_add_key_value(&h, "esc_bspace", "_\b_", &esc_first);
+	hanson_add_key_value(&h, "esc_feed", "_\f_", &esc_first);
+	hanson_add_key_value(&h, "esc_nl", "_\n_", &esc_first);
+	hanson_add_key_value(&h, "esc_cr", "_\r_", &esc_first);
+	hanson_add_key_value(&h, "esc_tab", "_\t_", &esc_first);
+	hanson_add_key_value(&h, "esc_unicode", "_\1_", &esc_first);
 	hanson_close_object(&h);
 
 	assert(hanson_close(&h, &buf, &buf_len) == 0);
@@ -1331,6 +1375,7 @@ struct test all_tests[] = {
 	T(t_min_agg),
 	T(t_stats),
 	T_EBPF(t_hanson),
+	T_EBPF(t_hanson_escape),
 	{ NULL,	NULL, 0, 0 }
 };
 #undef S

--- a/quark.h
+++ b/quark.h
@@ -133,9 +133,9 @@ void	 qlog_func(int, int, const char *, int, const char *, ...) __attribute__((f
 
 /* hanson.c */
 struct hanson;
-int	 hanson_add_ascii(struct hanson *, int);
+int	 hanson_add_ascii(struct hanson *, char);
 int	 hanson_add_string(struct hanson *, char *, int *);
-int	 hanson_add_integer(struct hanson *, int64_t);
+int	 hanson_add_integer(struct hanson *, int64_t, int *);
 int	 hanson_add_boolean(struct hanson *h, int, int *);
 int	 hanson_add_key_value(struct hanson *, char *, char *, int *);
 int	 hanson_add_key_value_int(struct hanson *, char *, int64_t, int *);
@@ -150,8 +150,8 @@ int	 hanson_close(struct hanson *, char **, size_t *);
 struct hanson {
 	int	 error;
 	char	*buf;
+	char	*buf_w;
 	size_t	 buf_len;
-	FILE	*stream;
 };
 
 /* ecs.c */


### PR DESCRIPTION
This improves hanson JSON generation by a factor of 5-8.

Two major bottlenecks:

1. glibc's stream operations are just too slow for this, so do the buffering ourselves. Our documents are rather large, around 6KB by now, so choose 16KB as default, it grows if needed.

2. sprintf just doesn't cut it, the classic integer to string algorithm implemented here is more than twice as fast as an unchecked sprintf.

Besides, also make some hot functions inline, it squeezes a bit more juice.

Since generating JSON is the most expensive thing quark can do, in essence JSON generation is 90+% of the compute time, so nothing else really matters. Considering this, add a binary for benchmarking hanson, which is what I used to do the improvements.
```
BEFORE                                  AFTER
$ hanson-bench string                   $ hanson-bench string
Time elapsed: 10.588344 seconds         Time elapsed: 1.567657 seconds
Documents per second: 94443.47          Documents per second: 637894.80
Document size: 2.49KB                   Document size: 2.49KB
Throughput: 234.79MB/s                  Throughput: 1585.81MB/s

$ hanson-bench int                      $ hanson-bench int
Time elapsed: 2.925168 seconds          Time elapsed: 0.616059 seconds
Documents per second: 34186.07          Documents per second: 162322.13
Document size: 7.11KB                   Document size: 7.11KB
Throughput: 242.93MB/s                  Throughput: 1153.46MB/s

$ hanson-bench comb                     $ hanson-bench comb
Time elapsed: 19.863080 seconds         Time elapsed: 2.504582 seconds
Documents per second: 50344.66          Documents per second: 399268.30
Document size: 3.17KB                   Document size: 3.17KB
Throughput: 159.79MB/s                  Throughput: 1267.28MB/s
```

Issue #225 