### PR TITLE
Add pod ips, aka: orchestrator.resource.ip

### DIFF
--- a/ecs.c
+++ b/ecs.c
@@ -490,6 +490,17 @@ ecs_orchestrator(struct hanson *h, const struct quark_event *qev, int *first)
 		hanson_add_key_value(h, "name", pod->name, &resource_first);
 		hanson_add_key_value(h, "namespace", pod->ns, &resource_first);
 
+		hanson_add_array(h, "ip", &resource_first);
+		{
+			int	ip_first = 1;
+
+			if (*pod->addr4_a != 0)
+				hanson_add_string(h, pod->addr4_a, &ip_first);
+			if (*pod->addr6_a != 0)
+				hanson_add_string(h, pod->addr6_a, &ip_first);
+		}
+		hanson_close_array(h);
+
 		hanson_add_object(h, "label", &resource_first);
 		{
 			int	label_first = 1;

--- a/quark.h
+++ b/quark.h
@@ -569,6 +569,10 @@ struct quark_pod {
 	char			*name;
 	char			*ns;
 	char			*uid;
+	struct quark_sockaddr	 addr4;
+	char			 addr4_a[INET6_ADDRSTRLEN];
+	struct quark_sockaddr	 addr6;
+	char			 addr6_a[INET6_ADDRSTRLEN];
 	struct label_tree	 labels;
 	struct pod_containers	 containers;
 	char			*phase;


### PR DESCRIPTION
Ips are per pod, the specification limits it to one address per address family, so no more than one ipv4 and one ipv6, even so, it gives us an array of objects keyed by ip:
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus

Store the ip address in adult form, and also as ascii, so we don't need to manipulate things on the fly for ECS.