### PR TITLE
Add remaining cloud and orchestrator fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.5
 require (
 	github.com/pborman/getopt/v2 v2.1.0
 	k8s.io/api v0.33.3
+	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 )
 
@@ -41,7 +42,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.33.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/quark.h
+++ b/quark.h
@@ -587,10 +587,14 @@ RB_HEAD(pod_by_uid, quark_pod);
 struct quark_kube_node {
 	char	*name;
 	char	*uid;
-	char	*zone;		/* might be NULL */
-	char	*region;	/* might be NULL */
-	char	*provider;	/* might be NULL */
-	char	*project;	/* might be NULL */
+	char	*zone;			/* might be NULL */
+	char	*region;		/* might be NULL */
+	char	*provider;		/* might be NULL */
+	char	*project;		/* might be NULL */
+	char	*project_id;		/* might be NULL */
+	char	*cluster_name;		/* might be NULL */
+	char	*cluster_uid;		/* might be NULL */
+	char	*cluster_version;	/* might be NULL */
 };
 
 /*


### PR DESCRIPTION
This adds:
 - cluster.name (GCP only)
 - cluster.id (GCP only)
 - cluster.version
 - project.id (GCP only)
 - account.name
 - account.id