### PR TITLE
Rename kube functions, tweak cloud provider name

### DIFF
--- a/quark-test.c
+++ b/quark-test.c
@@ -1252,7 +1252,7 @@ t_cgroup_parse(const struct test *t, struct quark_queue_attr *qa)
 	for (i = 0; cases[i].in != NULL; i++) {
 		bzero(cid, sizeof(cid));
 
-		r = parse_kube_cgroup(cases[i].in, cid, sizeof(cid));
+		r = kube_parse_cgroup(cases[i].in, cid, sizeof(cid));
 		assert(r == cases[i].expected_ret);
 		if (r == 0)
 			assert(!strcmp(cid, cases[i].out));

--- a/quark.h
+++ b/quark.h
@@ -65,7 +65,7 @@ struct quark_passwd *quark_passwd_lookup(struct quark_queue *, uid_t);
 struct quark_group *quark_group_lookup(struct quark_queue *, gid_t);
 
 /* quark.c: These are exported for testing only */
-int	 parse_kube_cgroup(const char *, char *, size_t);
+int	 kube_parse_cgroup(const char *, char *, size_t);
 
 /* btf.c */
 struct quark_btf_target {


### PR DESCRIPTION
Quark functions should be object_verb, not verb_object, so fix that.

While here, it should be "gcp" for gce, not "gke", props to @nicholasberlin for noticing it earlier.