### PR TITLE
Add QQ_TTY outside of QQ_BYPASS.

### DIFF
--- a/init.c
+++ b/init.c
@@ -143,6 +143,9 @@ main(int argc, char *argv[])
 
 		display_banner(argv);
 
+		if (setenv("QUARK_INITRAMFS", "1", 1) == -1)
+			err(1, "setenv");
+
 		return (execv(argv[0], argv));
 	}
 

--- a/quark.h
+++ b/quark.h
@@ -199,6 +199,7 @@ enum raw_types {
 	RAW_PTRACE,
 	RAW_MODULE_LOAD,
 	RAW_SHM,
+	RAW_TTY,
 	RAW_NUM_TYPES		/* must be last */
 };
 
@@ -374,6 +375,24 @@ struct raw_shm {
 	struct quark_shm	*quark_shm;
 };
 
+struct quark_tty {
+	u16	major;
+	u16	minor;
+	u16	cols;
+	u16	rows;
+	u32	cflag;
+	u32	iflag;
+	u32	lflag;
+	u32	oflag;
+	size_t	truncated;	/* how many bytes were truncated (lost) */
+	size_t	data_len;
+	char	data[];
+};
+
+struct raw_tty {
+	struct quark_tty	*quark_tty;
+};
+
 struct raw_event {
 	RB_ENTRY(raw_event)			entry_by_time;
 	RB_ENTRY(raw_event)			entry_by_pidtime;
@@ -396,6 +415,7 @@ struct raw_event {
 		struct raw_ptrace		ptrace;
 		struct raw_module_load		module_load;
 		struct raw_shm			shm;
+		struct raw_tty			tty;
 	};
 };
 
@@ -426,6 +446,7 @@ struct quark_event {
 #define QUARK_EV_PTRACE			(1 << 9)
 #define QUARK_EV_MODULE_LOAD		(1 << 10)
 #define QUARK_EV_SHM			(1 << 11)
+#define QUARK_EV_TTY			(1 << 12)
 	u64				 events;
 	const struct quark_process	*process;
 	const struct quark_socket	*socket;
@@ -435,6 +456,7 @@ struct quark_event {
 	struct quark_ptrace		 ptrace;
 	struct quark_module_load	*module_load;
 	struct quark_shm		*shm;
+	struct quark_tty		*tty;
 };
 
 /*


### PR DESCRIPTION
This forwards tty writes as a quark event, some notes:

We should do our own tty aggregation, possibly also aggregating within a fork+exec.

sudo traps the output of the child process and then forwards to the actual stdout, this means that under sudo the process that does the tty write is the parent of the actual process doing the write. This makes it difficult to filter our own output, meaning the first time we print something we get stuck in a self feeding loop.

In the future we can add some logic to detect we are running under sudo, by checking the environment or maybe going up the tree and seeing if we are the child of a sudo process.

Because of the sudo complication, I haven't added it to quark-mon(8) and/or quark_event_dump(), but there's a test.

We don't get events for tty_writes when running on initramfs, so detect it and
escape. It's likely that we don't have a pty and our code doesn't consider an
actual tty? Needs more investigation.


Issue #261 