### PR TITLE
Update go bindings

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "build amd64 in docker"
     key: make_docker
-    command: "make docker NO_KUBE_TALKER=y WITH_BTFHUB=y"
+    command: "make docker NO_GO=y WITH_BTFHUB=y"
     artifact_paths:
       - "initramfs.gz"
     agents:
@@ -11,7 +11,7 @@ steps:
 
   - label: "build amd64 in a centos7 container"
     key: make_centos7
-    command: "make centos7 NO_KUBE_TALKER=y WITH_BTFHUB=y"
+    command: "make centos7 NO_GO=y WITH_BTFHUB=y"
     artifact_paths:
       - "quark-test"
     agents:
@@ -21,7 +21,7 @@ steps:
 
   - label: "build arm64 cross-compiled in docker"
     key: make_docker_cross_arm64
-    command: "make docker-cross-arm64 NO_KUBE_TALKER=y WITH_BTFHUB=y"
+    command: "make docker-cross-arm64 NO_GO=y WITH_BTFHUB=y"
     agents:
       image: family/core-ubuntu-2404
       provider: gcp
@@ -29,7 +29,7 @@ steps:
 
   - label: "build amd64 in an alpine container"
     key: make_alpine
-    command: "make alpine NO_KUBE_TALKER=y WITH_BTFHUB=y"
+    command: "make alpine NO_GO=y WITH_BTFHUB=y"
     agents:
       image: family/core-ubuntu-2404
       provider: gcp
@@ -53,6 +53,16 @@ steps:
       image: family/core-ubuntu-2404
       provider: gcp
       machineType: n2-highcpu-8
+      enableNestedVirtualization: true
+
+  - label: "test-go"
+    key: test_go
+    # we trigger a full rebuild to make sure dependencies for go are correct
+    command: "./.buildkite/runtestgo.sh"
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
       enableNestedVirtualization: true
 
   - label: "quark-test on fedora 28 (no bpf)"

--- a/.buildkite/runtestgo.sh
+++ b/.buildkite/runtestgo.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${BUILDKITE}" ]; then
+	echo "This script doesn't appear to be running in buildkite" 1>&2
+	echo "refusing to continue" 1>&2
+	exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y 				\
+	clang						\
+	cpio						\
+	gcc						\
+	golang						\
+	linux-tools-6.11.0-26-generic			\
+	make						\
+	m4						\
+	valgrind
+
+make test-go BPFTOOL="/usr/lib/linux-tools/6.11.0-26-generic/bpftool"
+exit $?

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -368,16 +368,16 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 
 		if (net->net.family == EBPF_NETWORK_EVENT_AF_INET) {
 			conn->local.af = AF_INET;
-			memcpy(&conn->local.addr4, net->net.saddr, 4);
+			memcpy(&conn->local.u, net->net.saddr, 4);
 
 			conn->remote.af = AF_INET;
-			memcpy(&conn->remote.addr4, net->net.daddr, 4);
+			memcpy(&conn->remote.u, net->net.daddr, 4);
 		} else if (net->net.family == EBPF_NETWORK_EVENT_AF_INET6) {
 			conn->local.af = AF_INET6;
-			memcpy(conn->local.addr6, net->net.saddr6, 16);
+			memcpy(&conn->local.u, net->net.saddr6, 16);
 
 			conn->remote.af = AF_INET6;
-			memcpy(conn->remote.addr6, net->net.daddr6, 16);
+			memcpy(&conn->remote.u, net->net.daddr6, 16);
 		} else
 			goto bad;
 

--- a/ecs.c
+++ b/ecs.c
@@ -786,7 +786,7 @@ ecs_socket(struct hanson *h, const struct quark_event *qev, int *first)
 	{
 		int	source_first = 1;
 
-		if (inet_ntop(qsk->local.af, &qsk->local.addr6,
+		if (inet_ntop(qsk->local.af, &qsk->local.u,
 		    buf, sizeof(buf)) != NULL) {
 			hanson_add_key_value(h, "address", buf, &source_first);
 			hanson_add_key_value(h, "ip", buf, &source_first);
@@ -800,7 +800,7 @@ ecs_socket(struct hanson *h, const struct quark_event *qev, int *first)
 	{
 		int	destination_first = 1;
 
-		if (inet_ntop(qsk->remote.af, &qsk->remote.addr6,
+		if (inet_ntop(qsk->remote.af, &qsk->remote.u,
 		    buf, sizeof(buf)) != NULL) {
 			hanson_add_key_value(h, "address", buf, &destination_first);
 			hanson_add_key_value(h, "ip", buf, &destination_first);

--- a/quark-test.c
+++ b/quark-test.c
@@ -1287,10 +1287,10 @@ t_sock_conn(const struct test *t, struct quark_queue_attr *qa)
 	assert((pid_t)qev->socket->pid_origin == child);
 	assert((pid_t)qev->socket->pid_last_use == child);
 	assert(qev->socket->local.af == AF_INET);
-	assert(qev->socket->local.addr4 == htonl(INADDR_LOOPBACK));
+	assert(qev->socket->local.u.addr4 == htonl(INADDR_LOOPBACK));
 	assert(qev->socket->local.port == bound_port);
 	assert(qev->socket->remote.af == AF_INET);
-	assert(qev->socket->remote.addr4 == htonl(INADDR_LOOPBACK));
+	assert(qev->socket->remote.u.addr4 == htonl(INADDR_LOOPBACK));
 	assert(qev->socket->remote.port == htons(18888));
 	assert(qev->socket->close_time == 0);
 	assert(qev->socket->bytes_received == 0);
@@ -1307,10 +1307,10 @@ t_sock_conn(const struct test *t, struct quark_queue_attr *qa)
 	assert((pid_t)qev->socket->pid_origin == child);
 	assert((pid_t)qev->socket->pid_last_use == child);
 	assert(qev->socket->local.af == AF_INET);
-	assert(qev->socket->local.addr4 == htonl(INADDR_LOOPBACK));
+	assert(qev->socket->local.u.addr4 == htonl(INADDR_LOOPBACK));
 	assert(qev->socket->local.port == bound_port);
 	assert(qev->socket->remote.af == AF_INET);
-	assert(qev->socket->remote.addr4 == htonl(INADDR_LOOPBACK));
+	assert(qev->socket->remote.u.addr4 == htonl(INADDR_LOOPBACK));
 	assert(qev->socket->remote.port == htons(18888));
 	assert(qev->socket->close_time > 0);
 	assert(qev->socket->bytes_received == 0);

--- a/quark.c
+++ b/quark.c
@@ -678,12 +678,12 @@ socket_by_src_dst_cmp(struct quark_socket *a, struct quark_socket *b)
 		return (1);
 
 	cmplen = a->remote.af == AF_INET ? 4 : 16;
-	r = memcmp(&a->remote.addr6, &b->remote.addr6, cmplen);
+	r = memcmp(&a->remote.u, &b->remote.u, cmplen);
 	if (r != 0)
 		return (r);
 
 	cmplen = a->local.af == AF_INET ? 4 : 16;
-	r = memcmp(&a->local.addr6, &b->local.addr6, cmplen);
+	r = memcmp(&a->local.u, &b->local.u, cmplen);
 
 	return (r);
 }
@@ -1176,7 +1176,7 @@ kube_handle_pod(struct quark_queue *qq, cJSON *json)
 		if (!cJSON_IsString(ip))
 			continue;
 		bzero(&qsk, sizeof(qsk));
-		if (inet_pton(AF_INET, ip->valuestring, &qsk.addr4) == 1) {
+		if (inet_pton(AF_INET, ip->valuestring, &qsk.u) == 1) {
 			qsk.af = AF_INET;
 			pod->addr4 = qsk;
 			strlcpy(pod->addr4_a, ip->valuestring, sizeof(pod->addr4_a));
@@ -1184,7 +1184,7 @@ kube_handle_pod(struct quark_queue *qq, cJSON *json)
 			continue;
 		}
 		bzero(&qsk, sizeof(qsk));
-		if (inet_pton(AF_INET6, ip->valuestring, qsk.addr6) == 1) {
+		if (inet_pton(AF_INET6, ip->valuestring, &qsk.u) == 1) {
 			qsk.af = AF_INET6;
 			pod->addr6 = qsk;
 			strlcpy(pod->addr6_a, ip->valuestring, sizeof(pod->addr6_a));
@@ -2119,11 +2119,11 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		if (qsk == NULL)
 			return (-1);
 
-		if (inet_ntop(qsk->local.af, &qsk->local.addr6,
+		if (inet_ntop(qsk->local.af, &qsk->local.u,
 		    local, sizeof(local)) == NULL)
 			strlcpy(local, "bad address", sizeof(local));
 
-		if (inet_ntop(qsk->remote.af, &qsk->remote.addr6,
+		if (inet_ntop(qsk->remote.af, &qsk->remote.u,
 		    remote, sizeof(remote)) == NULL)
 			strlcpy(remote, "bad address", sizeof(remote));
 
@@ -3103,18 +3103,18 @@ sproc_net_tcp_line(struct quark_queue *qq, const char *line, int af,
 
 		if (af == AF_INET) {
 			ss->socket.local.af = AF_INET;
-			ss->socket.local.addr4 = local_addr4;
+			ss->socket.local.u.addr4 = local_addr4;
 
 			ss->socket.remote.af = AF_INET;
-			ss->socket.remote.addr4 = remote_addr4;
+			ss->socket.remote.u.addr4 = remote_addr4;
 		}
 
 		if (af == AF_INET6) {
 			ss->socket.local.af = AF_INET6;
-			memcpy(ss->socket.local.addr6, local_addr6, 16);
+			memcpy(ss->socket.local.u.addr6, local_addr6, 16);
 
 			ss->socket.remote.af = AF_INET6;
-			memcpy(ss->socket.remote.addr6, remote_addr6, 16);
+			memcpy(ss->socket.remote.u.addr6, remote_addr6, 16);
 		}
 
 		col = RB_INSERT(sproc_socket_by_inode, by_inode, ss);

--- a/quark.h
+++ b/quark.h
@@ -267,7 +267,7 @@ struct quark_sockaddr {
 	union {
 		u32	addr4;
 		u8	addr6[16];
-	};
+	} u;
 
 	u16	port;
 };


### PR DESCRIPTION
This adds socket, file, ptrace, module_load, tty and shm* events to go

CGO can't address anonymous C unions, so name the union in sockaddr to make it easier.

These are all very barebones and we might want to rethink how we structure the bindings.