### PR TITLE
Preliminary Rule System

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -276,7 +276,7 @@ steps:
 
   - label: "quark-test on rhel 8.5 (no file)"
     key: test_rhel_8_5
-    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open"
+    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule"
     depends_on:
       - make_docker
     agents:
@@ -287,7 +287,7 @@ steps:
 
   - label: "quark-test on rhel 8.6 (no file)"
     key: test_rhel_8_6
-    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open"
+    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule"
     depends_on:
       - make_docker
     agents:
@@ -298,7 +298,7 @@ steps:
 
   - label: "quark-test on rhel 8.7 (no file)"
     key: test_rhel_8_7
-    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open"
+    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule"
     depends_on:
       - make_docker
     agents:


### PR DESCRIPTION
    This implements the barebones of a rule system for filtering events.

    A ruleset is a collection of rules.
    A rule has zero or more rule_fields. Each rule_field expresses one attribute
    that must match, for example process.pid is one field, and file.path is another.
    A rule matches when _all_ its fields match.
    A rule with no fields always matches (can be a catch-all as the last rule).
    A ruleset matches the first rule it matches, meaning this is a match-first scheme.

    Currently we have only two actions RA_PASS and RA_DROP, if nothinig matches,
    it's PASS.
    For now, only 4 rule_fields, process.pid, process.ppid, process.filename and
    file.path.

    The next step is to design a proper DSL ala pf.conf(5), that then compiles an
    ascii line-based ruleset into a quark_ruleset.

Note that two minor changes were piggy backed in different commits (gc_collect + re-align)