### PR TITLE
Fix qreadlinkat to return resolved target length

### DIFF
--- a/qutil.c
+++ b/qutil.c
@@ -52,9 +52,9 @@ qwrite(int fd, const void *buf, size_t count)
 }
 
 /*
- * Safer readlinkat(2), guarantees termination and returns strlen(pathname) so
- * caller can check truncation, like strlcpy(). Compare to >= 0 if truncation is
- * acceptable.
+ * Safer readlinkat(2), guarantees termination and returns the length of the
+ * resolved target so caller can check truncation, like strlcpy(). If the
+ * return value is >= bufsiz, truncation occurred.
  */
 ssize_t
 qreadlinkat(int dfd, const char *pathname, char *buf, size_t bufsiz)
@@ -67,7 +67,7 @@ qreadlinkat(int dfd, const char *pathname, char *buf, size_t bufsiz)
 		return (-1);
 	buf[n] = 0;
 
-	return (strlen(pathname));
+	return (n);
 }
 
 /*


### PR DESCRIPTION
qreadlinkat() was returning strlen(pathname) — the length of the input symlink path (e.g., "exe", "ns/pid") — instead of the actual number of bytes read by readlinkat(). This broke truncation detection at all call sites, since short pathnames like "exe" (3 chars) made the check n >= sizeof(buf) always false even when the symlink target was truncated.

Return n (the readlinkat result) so callers can properly detect truncation when n >= bufsiz.

Add t_qreadlinkat test that verifies the return value matches the resolved target length and that truncation is correctly signaled.