### PR TITLE
Fix qreadlinkat ret val and truncation detection

### DIFF
--- a/qutil.c
+++ b/qutil.c
@@ -52,9 +52,9 @@ qwrite(int fd, const void *buf, size_t count)
 }
 
 /*
- * Safer readlinkat(2), guarantees termination and returns strlen(pathname) so
- * caller can check truncation, like strlcpy(). Compare to >= 0 if truncation is
- * acceptable.
+ * Safer readlinkat(2), guarantees termination and returns the number of bytes
+ * placed in buf (excluding NUL) so caller can check truncation, like strlcpy().
+ * If the return value is >= bufsiz, truncation occurred.
  */
 ssize_t
 qreadlinkat(int dfd, const char *pathname, char *buf, size_t bufsiz)
@@ -66,8 +66,10 @@ qreadlinkat(int dfd, const char *pathname, char *buf, size_t bufsiz)
 	if ((n = readlinkat(dfd, pathname, buf, bufsiz - 1)) == -1)
 		return (-1);
 	buf[n] = 0;
+	if ((size_t)n == (bufsiz - 1))
+		n++;
 
-	return (strlen(pathname));
+	return (n);
 }
 
 /*


### PR DESCRIPTION
## Fix qreadlinkat return value and truncation detection

`qreadlinkat()` had two bugs:

1. It returned `strlen(pathname)` (the pathname argument, e.g. `3` for `"exe"`) instead of the length of the resolved symlink target. This meant callers always got the wrong value back.

2. Truncation was undetectable. Since `readlinkat(2)` was called with `bufsiz - 1`, callers checking `n >= bufsiz` could never see truncation. Fixed by bumping `n` to `bufsiz` when `readlinkat(2)` fills the entire buffer (`n == bufsiz - 1`).

### Changes

- **`qutil.c`**: Return `n` instead of `strlen(pathname)`. When `readlinkat(2)` returns `bufsiz - 1` (buffer full), increment `n` to `bufsiz` so callers can detect truncation via `n >= bufsiz`.