### PR TITLE
Cope with PREEMPT_LAZY in our bpf probes.

### DIFF
--- a/elastic-ebpf/GPL/Events/File/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/File/Probe.bpf.c
@@ -45,13 +45,25 @@ static int do_unlinkat__enter()
 SEC("fentry/do_unlinkat")
 int BPF_PROG(fentry__do_unlinkat)
 {
-    return do_unlinkat__enter();
+    int r;
+
+    preempt_disable();
+    r = do_unlinkat__enter();
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/do_unlinkat")
 int BPF_KPROBE(kprobe__do_unlinkat)
 {
-    return do_unlinkat__enter();
+    int r;
+
+    preempt_disable();
+    r = do_unlinkat__enter();
+    preempt_enable();
+
+    return r;
 }
 
 static int mnt_want_write__enter(struct vfsmount *mnt)
@@ -89,13 +101,25 @@ out:
 SEC("fentry/mnt_want_write")
 int BPF_PROG(fentry__mnt_want_write, struct vfsmount *mnt)
 {
-    return mnt_want_write__enter(mnt);
+    int r;
+
+    preempt_disable();
+    r = mnt_want_write__enter(mnt);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/mnt_want_write")
 int BPF_KPROBE(kprobe__mnt_want_write, struct vfsmount *mnt)
 {
-    return mnt_want_write__enter(mnt);
+    int r;
+
+    preempt_disable();
+    r = mnt_want_write__enter(mnt);
+    preempt_enable();
+
+    return r;
 }
 
 static int vfs_unlink__exit(int ret)
@@ -167,14 +191,26 @@ out:
 SEC("fexit/vfs_unlink")
 int BPF_PROG(fexit__vfs_unlink)
 {
-    int ret = FUNC_RET_READ(___type(ret), vfs_unlink);
-    return vfs_unlink__exit(ret);
+    int ret, r;
+
+    preempt_disable();
+    ret = FUNC_RET_READ(___type(ret), vfs_unlink);
+    r = vfs_unlink__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kretprobe/vfs_unlink")
 int BPF_KRETPROBE(kretprobe__vfs_unlink, int ret)
 {
-    return vfs_unlink__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = vfs_unlink__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 static int vfs_unlink__enter(struct dentry *de)
@@ -198,20 +234,34 @@ out:
 SEC("fentry/vfs_unlink")
 int BPF_PROG(fentry__vfs_unlink)
 {
-    struct dentry *de = FUNC_ARG_READ(___type(de), vfs_unlink, dentry);
-    return vfs_unlink__enter(de);
+    struct dentry *de;
+    int r;
+
+    preempt_disable();
+    de = FUNC_ARG_READ(___type(de), vfs_unlink, dentry);
+    r = vfs_unlink__enter(de);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/vfs_unlink")
 int BPF_KPROBE(kprobe__vfs_unlink)
 {
     struct dentry *de;
+    int r;
+
+    preempt_disable();
+    r = 0;
     if (FUNC_ARG_READ_PTREGS(de, vfs_unlink, dentry)) {
         bpf_printk("kprobe__vfs_unlink: error reading dentry\n");
-        return 0;
+        goto out;
     }
 
-    return vfs_unlink__enter(de);
+    r = vfs_unlink__enter(de);
+out:
+    preempt_enable();
+    return r;
 }
 
 // prepare a file event and send it to ringbuf.
@@ -355,7 +405,13 @@ int BPF_KPROBE(kprobe__fsnotify,
                const unsigned char *file_name,
                u32 cookie)
 {
-    return fsnotify__enter(mask);
+    int r;
+
+    preempt_disable();
+    r = fsnotify__enter(mask);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("fentry/fsnotify")
@@ -367,7 +423,13 @@ int BPF_PROG(fentry__fsnotify,
              const unsigned char *file_name,
              u32 cookie)
 {
-    return fsnotify__enter(mask);
+    int r;
+
+    preempt_disable();
+    r = fsnotify__enter(mask);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("fexit/do_filp_open")
@@ -377,13 +439,25 @@ int BPF_PROG(fexit__do_filp_open,
              const struct open_flags *op,
              struct file *ret)
 {
-    return do_filp_open__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = do_filp_open__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kretprobe/do_filp_open")
 int BPF_KRETPROBE(kretprobe__do_filp_open, struct file *ret)
 {
-    return do_filp_open__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = do_filp_open__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 static int do_renameat2__enter()
@@ -409,13 +483,25 @@ out:
 SEC("fentry/do_renameat2")
 int BPF_PROG(fentry__do_renameat2)
 {
-    return do_renameat2__enter();
+    int r;
+
+    preempt_disable();
+    r = do_renameat2__enter();
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/do_renameat2")
 int BPF_KPROBE(kprobe__do_renameat2)
 {
-    return do_renameat2__enter();
+    int r;
+
+    preempt_disable();
+    r = do_renameat2__enter();
+    preempt_enable();
+
+    return r;
 }
 
 static int vfs_rename__enter(struct dentry *old_dentry, struct dentry *new_dentry)
@@ -454,6 +540,9 @@ SEC("fentry/vfs_rename")
 int BPF_PROG(fentry__vfs_rename)
 {
     struct dentry *old_dentry, *new_dentry;
+    int r;
+
+    preempt_disable();
 
     if (FUNC_ARG_EXISTS(vfs_rename, rd)) {
         /* Function arguments have been refactored into struct renamedata */
@@ -466,14 +555,19 @@ int BPF_PROG(fentry__vfs_rename)
         new_dentry = FUNC_ARG_READ(___type(new_dentry), vfs_rename, new_dentry);
     }
 
-    return vfs_rename__enter(old_dentry, new_dentry);
+    r = vfs_rename__enter(old_dentry, new_dentry);
+    preempt_enable();
+    return r;
 }
 
 SEC("kprobe/vfs_rename")
 int BPF_KPROBE(kprobe__vfs_rename)
 {
     struct dentry *old_dentry, *new_dentry;
+    int r;
 
+    preempt_disable();
+    r = 0;
     if (FUNC_ARG_EXISTS(vfs_rename, rd)) {
         /* Function arguments have been refactored into struct renamedata */
         struct renamedata rd;
@@ -484,15 +578,18 @@ int BPF_KPROBE(kprobe__vfs_rename)
         /* Dentries are accessible from ctx */
         if (FUNC_ARG_READ_PTREGS(old_dentry, vfs_rename, old_dentry)) {
             bpf_printk("kprobe__vfs_rename: error reading old_dentry\n");
-            return 0;
+            goto out;
         }
         if (FUNC_ARG_READ_PTREGS(new_dentry, vfs_rename, new_dentry)) {
             bpf_printk("kprobe__vfs_rename: error reading new_dentry\n");
-            return 0;
+            goto out;
         }
     }
 
-    return vfs_rename__enter(old_dentry, new_dentry);
+    r = vfs_rename__enter(old_dentry, new_dentry);
+out:
+    preempt_enable();
+    return r;
 }
 
 static int vfs_rename__exit(int ret)
@@ -571,14 +668,26 @@ out:
 SEC("fexit/vfs_rename")
 int BPF_PROG(fexit__vfs_rename)
 {
-    int ret = FUNC_RET_READ(___type(ret), vfs_rename);
-    return vfs_rename__exit(ret);
+    int ret, r;
+
+    preempt_disable();
+    ret = FUNC_RET_READ(___type(ret), vfs_rename);
+    r = vfs_rename__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kretprobe/vfs_rename")
 int BPF_KRETPROBE(kretprobe__vfs_rename, int ret)
 {
-    return vfs_rename__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = vfs_rename__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 static void file_modify_event__emit(enum ebpf_file_change_type typ, struct path *path)
@@ -645,10 +754,14 @@ int BPF_KPROBE(kprobe__chmod_common, const struct path *path, umode_t mode)
     state.chmod.path               = (struct path *)path;
     state.chmod.mode               = mode;
 
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
 
     ebpf_events_state__set(EBPF_EVENTS_STATE_CHMOD, &state);
+
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -669,20 +782,26 @@ out:
 SEC("fexit/chmod_common")
 int BPF_PROG(fexit__chmod_common, const struct path *path, umode_t mode, int ret)
 {
+    preempt_disable();
     chmod_common__exit((struct path *)path, ret);
+    preempt_enable();
     return 0;
 }
 
 SEC("kretprobe/chmod_common")
 int BPF_KRETPROBE(kretprobe__chmod_common, int ret)
 {
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHMOD);
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHMOD);
     if (!state)
         goto out;
 
     chmod_common__exit(state->chmod.path, ret);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -691,19 +810,22 @@ int BPF_KPROBE(kprobe__do_truncate)
 {
     struct ebpf_events_state state = {};
 
+    preempt_disable();
+
     if (ebpf_events_is_trusted_pid())
         goto out;
 
     struct file *filp;
     if (FUNC_ARG_READ_PTREGS(filp, do_truncate, filp)) {
         bpf_printk("kprobe__do_truncate: error reading filp\n");
-        return 0;
+        goto out;
     }
 
     state.truncate.path = path_from_file(filp);
     ebpf_events_state__set(EBPF_EVENTS_STATE_TRUNCATE, &state);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -724,22 +846,32 @@ out:
 SEC("fexit/do_truncate")
 int BPF_PROG(fexit__do_truncate)
 {
-    struct file *filp = FUNC_ARG_READ(___type(filp), do_truncate, filp);
-    int ret           = FUNC_RET_READ(___type(ret), do_truncate);
+    struct file *filp;
+    int ret;
+
+    preempt_disable();
+    filp = FUNC_ARG_READ(___type(filp), do_truncate, filp);
+    ret = FUNC_RET_READ(___type(ret), do_truncate);
     do_truncate__exit(path_from_file(filp), ret);
+    preempt_enable();
+
     return 0;
 }
 
 SEC("kretprobe/do_truncate")
 int BPF_KRETPROBE(kretprobe__do_truncate, int ret)
 {
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_TRUNCATE);
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_TRUNCATE);
     if (!state)
         goto out;
 
     do_truncate__exit(state->truncate.path, ret);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -747,12 +879,15 @@ SEC("kprobe/vfs_write")
 int BPF_KPROBE(kprobe__vfs_write, struct file *file)
 {
     struct ebpf_events_state state = {};
+
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
 
     state.write.path = path_from_file(file);
     ebpf_events_state__set(EBPF_EVENTS_STATE_WRITE, &state);
-
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -760,12 +895,16 @@ SEC("kprobe/vfs_writev")
 int BPF_KPROBE(kprobe__vfs_writev, struct file *file)
 {
     struct ebpf_events_state state = {};
+
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
 
     state.writev.path = path_from_file(file);
     ebpf_events_state__set(EBPF_EVENTS_STATE_WRITEV, &state);
 
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -787,7 +926,9 @@ SEC("fexit/vfs_write")
 int BPF_PROG(
     fexit__vfs_write, struct file *file, const char *buf, size_t count, loff_t *pos, ssize_t ret)
 {
+    preempt_disable();
     vfs_write__exit(path_from_file(file), ret);
+    preempt_enable();
     return 0;
 }
 
@@ -800,33 +941,43 @@ int BPF_PROG(fexit__vfs_writev,
              rwf_t flags,
              ssize_t ret)
 {
+    preempt_disable();
     vfs_write__exit(path_from_file(file), ret);
+    preempt_enable();
     return 0;
 }
 
 SEC("kretprobe/vfs_write")
 int BPF_KRETPROBE(kretprobe__vfs_write, ssize_t ret)
 {
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITE);
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITE);
     if (!state)
         goto out;
 
     vfs_write__exit(state->write.path, ret);
 
 out:
+    preempt_enable();
     return 0;
 }
 
 SEC("kretprobe/vfs_writev")
 int BPF_KRETPROBE(kretprobe__vfs_writev, ssize_t ret)
 {
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITEV);
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_WRITEV);
     if (!state)
         goto out;
 
     vfs_write__exit(state->writev.path, ret);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -834,10 +985,14 @@ SEC("kprobe/chown_common")
 int BPF_KPROBE(kprobe__chown_common, struct path *path, uid_t user, gid_t group)
 {
     struct ebpf_events_state state = {};
+
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
     state.chown.path               = path;
     ebpf_events_state__set(EBPF_EVENTS_STATE_CHOWN, &state);
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -858,19 +1013,25 @@ out:
 SEC("fexit/chown_common")
 int BPF_PROG(fexit__chown_common, struct path *path, uid_t user, gid_t group, int ret)
 {
+    preempt_disable();
     chown_common__exit(path, ret);
+    preempt_enable();
     return 0;
 }
 
 SEC("kretprobe/chown_common")
 int BPF_KRETPROBE(kretprobe__chown_common, int ret)
 {
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHOWN);
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_CHOWN);
     if (!state)
         goto out;
 
     chown_common__exit(state->chown.path, ret);
 
 out:
+    preempt_enable();
     return 0;
 }

--- a/elastic-ebpf/GPL/Events/Helpers.h
+++ b/elastic-ebpf/GPL/Events/Helpers.h
@@ -396,4 +396,20 @@ static u64 bpf_ktime_get_boot_ns_helper()
         return 0;
 }
 
+extern void bpf_preempt_disable(void) __ksym __weak;
+
+static void preempt_disable(void)
+{
+    if (bpf_ksym_exists(bpf_preempt_disable))
+        bpf_preempt_disable();
+}
+
+extern void bpf_preempt_enable(void) __ksym __weak;
+
+static void preempt_enable(void)
+{
+    if (bpf_ksym_exists(bpf_preempt_enable))
+        bpf_preempt_enable();
+}
+
 #endif // EBPF_EVENTPROBE_HELPERS_H

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -59,13 +59,25 @@ SEC("fexit/inet_csk_accept")
 int BPF_PROG(fexit__inet_csk_accept)
 {
     struct sock *ret = FUNC_RET_READ(___type(ret), inet_csk_accept);
-    return inet_csk_accept__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = inet_csk_accept__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kretprobe/inet_csk_accept")
 int BPF_KRETPROBE(kretprobe__inet_csk_accept, struct sock *ret)
 {
-    return inet_csk_accept__exit(ret);
+    int r;
+
+    preempt_disable();
+    r = inet_csk_accept__exit(ret);
+    preempt_enable();
+
+    return r;
 }
 
 static int tcp_connect(struct sock *sk, int ret)
@@ -98,7 +110,13 @@ out:
 SEC("fexit/tcp_v4_connect")
 int BPF_PROG(fexit__tcp_v4_connect, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
 {
-    return tcp_connect(sk, ret);
+    int r;
+
+    preempt_disable();
+    r = tcp_connect(sk, ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/tcp_v4_connect")
@@ -106,9 +124,14 @@ int BPF_KPROBE(kprobe__tcp_v4_connect, struct sock *sk)
 {
     struct ebpf_events_state state = {};
     state.tcp_v4_connect.sk        = sk;
+
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
     ebpf_events_state__set(EBPF_EVENTS_STATE_TCP_V4_CONNECT, &state);
+
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -116,18 +139,31 @@ SEC("kretprobe/tcp_v4_connect")
 int BPF_KRETPROBE(kretprobe__tcp_v4_connect, int ret)
 {
     struct ebpf_events_state *state;
+    int r;
 
+    preempt_disable();
+    r = 0;
     state = ebpf_events_state__get(EBPF_EVENTS_STATE_TCP_V4_CONNECT);
     if (!state)
-        return 0;
+        goto out;
 
-    return tcp_connect(state->tcp_v4_connect.sk, ret);
+    r = tcp_connect(state->tcp_v4_connect.sk, ret);
+
+out:
+    preempt_enable();
+    return r;
 }
 
 SEC("fexit/tcp_v6_connect")
 int BPF_PROG(fexit__tcp_v6_connect, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
 {
-    return tcp_connect(sk, ret);
+    int r;
+
+    preempt_disable();
+    r = tcp_connect(sk, ret);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/tcp_v6_connect")
@@ -135,9 +171,14 @@ int BPF_KPROBE(kprobe__tcp_v6_connect, struct sock *sk)
 {
     struct ebpf_events_state state = {};
     state.tcp_v6_connect.sk        = sk;
+
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
-        return 0;
+        goto out;
     ebpf_events_state__set(EBPF_EVENTS_STATE_TCP_V6_CONNECT, &state);
+
+out:
+    preempt_enable();
     return 0;
 }
 
@@ -145,12 +186,20 @@ SEC("kretprobe/tcp_v6_connect")
 int BPF_KRETPROBE(kretprobe__tcp_v6_connect, int ret)
 {
     struct ebpf_events_state *state;
+    int r;
 
+    preempt_disable();
+    r = 0;
     state = ebpf_events_state__get(EBPF_EVENTS_STATE_TCP_V6_CONNECT);
     if (!state)
-        return 0;
+        goto out;
 
-    return tcp_connect(state->tcp_v6_connect.sk, ret);
+    r = tcp_connect(state->tcp_v6_connect.sk, ret);
+
+out:
+    preempt_enable();
+
+    return r;
 }
 
 static int tcp_close__enter(struct sock *sk)
@@ -189,13 +238,25 @@ out:
 SEC("fentry/tcp_close")
 int BPF_PROG(fentry__tcp_close, struct sock *sk, long timeout)
 {
-    return tcp_close__enter(sk);
+    int r;
+
+    preempt_disable();
+    r = tcp_close__enter(sk);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/tcp_close")
 int BPF_KPROBE(kprobe__tcp_close, struct sock *sk, long timeout)
 {
-    return tcp_close__enter(sk);
+    int r;
+
+    preempt_disable();
+    r = tcp_close__enter(sk);
+    preempt_enable();
+
+    return r;
 }
 
 #ifdef notyet
@@ -203,7 +264,7 @@ int BPF_KPROBE(kprobe__tcp_close, struct sock *sk, long timeout)
  * XXX naive, only handles ROUTING and DEST, untested, ipv6 needs more work to
  * be enabled.
  */
-int skb_peel_nexthdr(struct __sk_buff *skb, u8 wanted)
+static int skb_peel_nexthdr(struct __sk_buff *skb, u8 wanted)
 {
     struct ipv6hdr ip6;
     int off;
@@ -235,7 +296,7 @@ int skb_peel_nexthdr(struct __sk_buff *skb, u8 wanted)
 }
 #endif
 
-int skb_in_or_egress(struct __sk_buff *skb, int ingress)
+static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
 {
     struct udphdr udp;
     struct bpf_sock *sk;
@@ -342,16 +403,28 @@ ignore:
 SEC("cgroup_skb/egress")
 int skb_egress(struct __sk_buff *skb)
 {
-    return skb_in_or_egress(skb, 0);
+    int r;
+
+    preempt_disable();
+    r = skb_in_or_egress(skb, 0);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("cgroup_skb/ingress")
 int skb_ingress(struct __sk_buff *skb)
 {
-    return skb_in_or_egress(skb, 1);
+    int r;
+
+    preempt_disable();
+    r = skb_in_or_egress(skb, 1);
+    preempt_enable();
+
+    return r;
 }
 
-int sk_maybe_save_tgid(struct bpf_sock *sk)
+static int sk_maybe_save_tgid(struct bpf_sock *sk)
 {
     u32 tgid, zero = 0;
     u64 *sk_addr;
@@ -384,25 +457,49 @@ int sk_maybe_save_tgid(struct bpf_sock *sk)
 SEC("cgroup/sendmsg4")
 int sendmsg4(struct bpf_sock_addr *sa)
 {
-    return sk_maybe_save_tgid(sa->sk);
+    int r;
+
+    preempt_disable();
+    r = sk_maybe_save_tgid(sa->sk);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("cgroup/recvmsg4")
 int recvmsg4(struct bpf_sock_addr *sa)
 {
-    return sk_maybe_save_tgid(sa->sk);
+    int r;
+
+    preempt_disable();
+    r = sk_maybe_save_tgid(sa->sk);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("cgroup/connect4")
 int connect4(struct bpf_sock_addr *sa)
 {
-    return sk_maybe_save_tgid(sa->sk);
+    int r;
+
+    preempt_disable();
+    r = sk_maybe_save_tgid(sa->sk);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("cgroup/sock_create")
 int sock_create(struct bpf_sock *sk)
 {
-    return sk_maybe_save_tgid(sk);
+    int r;
+
+    preempt_disable();
+    r = sk_maybe_save_tgid(sk);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("cgroup/sock_release")
@@ -411,8 +508,9 @@ int sock_release(struct bpf_sock *sk)
     u32 zero = 0;
     u64 *sk_addr;
 
+    preempt_disable();
     if (sk->protocol != IPPROTO_UDP)
-        return (1);
+        goto out;
 
     /*
      * Needed for kernels prior to f79efcb0075a20633cbf9b47759f2c0d538f78d8
@@ -420,9 +518,12 @@ int sock_release(struct bpf_sock *sk)
      */
     sk_addr = bpf_map_lookup_elem(&scratch64, &zero);
     if (sk_addr == NULL)
-        return (1);
+        goto out;
     *sk_addr = (u64)sk;
     bpf_map_delete_elem(&sk_to_tgid, sk_addr);
+
+out:
+    preempt_enable();
 
     return (1);
 }

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -38,6 +38,7 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
+    preempt_disable();
     // Ignore the !is_thread_group_leader(child) case as we want to ignore
     // thread creations in the same thread group.
     //
@@ -81,6 +82,7 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
     ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -90,6 +92,7 @@ int BPF_PROG(sched_process_exec,
              pid_t old_pid,
              const struct linux_binprm *binprm)
 {
+    preempt_disable();
     if (!binprm)
         goto out;
 
@@ -173,6 +176,7 @@ int BPF_PROG(sched_process_exec,
     ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -247,13 +251,25 @@ static int disassociate_ctty__enter(int on_exit)
 SEC("fentry/disassociate_ctty")
 int BPF_PROG(fentry__disassociate_ctty, int on_exit)
 {
-    return disassociate_ctty__enter(on_exit);
+    int r;
+
+    preempt_disable();
+    r = disassociate_ctty__enter(on_exit);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/disassociate_ctty")
 int BPF_KPROBE(kprobe__disassociate_ctty, int on_exit)
 {
-    return disassociate_ctty__enter(on_exit);
+    int r;
+
+    preempt_disable();
+    r = disassociate_ctty__enter(on_exit);;
+    preempt_enable();
+
+    return r;
 }
 
 static int setsid__exit(int evtype)
@@ -288,24 +304,36 @@ out:
 SEC("tracepoint/syscalls/sys_exit_setsid")
 int tracepoint_syscalls_sys_exit_setsid(struct syscall_trace_exit *args)
 {
+    int r;
+
+    r = 0;
+    preempt_disable();
     if (BPF_CORE_READ(args, ret) < 0)
         goto out;
 
-    return setsid__exit(EBPF_EVENT_PROCESS_SETSID);
+    r = setsid__exit(EBPF_EVENT_PROCESS_SETSID);
 
 out:
-    return 0;
+    preempt_enable();
+    return r;
 }
 
 SEC("tracepoint/syscalls/sys_exit_getpid")
 int tracepoint_syscalls_sys_exit_getpid(struct syscall_trace_exit *args)
 {
-    return setsid__exit(EBPF_EVENT_PROCESS_GETPID);
+    int r;
+
+    preempt_disable();
+    r = setsid__exit(EBPF_EVENT_PROCESS_GETPID);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("tp_btf/module_load")
 int BPF_PROG(module_load, struct module *mod)
 {
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
         goto out;
 
@@ -357,6 +385,7 @@ int BPF_PROG(module_load, struct module *mod)
     ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
 
 out:
+    preempt_enable();
     return 0;
 }
 
@@ -411,7 +440,13 @@ int BPF_KPROBE(kprobe__ptrace_attach,
                unsigned long addr,
                unsigned long data)
 {
-    return ptrace_event(child, request, addr, data);
+    int r;
+
+    preempt_disable();
+    r = ptrace_event(child, request, addr, data);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/arch_ptrace")
@@ -421,12 +456,19 @@ int BPF_KPROBE(kprobe__arch_ptrace,
                unsigned long addr,
                unsigned long data)
 {
-    return ptrace_event(child, request, addr, data);
+    int r;
+
+    preempt_disable();
+    r = ptrace_event(child, request, addr, data);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("tracepoint/syscalls/sys_enter_shmget")
 int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
 {
+    preempt_disable();
     if (ebpf_events_is_trusted_pid())
         goto out;
 
@@ -461,12 +503,14 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
 
     bpf_ringbuf_submit(event, 0);
 out:
+    preempt_enable();
     return 0;
 }
 
 SEC("tracepoint/syscalls/sys_enter_memfd_create")
 int tracepoint_syscalls_sys_enter_memfd_create(struct syscall_trace_enter *ctx)
 {
+    preempt_disable();
     // from: /sys/kernel/debug/tracing/events/syscalls/sys_enter_memfd_create/format
     struct memfd_create_args {
         short common_type;
@@ -482,6 +526,7 @@ int tracepoint_syscalls_sys_enter_memfd_create(struct syscall_trace_enter *ctx)
     struct ebpf_events_state state = {};
     state.memfd.flags = ex_args->flags;
     ebpf_events_state__set(EBPF_EVENTS_STATE_MEMFD_CREATE, &state);
+    preempt_enable();
     return 0;
 }
 
@@ -531,25 +576,49 @@ out:
 SEC("fentry/hugetlb_file_setup")
 int BPF_PROG(fentry__hugetlb_file_setup, const char * name)
 {
-    return emit_memfd_create_event(name);
+    int r;
+
+    preempt_disable();
+    r = emit_memfd_create_event(name);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/hugetlb_file_setup")
 int BPF_KPROBE(kprobe__hugetlb_file_setup, const char * name)
 {
-    return emit_memfd_create_event(name);
+    int r;
+
+    preempt_disable();
+    r = emit_memfd_create_event(name);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("fentry/shmem_file_setup")
 int BPF_PROG(fentry__shmem_file_setup, const char * name)
 {
-    return emit_memfd_create_event(name);
+    int r;
+
+    preempt_disable();
+    r = emit_memfd_create_event(name);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/shmem_file_setup")
 int BPF_KPROBE(kprobe__shmem_file_setup, const char * name)
 {
-    return emit_memfd_create_event(name);
+    int r;
+
+    preempt_disable();
+    r = emit_memfd_create_event(name);
+    preempt_enable();
+
+    return r;
 }
 
 static int commit_creds__enter(struct cred *new)
@@ -625,13 +694,25 @@ out:
 SEC("fentry/commit_creds")
 int BPF_PROG(fentry__commit_creds, struct cred *new)
 {
-    return commit_creds__enter(new);
+    int r;
+
+    preempt_disable();
+    r = commit_creds__enter(new);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/commit_creds")
 int BPF_KPROBE(kprobe__commit_creds, struct cred *new)
 {
-    return commit_creds__enter(new);
+    int r;
+
+    preempt_disable();
+    r = commit_creds__enter(new);
+    preempt_enable();
+
+    return r;
 }
 
 #define MAX_NR_SEGS 8
@@ -773,11 +854,23 @@ out:
 SEC("fentry/tty_write")
 int BPF_PROG(fentry__tty_write, struct kiocb *iocb, struct iov_iter *from)
 {
-    return tty_write__enter(iocb, from);
+    int r;
+
+    preempt_disable();
+    r = tty_write__enter(iocb, from);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("kprobe/tty_write")
 int BPF_KPROBE(kprobe__tty_write, struct kiocb *iocb, struct iov_iter *from)
 {
-    return tty_write__enter(iocb, from);
+    int r;
+
+    preempt_disable();
+    r = tty_write__enter(iocb, from);
+    preempt_enable();
+
+    return r;
 }


### PR DESCRIPTION
Linux introduced a new form of preemption which is to become the default, PREEMPT_LAZY was introduced around 6.13 in 7c70cb94d29cd325fabe4a818c18613e3b9919a1.

It is a combination of voluntary and realtime preemption schemes. When one thread is to be preempted, it gets asked nicely by havin a flag set, it then voluntary preempts if it reaches a preemption point. But, if the scheduler tries to set the flag, but the flag is already set, meaning the thread has been a bad boi and didn't voluntary preempt itself, it forces a full switch on the spot.

This causes our probe to become actually preemptive, which is a first, and all our code has been written assuming probes would never be preemptive.

Around 6.10 bpf_{disable,enable}_preemption() has been added as a KFUNC, this commit adds it around every probe we install it if the KFUNC is there. This disregards the actual preemption model of the kernel, as we can't check it during runtime (it can change at any time). As a bonus, we should now actually function in RT kernels (I guess?).

The observed behaviour was a nasty corruption of the event buffer, which then made it to the ring buffer with invalid offsets, the "fields" and "field" size would get corrupted, as can be seen in this partial analysis of the ring buffer:

```
(gdb) x/256bx &$exec->vl_fields
0x7ffff6d99c00: 0x23 0x00 0x00 0x00 0x00 0x00 0x00 0x00 (0x23 should be nfields (4 bytes)) WHERE IS NFIELDS? WHERE IS SIZE?
0x7ffff6d99c08: 0x08 0x00 0x00 0x00 0x1b 0x00 0x00 0x00 (0x08 is in the upper half of the size_t (8bytes), 34359738368) 8 is also=EBPF_VL_FIELD_PIDS_SS_CGROUP_PATH
0x7ffff6d99c10: 0x2f 0x73 0x79 0x73 0x74 0x65 0x6d 0x2e (/system.slice/nrpe.service
0x7ffff6d99c18: 0x73 0x6c 0x69 0x63 0x65 0x2f 0x6e 0x72 .....
0x7ffff6d99c20: 0x70 0x65 0x2e 0x73 0x65 0x72 0x76 0x69 ....
0x7ffff6d99c28: 0x63 0x65 0x00 0x00 0x03 0xd0 0x16 0x00 ....)
```

This was figured out by Nick Berlin, Yours Truly and the help of a $VERY_NICE_AND_HELPFUL_CUSTOMER (Many Thanks!)

We could try to go over all data structures of our probes and think about re-entrancy, but I claim it to be the wrong approach, if all was written with the mindset of no preemption, the safest approach should be to recreate that view, and not try to work around it with it.

Nick provided a test program that rapidly reproduces the problem making quark-mon(8) crash, it should be visible in this commit's PR, and we will incorporate it in testing somehow.