### PR TITLE
make SYSLIB=y won't work with golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ define assert_no_syslib
   $(if $(SYSLIB), $(error cant build target $@ with SYSLIB))
 endef
 
+ifdef SYSLIB
+ifndef NO_GO
+$(error defining SYSLIB implies defining NO_GO, define both!)
+endif
+endif
+
 CFLAGS?= -g -O2 -fno-strict-aliasing -fPIC
 ifdef CENTOS7
 CFLAGS+= -std=gnu99 -DNO_PUSH_PRAGMA -DNO_MEMFD -DNO_SHM_OPEN
@@ -563,7 +569,7 @@ clean:
 		quark-kube-talker	\
 		quark-go-test		\
 		true			\
-		btf_prog_skel.h		\
+		bpf_probes_skel.h	\
 		init
 	$(Q)rm -rf initramfs
 


### PR DESCRIPTION
For now just make sure you have to specify both, otherwise it won't build and you'll get a criptic error, that's cause we're cheating on the golang dependencies.

While here, fix a typo in the clean target.