### PR TITLE
Add skeleton for the nova bpf probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,11 +184,10 @@ ifdef CENTOS7
 LIBBPF_EXTRA_CFLAGS+= -Wno-address
 endif
 
-# BPFPROG (kernel side)
-BPFPROG_OBJ:= bpf_probes.o
-BPFPROG_DEPS:= bpf_probes.c
+# BPFPROBES (kernel side)
+BPFPROBES_DEPS:= bpf_probes.c
 ifndef SYSLIB
-BPFPROG_DEPS+= $(LIBBPF_DEPS) $(EEBPF_FILES) include
+BPFPROBES_DEPS+= $(LIBBPF_DEPS) $(EEBPF_FILES) include
 endif
 
 # NOVA
@@ -257,11 +256,11 @@ $(LIBQUARK_OBJS): %.o: %.c $(LIBQUARK_DEPS)
 	$(Q)$(CC) -c $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) $<
 
 # careful! stupid bpftool writes to stdout even if it fails!
-bpf_probes_skel.h: $(BPFPROG_OBJ)
-	$(call msg,BPFTOOL,bpf_probes_skel.h)
-	$(Q)$(BPFTOOL) gen skeleton $(BPFPROG_OBJ) > bpf_probes_skel.h
+bpf_probes_skel.h: bpf_probes.o
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $^ > $@
 
-$(BPFPROG_OBJ): $(BPFPROG_DEPS)
+bpf_probes.o: $(BPFPROBES_DEPS)
 	$(call msg,BPF_CC,$@)
 	$(Q)$(BPF_CC)								\
 		-g -O2								\

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ EEBPF_FILES:= $(shell find elastic-ebpf)
 EEBPF_INCLUDES:= -Ielastic-ebpf/GPL/Events -Ielastic-ebpf/contrib/vmlinux/$(ARCH_ALT)
 
 # LIBQUARK
-LIBQUARK_DEPS:= $(wildcard *.h) bpf_probes_skel.h
+LIBQUARK_DEPS:= $(wildcard *.h) bpf_probes_skel.h nova_skel.h
 ifndef SYSLIB
 LIBQUARK_DEPS+= $(EEBPF_FILES) include
 endif
@@ -129,6 +129,7 @@ LIBQUARK_SRCS:=			\
 	hanson.c		\
 	kprobe_queue.c		\
 	parse.tab.c		\
+	nova_queue.c		\
 	qbtf.c			\
 	quark.c			\
 	qutil.c
@@ -190,6 +191,11 @@ ifndef SYSLIB
 BPFPROG_DEPS+= $(LIBBPF_DEPS) $(EEBPF_FILES) include
 endif
 
+# NOVA
+NOVA_DEPS:= nova.bpf.c
+ifndef SYSLIB
+NOVA_DEPS+= $(LIBBPF_DEPS) include
+endif
 # Go files
 GO_FILES:= $(shell find go/)
 QUARK_GO_DEPS:= $(LIBQUARK_DEPS) $(LIBQUARK_STATIC_BIG) $(GO_FILES)
@@ -250,6 +256,7 @@ $(LIBQUARK_OBJS): %.o: %.c $(LIBQUARK_DEPS)
 	$(call msg,CC,$@)
 	$(Q)$(CC) -c $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) $<
 
+# careful! stupid bpftool writes to stdout even if it fails!
 bpf_probes_skel.h: $(BPFPROG_OBJ)
 	$(call msg,BPFTOOL,bpf_probes_skel.h)
 	$(Q)$(BPFTOOL) gen skeleton $(BPFPROG_OBJ) > bpf_probes_skel.h
@@ -264,6 +271,21 @@ $(BPFPROG_OBJ): $(BPFPROG_DEPS)
 		$(CPPFLAGS)							\
 		$(EEBPF_INCLUDES)						\
 		-c bpf_probes.c							\
+		-o $@
+
+# careful! stupid bpftool writes to stdout even if it fails!
+nova_skel.h: nova.bpf.o
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $^ > $@
+
+nova.bpf.o: $(NOVA_DEPS)
+	$(call msg,BPF_CC,$@)
+	$(Q)$(BPF_CC)								\
+		-g -O2								\
+		-target $(BPF_ARCH)						\
+		-Ielastic-ebpf/contrib/vmlinux/$(ARCH_ALT)			\
+		$(CPPFLAGS)							\
+		-c nova.bpf.c							\
 		-o $@
 
 parse.tab.c: parse.y quark.h
@@ -314,8 +336,8 @@ CENTOS7_RUN_ARGS=$(QDOCKER)				\
 # These are targets that we can't build on centos7 since it's too old
 # We build them in the ubuntu24 docker container first, and then
 # continue with the rest of the build on centos7.
-CENTOS7_BORROW_TARGETS+=bpf_probes.o
-CENTOS7_BORROW_TARGETS+=bpf_probes_skel.h
+CENTOS7_BORROW_TARGETS+=bpf_probes.o bpf_probes_skel.h
+CENTOS7_BORROW_TARGETS+=nova.bpf.o nova_skel.h
 ifndef NO_GO
 CENTOS7_BORROW_TARGETS+=quark-kube-talker
 endif
@@ -570,6 +592,7 @@ clean:
 		quark-go-test		\
 		true			\
 		bpf_probes_skel.h	\
+		nova_skel.h		\
 		init
 	$(Q)rm -rf initramfs
 

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+/* Copyright (c) 2026 Elastic NV */
+
+#include "vmlinux.h"		/* XXX still getting the old one XXX */
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#include <linux/limits.h>
+
+SEC("lsm/file_open")
+int BPF_PROG(test_path, struct file *file)
+{
+	return (0);
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright (c) 2026 Elastic NV */
+
+#include <sys/epoll.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/sysinfo.h>
+
+#include <ctype.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <bpf/btf.h>
+
+#include "quark.h"
+/* #include "nova_skel.h" */
+
+struct nova_queue {
+	void	*nada;
+};
+
+static int	nova_queue_populate(struct quark_queue *);
+static int	nova_queue_update_stats(struct quark_queue *);
+static void	nova_queue_close(struct quark_queue *);
+
+struct quark_queue_ops queue_ops_qbpf = {
+	.open	      = nova_queue_open,
+	.populate     = nova_queue_populate,
+	.update_stats = nova_queue_update_stats,
+	.close	      = nova_queue_close,
+};
+
+int
+nova_queue_open(struct quark_queue *qq)
+{
+#ifdef notyet
+	if ((qq->flags & QQ_NOVA) == 0)
+		return (errno = ENOTSUP, -1);
+
+	return (0);
+#endif
+	return (errno = ENOTSUP, -1);
+}
+
+static int
+nova_queue_populate(struct quark_queue *qq)
+{
+	return (0);
+}
+
+static int
+nova_queue_update_stats(struct quark_queue *qq)
+{
+	return (0);
+}
+
+static void
+nova_queue_close(struct quark_queue *qq)
+{
+	/* NADA */
+}

--- a/quark.h
+++ b/quark.h
@@ -139,7 +139,10 @@ int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 
 /* kprobe_queue.c */
-int	kprobe_queue_open(struct quark_queue *);
+int			 kprobe_queue_open(struct quark_queue *);
+
+/* nova_queue.c */
+int			 nova_queue_open(struct quark_queue *);
 
 ssize_t		 qread(int, void *, size_t);
 int		 qwrite(int, const void *, size_t);
@@ -885,7 +888,8 @@ struct quark_queue_attr {
 #define QQ_PTRACE		(1 << 11)
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
-#define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)
+#define QQ_NOVA			(1 << 14)
+#define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)	/* QQ_NOVA excluded for now */
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */

--- a/quark.h
+++ b/quark.h
@@ -141,12 +141,6 @@ int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 /* kprobe_queue.c */
 int	kprobe_queue_open(struct quark_queue *);
 
-/* qutil.c */
-struct qstr {
-	char	*p;
-	char	 small[64];
-};
-
 ssize_t		 qread(int, void *, size_t);
 int		 qwrite(int, const void *, size_t);
 ssize_t		 qreadlinkat(int, const char *, char *, size_t);


### PR DESCRIPTION
Three commits, two minor nits, main one is:
```
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Mon Apr 13 10:48:36 2026 +0200

    Add skeleton for the nova bpf probes

    It's here, we're writing new probes. The goal is to be able to express the
    ruleset inside bpf, which preliminary results show it shouldn't be too hard.

    This will be a new queue QQ_NOVA, so that we can develop and break things freely
    while keeping QQ_BPF as it is, for now this is the plan, we can re-evaluate it
    in the medium term.

    Naming is hard, initially it would be qbpf, but it makes it too easy to mix
    things up, for example qbpf_queue.c X bpf_queue.c, QQ_EBPF vs QQ_QBPF.

    So pretend we're cool and name it "nova", no way to mix things up there.

    This only hooks up the build system with empty declarations.
```
