### PR TITLE
Nova loader

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1359,7 +1359,7 @@ bpf_queue_open(struct quark_queue *qq)
 
 	if (bpf_queue_open1(qq, 1) == -1) {
 		qwarn("bpf_queue_open failed with fentry, trying kprobe");
-		return bpf_queue_open1(qq, 0);
+		return (bpf_queue_open1(qq, 0));
 	}
 
 	return (0);

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -9,8 +9,8 @@
 
 #include <linux/limits.h>
 
-SEC("lsm/file_open")
-int BPF_PROG(test_path, struct file *file)
+SEC("lsm/task_alloc")
+int BPF_PROG(task_alloc, struct task_struct *task, __u64 clone_flags)
 {
 	return (0);
 }

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -17,17 +17,17 @@
 #include <bpf/btf.h>
 
 #include "quark.h"
-/* #include "nova_skel.h" */
+#include "nova_skel.h"
 
 struct nova_queue {
-	void	*nada;
+	struct nova_bpf	*nova_bpf;
 };
 
 static int	nova_queue_populate(struct quark_queue *);
 static int	nova_queue_update_stats(struct quark_queue *);
 static void	nova_queue_close(struct quark_queue *);
 
-struct quark_queue_ops queue_ops_qbpf = {
+struct quark_queue_ops queue_ops_nova = {
 	.open	      = nova_queue_open,
 	.populate     = nova_queue_populate,
 	.update_stats = nova_queue_update_stats,
@@ -37,13 +37,24 @@ struct quark_queue_ops queue_ops_qbpf = {
 int
 nova_queue_open(struct quark_queue *qq)
 {
-#ifdef notyet
+	struct nova_queue	*nqq;
+
 	if ((qq->flags & QQ_NOVA) == 0)
 		return (errno = ENOTSUP, -1);
 
+	if ((nqq = calloc(1, sizeof(*nqq))) == NULL)
+		return (-1);
+	if ((nqq->nova_bpf = nova_bpf__open_and_load()) == NULL)
+		goto fail;
+
+	qq->queue_be = nqq;
+	qq->queue_ops = &queue_ops_nova;
+	qq->stats.backend = QQ_NOVA;
+
 	return (0);
-#endif
-	return (errno = ENOTSUP, -1);
+fail:
+	nova_queue_close(qq);
+	return (-1);
 }
 
 static int
@@ -61,5 +72,12 @@ nova_queue_update_stats(struct quark_queue *qq)
 static void
 nova_queue_close(struct quark_queue *qq)
 {
-	/* NADA */
+	struct nova_queue	*nqq = qq->queue_be;
+
+	if (nqq == NULL)
+		return;
+
+	nova_bpf__destroy(nqq->nova_bpf);
+	free(nqq);
+	qq->queue_be = NULL;
 }

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl BbDEeFGgHhkMNSsTtv
+.Op Fl BbDEeFGgHhkMNnSsTtv
 .Op Fl C Ar filename
 .Op Fl K Ar kubeconfig
 .Op Fl l Ar maxlength
@@ -110,6 +110,8 @@ This is used purely for internal debugging.
 Run in a simple benchmark form that only counts and display stats.
 .It Fl N
 Enable DNS events (experimental).
+.It Fl n
+Attempt NOVA as the backend.
 .It Fl P Ar ppid
 Display only events where parent pid is
 .Ar ppid .

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -65,6 +65,7 @@ fetch_backend(struct quark_queue *qq)
 
 	return (s.backend == QQ_EBPF ? "ebpf" :
 	    s.backend == QQ_KPROBE ? "kprobe" :
+	    s.backend == QQ_NOVA ? "nova" :
 	    "invalid");
 }
 
@@ -116,7 +117,7 @@ static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s -h\n", program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNSsTtv]\n",
+	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNnSsTtv]\n",
 	    program_invocation_short_name);
 	fprintf(stderr, "%16c [-C filename ] [-K kubeconfig] "
 	    "[-l maxlength] [-m maxnodes]\n", ' ');
@@ -178,7 +179,7 @@ main(int argc, char *argv[])
 	kube_config = NULL;
 	print_event = print_dump;
 
-	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NP:Ttr:SsvV")) != -1) {
+	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsvV")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -260,6 +261,9 @@ main(int argc, char *argv[])
 			break;
 		case 'N':
 			qa.flags |= QQ_DNS;
+			break;
+		case 'n':
+			qa.flags |= QQ_NOVA;
 			break;
 		case 'P':
 			if (optarg == NULL)

--- a/quark-test.8
+++ b/quark-test.8
@@ -43,6 +43,8 @@ Display this manpage.
 Run only KPROBE tests.
 .It Fl l
 Prints all available tests on stdout.
+.It Fl b
+Run only NOVA tests.
 .It Fl t
 Print out the contents of
 .Pa /sys/kernel/tracing/trace_pipe

--- a/quark-test.c
+++ b/quark-test.c
@@ -81,6 +81,7 @@ enum {
 static int	noforkflag;	/* don't fork on each test */
 static int	bflag;		/* run bpf tests */
 static int	kflag;		/* run kprobe tests */
+static int	nflag;		/* run nova tests */
 static int	tflag;		/* listen to the tracepipe */
 static u64	boottime;
 static int	fancy_tty;
@@ -143,6 +144,8 @@ backend_of_attr(struct quark_queue_attr *qa)
 		be = QQ_EBPF;
 	else if (qa->flags & QQ_KPROBE)
 		be = QQ_KPROBE;
+	else if (qa->flags & QQ_NOVA)
+		be = QQ_NOVA;
 	else
 		errx(1, "bad flags");
 
@@ -2162,10 +2165,12 @@ t_trusted_pid(const struct test *t, struct quark_queue_attr *qa)
 #define T(_x)		{ S(_x), _x, 0, 0 }
 #define T_KPROBE(_x)	{ S(_x), _x, QQ_KPROBE, 0 }
 #define T_EBPF(_x)	{ S(_x), _x, QQ_EBPF, 0 }
+#define T_NOVA(_x)	{ S(_x), _x, QQ_NOVA, 0 }
 #define S(_x)		#_x
 struct test all_tests[] = {
 	T_EBPF(t_probe),
 	T_KPROBE(t_probe),
+	T_NOVA(t_probe),
 	T_EBPF(t_os_release),
 	T_KPROBE(t_os_release),
 	T_EBPF(t_fork_exec_exit),
@@ -2293,7 +2298,10 @@ run_test(struct progress *progress, struct test *t, struct quark_queue_attr *qa)
 	linepos = printf("%s", t->name);
 	if (be != -1) {
 		linepos += printf(" @ %s",
-		    be == QQ_EBPF ? "ebpf" : "kprobe");
+		    be == QQ_EBPF ? "ebpf" :
+		    be == QQ_KPROBE ? "kprobe" :
+		    be == QQ_NOVA ? "nova" :
+		    "unknown");
 	}
 
 	while (++linepos < STATUS_LINELEN)
@@ -2491,6 +2499,7 @@ run_tests(int argc, char *argv[])
 	int			 failed, i;
 	struct quark_queue_attr	 bpf_attr;
 	struct quark_queue_attr	 kprobe_attr;
+	struct quark_queue_attr	 nova_attr;
 	struct quark_queue_attr	*attr;
 	struct progress		 progress;
 
@@ -2505,6 +2514,12 @@ run_tests(int argc, char *argv[])
 	kprobe_attr.flags |= QQ_KPROBE | QQ_ENTRY_LEADER;
 	kprobe_attr.hold_time = 100;
 	kprobe_attr.max_env = 32768;
+
+	quark_queue_default_attr(&nova_attr);
+	nova_attr.flags &= ~QQ_ALL_BACKENDS;
+	nova_attr.flags |= QQ_NOVA | QQ_ENTRY_LEADER;
+	nova_attr.hold_time = 100;
+	nova_attr.max_env = 32768;
 
 	bzero(&progress, sizeof(progress));
 	failed = 0;
@@ -2526,7 +2541,8 @@ run_tests(int argc, char *argv[])
 	 */
 	for (t = all_tests; t->name != NULL; t++) {
 		if ((t->backend == QQ_EBPF && !bflag) ||
-		    (t->backend == QQ_KPROBE && !kflag))
+		    (t->backend == QQ_KPROBE && !kflag) ||
+		    (t->backend == QQ_NOVA && !nflag))
 			t->excluded = 1;
 	}
 
@@ -2547,6 +2563,8 @@ run_tests(int argc, char *argv[])
 			attr = &bpf_attr;
 		else if (t->backend == QQ_KPROBE)
 			attr = &kprobe_attr;
+		else if (t->backend == QQ_NOVA)
+			attr = &nova_attr;
 		else
 			attr = NULL;
 		if (run_test(&progress, t, attr) != 0)
@@ -2574,7 +2592,7 @@ main(int argc, char *argv[])
 	fancy_tty = probe_fancy_tty();
 	in_valgrind = getenv("VALGRIND") != NULL;
 
-	while ((ch = getopt(argc, argv, "1bhkltvVx:")) != -1) {
+	while ((ch = getopt(argc, argv, "1bhklntvVx:")) != -1) {
 		switch (ch) {
 		case '1':
 			noforkflag = 1;
@@ -2594,6 +2612,9 @@ main(int argc, char *argv[])
 		case 'l':
 			display_tests();
 			break;	/* NOTREACHED */
+		case 'n':
+			nflag = 1;
+			break;
 		case 't':
 			tflag = 1;
 			break;
@@ -2616,7 +2637,10 @@ main(int argc, char *argv[])
 
 	boottime = fetch_boottime();
 
-	if (!bflag && !kflag)
+	/*
+	 * Run bpf and kprobe by default, don't run nova
+	 */
+	if (!bflag && !kflag && !nflag)
 		bflag = kflag = 1;
 
 	argc -= optind;

--- a/quark.c
+++ b/quark.c
@@ -4063,7 +4063,8 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	 */
 	if (qa->flags & QQ_BYPASS) {
 		if ((qa->flags &
-		    (QQ_KPROBE|QQ_ENTRY_LEADER|QQ_MIN_AGG|QQ_THREAD_EVENTS)) ||
+		    (QQ_KPROBE|QQ_NOVA|QQ_ENTRY_LEADER|
+		    QQ_MIN_AGG|QQ_THREAD_EVENTS)) ||
 		    !(qa->flags & QQ_EBPF) ||
 		    qa->kubefd != -1)
 			return (errno = EINVAL, -1);
@@ -4075,7 +4076,8 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 		qa->max_length = 1;
 	}
 
-	if ((qa->flags & QQ_ALL_BACKENDS) == 0 ||
+	/* XXX hardcode QQ_NOVA for now XXX */
+	if ((qa->flags & (QQ_ALL_BACKENDS | QQ_NOVA)) == 0 ||
 	    qa->max_length <= 0 ||
 	    qa->cache_grace_time < 0 ||
 	    qa->hold_time < 10)
@@ -4185,7 +4187,9 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	/*
 	 * Open the rings
 	 */
-	if (bpf_queue_open(qq) && kprobe_queue_open(qq)) {
+	if (nova_queue_open(qq) != 0 &&
+	    bpf_queue_open(qq) != 0 &&
+	    kprobe_queue_open(qq) != 0) {
 		qwarnx("all backends failed");
 		goto fail;
 	}


### PR DESCRIPTION
```
Hook nova probes into QQ_NOVA and t_probe.
This adds the remaining bits so we can start loading the probes and adding tests
to quark-test(8).

QQ_NOVA will likely remain outside of QQ_ALL_BACKENDS until everything else is
in place.
```