### PR TITLE
Nova ruleset evaluation in bpf probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,13 @@ EEBPF_FILES:= $(shell find elastic-ebpf)
 EEBPF_INCLUDES:= -Ielastic-ebpf/GPL/Events -Ielastic-ebpf/contrib/vmlinux/$(ARCH_ALT)
 
 # LIBQUARK
-LIBQUARK_DEPS:= $(wildcard *.h) bpf_probes_skel.h nova_skel.h
+LIBQUARK_DEPS:= $(wildcard *.h)
+LIBQUARK_DEPS:= $(filter-out nova_skel.h, $(LIBQUARK_DEPS))
+LIBQUARK_DEPS:= $(filter-out bpf_probes_skel.h, $(LIBQUARK_DEPS))
+LIBQUARK_DEPS:= $(filter-out manpages.h, $(LIBQUARK_DEPS))
 ifndef SYSLIB
 LIBQUARK_DEPS+= $(EEBPF_FILES) include
 endif
-LIBQUARK_DEPS:= $(filter-out manpages.h, $(LIBQUARK_DEPS))
 LIBQUARK_SRCS:=			\
 	base64.c		\
 	bpf_queue.c		\
@@ -191,7 +193,7 @@ BPFPROBES_DEPS+= $(LIBBPF_DEPS) $(EEBPF_FILES) include
 endif
 
 # NOVA
-NOVA_DEPS:= nova.bpf.c
+NOVA_DEPS:= nova.bpf.c nova.h
 ifndef SYSLIB
 NOVA_DEPS+= $(LIBBPF_DEPS) include
 endif
@@ -255,6 +257,9 @@ $(LIBQUARK_OBJS): %.o: %.c $(LIBQUARK_DEPS)
 	$(call msg,CC,$@)
 	$(Q)$(CC) -c $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) $<
 
+# Explicit dependency so we only rebuild bpf_queue.o when the skel changes
+bpf_queue.o: bpf_probes_skel.h
+
 # careful! stupid bpftool writes to stdout even if it fails!
 bpf_probes_skel.h: bpf_probes.o
 	$(call msg,BPFTOOL,$@)
@@ -271,6 +276,9 @@ bpf_probes.o: $(BPFPROBES_DEPS)
 		$(EEBPF_INCLUDES)						\
 		-c bpf_probes.c							\
 		-o $@
+
+# Explicit dependency so we only rebuild nova_queue.o when the skel changes
+nova_queue.o: nova_skel.h
 
 # careful! stupid bpftool writes to stdout even if it fails!
 nova_skel.h: nova.bpf.o

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -7,11 +7,112 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 
-#include <linux/limits.h>
+#include "nova.h"
+
+/* XXX check if there isn't something like this on the headers XXX */
+#define LOOP_CONTINUE	0
+#define LOOP_STOP	1
+
+#define E2BIG		7
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct nova_rule);
+} scratch_rule SEC(".maps");
+
+#define my_rule_eval_ctx()	bpf_map_lookup_elem(&scratch_rule, &(int){0})
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, struct nova_rule);
+	__uint(max_entries, NOVA_MAX_RULES);
+} ruleset SEC(".maps");
+
+struct rule_eval_loop_ctx {
+	struct nova_rule	*rctx;
+	struct nova_rule	*match;
+};
+
+extern void bpf_preempt_disable(void) __ksym __weak;
+
+static void preempt_disable(void)
+{
+	if (bpf_ksym_exists(bpf_preempt_disable))
+		bpf_preempt_disable();
+}
+
+extern void bpf_preempt_enable(void) __ksym __weak;
+
+static void preempt_enable(void)
+{
+	if (bpf_ksym_exists(bpf_preempt_enable))
+		bpf_preempt_enable();
+}
+
+static int
+rule_eval_loop(__u32 i, struct rule_eval_loop_ctx *lctx)
+{
+	struct nova_rule	*cand;
+	struct nova_rule	*rctx;
+
+	rctx = lctx->rctx;
+	if (rctx == NULL ||
+	    ((cand = bpf_map_lookup_elem(&ruleset, &i)) == NULL))
+		return (LOOP_CONTINUE); /* XXX signal something is really wrong XXX */
+	rctx->fields = 0;
+	rctx->fields |= (__u64)(rctx->pid == cand->pid) * QUARK_RF_PROCESS_PID;
+	rctx->fields |= (__u64)(rctx->ppid == cand->ppid) * QUARK_RF_PROCESS_PPID;
+	rctx->fields |= (__u64)(rctx->uid == cand->uid) * QUARK_RF_PROCESS_UID;
+	rctx->fields |= (__u64)(rctx->gid == cand->gid) * QUARK_RF_PROCESS_GID;
+	rctx->fields |= (__u64)(rctx->sid == cand->sid) * QUARK_RF_PROCESS_SID;
+	rctx->fields |= (__u64)(rctx->poison_tag == cand->poison_tag) * QUARK_RF_POISON;
+
+	if ((rctx->fields & cand->fields) == cand->fields) {
+		lctx->match = cand;
+
+		return (LOOP_STOP);
+	}
+
+	return (LOOP_CONTINUE);
+}
+
+static int
+rule_eval(struct nova_rule *rctx)
+{
+	struct rule_eval_loop_ctx	lctx;
+	int				r;
+
+	lctx.rctx = rctx;
+	lctx.match = NULL;
+
+	r = bpf_loop(NOVA_MAX_RULES, rule_eval_loop, &lctx, 0);
+	if (r < 0) {
+		bpf_printk("bad bpf_loop %d", r);
+		return (0);
+	}
+	if (lctx.match == NULL)
+		return (0);
+
+	return (0);
+}
 
 SEC("lsm/task_alloc")
 int BPF_PROG(task_alloc, struct task_struct *task, __u64 clone_flags)
 {
+	struct nova_rule	*rctx;
+	int			 r;
+
+	bpf_preempt_disable();
+
+	rctx = my_rule_eval_ctx();
+	r = rule_eval(rctx);
+	/* XXX r ignored for now */
+
+	bpf_preempt_enable();
+
 	return (0);
 }
 

--- a/nova.h
+++ b/nova.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright (c) 2026 Elastic NV */
+
+#ifndef _NOVA_H_
+#define _NOVA_H_
+
+#define NOVA_MAX_RULES	1024
+
+#define QUARK_RF_PROCESS_PID		(1ULL << 0)
+#define QUARK_RF_PROCESS_PPID		(1ULL << 1)
+#define QUARK_RF_PROCESS_UID		(1ULL << 2)
+#define QUARK_RF_PROCESS_GID		(1ULL << 3)
+#define QUARK_RF_PROCESS_SID		(1ULL << 4)
+#define QUARK_RF_PROCESS_COMM		(1ULL << 5)
+#define QUARK_RF_PROCESS_FILENAME	(1ULL << 6)
+#define QUARK_RF_FILE_PATH		(1ULL << 7)
+#define QUARK_RF_POISON			(1ULL << 8)
+
+enum quark_rule_action {
+	QUARK_RA_INVALID,
+	QUARK_RA_DROP,
+	QUARK_RA_PASS,
+	QUARK_RA_POISON,
+};
+
+struct nova_rule {
+	enum quark_rule_action	action;
+	__u64			fields;	/* QUARK_RF_* bitmask */
+	__u32			pid;
+	__u32			ppid;
+	__u32			uid;
+	__u32			gid;
+	__u32			sid;
+	char			comm[16];
+	__u64			poison_tag;
+};
+
+#endif /* _NOVA_H_ */

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -34,6 +34,95 @@ struct quark_queue_ops queue_ops_nova = {
 	.close	      = nova_queue_close,
 };
 
+static int
+nova_rule_from_quark(struct nova_rule *nr, struct quark_rule *qr)
+{
+	size_t			 i;
+	struct quark_rule_field *field;
+
+	bzero(nr, sizeof(*nr));
+
+	for (i = 0; i < qr->n_fields; i++) {
+		field = qr->fields + i;
+
+		switch (field->code) {
+		case QUARK_RF_PROCESS_PID:
+			nr->pid = field->id;
+			break;
+		case QUARK_RF_PROCESS_PPID:
+			nr->ppid = field->id;
+			break;
+		case QUARK_RF_PROCESS_UID:
+			nr->uid = field->id;
+			break;
+		case QUARK_RF_PROCESS_GID:
+			nr->gid = field->id;
+			break;
+		case QUARK_RF_PROCESS_SID:
+			nr->sid = field->id;
+			break;
+		case QUARK_RF_PROCESS_COMM:
+			strlcpy(nr->comm, field->comm, sizeof(nr->comm));
+			break;
+		case QUARK_RF_PROCESS_FILENAME:
+			/* TODO */
+			errno = ENOTSUP;
+			qwarn("QUARK_RF_PROCESS_FILENAME");
+			return (-1);
+			break;
+		case QUARK_RF_FILE_PATH:
+			/* TODO */
+			errno = ENOTSUP;
+			qwarn("QUARK_RF_FILE_PATH");
+			return (-1);
+			break;
+		case QUARK_RF_POISON:
+			nr->poison_tag = field->poison_tag;
+			break;
+		default:
+			errno = EINVAL;
+			qwarn("bad field->code %llu", field->code);
+			return (-1);
+			break;
+		}
+
+		nr->fields |= field->code;
+	}
+
+	nr->action = qr->action;
+
+	return (0);
+}
+
+static int
+load_ruleset(struct quark_queue *qq, struct nova_queue *nqq)
+{
+	u32			 i;
+	struct nova_bpf		*nova_bpf;
+	struct nova_rule	 nr;
+
+	if (qq->ruleset == NULL)
+		return (0);
+	if (qq->ruleset->n_rules > NOVA_MAX_RULES)
+		return (errno = EFBIG, -1);
+	if ((nova_bpf = nqq->nova_bpf) == NULL)
+		return (errno = EINVAL, -1);
+
+	for (i = 0; i < (u32)qq->ruleset->n_rules; i++) {
+		if (nova_rule_from_quark(&nr, qq->ruleset->rules + i) == -1) {
+			qwarn("quark_rule_to_nova");
+			return (-1);
+		}
+		if (bpf_map__update_elem(nova_bpf->maps.ruleset, &i, sizeof(i),
+		    &nr, sizeof(nr), BPF_ANY) != 0) {
+			qwarn("bpf_map__update_elem %d", i);
+			return (-1);
+		}
+	}
+
+	return (0);
+}
+
 int
 nova_queue_open(struct quark_queue *qq)
 {
@@ -45,6 +134,10 @@ nova_queue_open(struct quark_queue *qq)
 	if ((nqq = calloc(1, sizeof(*nqq))) == NULL)
 		return (-1);
 	if ((nqq->nova_bpf = nova_bpf__open_and_load()) == NULL)
+		goto fail;
+	if (load_ruleset(qq, nqq) == -1)
+		goto fail;
+	if (nova_bpf__attach(nqq->nova_bpf) != 0)
 		goto fail;
 
 	qq->queue_be = nqq;

--- a/quark-test.8
+++ b/quark-test.8
@@ -43,7 +43,7 @@ Display this manpage.
 Run only KPROBE tests.
 .It Fl l
 Prints all available tests on stdout.
-.It Fl b
+.It Fl n
 Run only NOVA tests.
 .It Fl t
 Print out the contents of

--- a/quark.h
+++ b/quark.h
@@ -18,6 +18,9 @@
 /* Compat, tree.h, queue.h */
 #include "compat.h"
 
+/* Shared quark_rule definitions are in nova.h */
+#include "nova.h"
+
 /* Misc */
 #ifndef ALIGN_UP
 #define ALIGN_UP(_p, _b) (((u64)(_p) + ((_b) - 1)) & ~((_b) - 1))
@@ -768,24 +771,10 @@ struct quark_group {
 	char			*name;
 };
 
-enum quark_rule_field_code {
-	QUARK_RF_NONE,
-	QUARK_RF_PROCESS_PID,
-	QUARK_RF_PROCESS_PPID,
-	QUARK_RF_PROCESS_UID,
-	QUARK_RF_PROCESS_GID,
-	QUARK_RF_PROCESS_SID,
-	QUARK_RF_PROCESS_COMM,
-	QUARK_RF_PROCESS_FILENAME,
-	QUARK_RF_FILE_PATH,
-	QUARK_RF_POISON,
-	QUARK_RF_MAX,
-};
-
 /* Rule Field */
 struct quark_rule_field {
-	enum quark_rule_field_code	code;
-	size_t				wildcard_len;
+	u64		 code;
+	size_t		 wildcard_len;
 	union {
 		u32	 pid;
 		u64	 poison_tag;
@@ -793,13 +782,6 @@ struct quark_rule_field {
 		u32	 id;
 		char	 comm[16];
 	};
-};
-
-enum quark_rule_action {
-	QUARK_RA_INVALID,
-	QUARK_RA_DROP,
-	QUARK_RA_PASS,
-	QUARK_RA_POISON,
 };
 
 struct quark_rule {


### PR DESCRIPTION
This implements the basic rule matching for nova probes, this diff does
basically two things:

o - Actually load QQ_NOVA probes
o - Installs the quark_ruleset into the BPF probes so we can evaluate rules in
    kernel land. Path matching is still missing but this is a good start.

We support 1024 rules, and for the first version we will require 5.17 so we have
bpf_loop(). We do some slightly smart things like diminishing the amount of
branches the verifier has to calculate by doing branchless comparisons in the
evaluation loop, this is likely not necessary for 5.17 as bpf_loop() saves a lot
of budget.

Next step is implementing path matching via bpf_strncmp() or manually, since we
likely don't need TRIE for this.
