### PR TITLE
Minor fixes, Update Container & clang-20+ fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM ubuntu:24.04
-ENV BPFTOOL="/usr/lib/linux-tools/6.11.0-26-generic/bpftool"
+FROM ubuntu:26.04
 ENV HOME=/tmp/quark-builder
 RUN apt-get update && apt-get install -y		\
 	bison						\
+	bpftool                                         \
 	clang						\
 	cpio						\
 	gcc						\
 	golang						\
 	gcc-aarch64-linux-gnu				\
-	linux-tools-6.11.0-26-generic			\
 	make						\
 	m4

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,5 +1,9 @@
 FROM centos:7
+ENV HOME=/tmp/centos7-quark-builder
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
-RUN yum install -y bison gcc make m4 less
+RUN yum install -y bison gcc make m4 less curl
+RUN cd /tmp && curl -L -O https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go1.26.2.linux-amd64.tar.gz
+ENV PATH="$PATH:/usr/local/go/bin"

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ LIBBPF_DEPS+=	$(ELFTOOLCHAIN_FILES)			\
 endif
 LIBBPF_EXTRA_CFLAGS:= -DQUARK
 LIBBPF_EXTRA_CFLAGS+= -fPIC
+LIBBPF_EXTRA_CFLAGS+= -Wno-discarded-qualifiers
 LIBBPF_EXTRA_CFLAGS+= -I../../elftoolchain/libelf
 LIBBPF_EXTRA_CFLAGS+= -I../../elftoolchain/common
 LIBBPF_EXTRA_CFLAGS+= -I../../zlib

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 
 CFLAGS?= -g -O2 -fno-strict-aliasing -fPIC
 ifdef CENTOS7
-CFLAGS+= -std=gnu99 -DNO_PUSH_PRAGMA -DNO_MEMFD -DNO_SHM_OPEN
+CFLAGS+= -std=gnu99
 endif
 
 CPPFLAGS+= -D_GNU_SOURCE
@@ -62,7 +62,9 @@ ifndef MUSL
 CPPFLAGS+= -DHAVE_GETPWENT_R
 CPPFLAGS+= -DHAVE_GETGRENT_R
 endif
-ifndef CENTOS7
+ifdef CENTOS7
+CPPFLAGS+= -DNO_MEMFD -DNO_SHM_OPEN
+else
 CPPFLAGS+= -DHAVE_EXPLICIT_BZERO
 CPPFLAGS+= -DHAVE_REALLOCARRAY
 CPPFLAGS+= -DHAVE_STATIC_ASSERT
@@ -345,9 +347,6 @@ CENTOS7_RUN_ARGS=$(QDOCKER)				\
 # continue with the rest of the build on centos7.
 CENTOS7_BORROW_TARGETS+=bpf_probes.o bpf_probes_skel.h
 CENTOS7_BORROW_TARGETS+=nova.bpf.o nova_skel.h
-ifndef NO_GO
-CENTOS7_BORROW_TARGETS+=quark-kube-talker
-endif
 
 centos7: clean-all docker-image centos7-image
 	# We first make only bpf_probes.o, bpf_probes_skel.h and quark-kube-talker

--- a/base64.c
+++ b/base64.c
@@ -189,7 +189,7 @@ qb64_pton(char const *src, u_char *target, size_t targsize)
 {
 	u_int tarindex, state;
 	int ch;
-	char *pos;
+	const char *pos;
 
 	state = 0;
 	tarindex = 0;

--- a/elastic-ebpf/GPL/Events/Helpers.h
+++ b/elastic-ebpf/GPL/Events/Helpers.h
@@ -155,20 +155,36 @@ static long read_kernel_str_or_empty_str(void *dst, int size, const void *unsafe
     return ret;
 }
 
-static long ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct *task)
+// These should be kept _well_ under half the size of the event_buffer_map or
+// the verifier will be unhappy due to bounds checks. Putting a cap on these
+// things also prevents any one process from DoS'ing and filling up the
+// ringbuffer with super rapid-fire events.
+#define ARGV_MAX 20480u
+#define ENV_MAX 40960u
+
+static long ebpf_argv__fill(char *buf, const struct task_struct *task)
 {
-    unsigned long start, end, size;
+    unsigned long start, end;
+    u32 size;
 
     start = BPF_CORE_READ(task, mm, arg_start);
     end   = BPF_CORE_READ(task, mm, arg_end);
 
-    if (end <= start) {
-        buf[0] = '\0';
-        return 1;
-    }
+    /* Make sure we NUL terminate if we bail */
+    buf[0] = 0;
 
-    size = end - start;
-    size = size > buf_size ? buf_size : size;
+    if (start >= end)
+	    return 1;
+
+    /*
+     * Make sure we never narrow a 64bit to 32bit, in older kernels, 5.10,
+     * depending on the code clang-20+ emits, we might end up narrowing the
+     * computation, which makes the verifier lose track of bounds.
+     */
+    size = (u32)(end - start);
+    if (size == 0)
+            return 1;
+    size = size > ARGV_MAX ? ARGV_MAX : size;
 
     bpf_probe_read_user(buf, size, (void *)start);
 
@@ -178,20 +194,29 @@ static long ebpf_argv__fill(char *buf, size_t buf_size, const struct task_struct
     return size;
 }
 
-static long ebpf_env__fill(char *buf, size_t buf_size, const struct task_struct *task)
+static long ebpf_env__fill(char *buf, const struct task_struct *task)
 {
-    unsigned long start, end, size;
+    unsigned long start, end;
+    u32 size;
 
     start = BPF_CORE_READ(task, mm, env_start);
     end   = BPF_CORE_READ(task, mm, env_end);
 
-    if (end <= start) {
-        buf[0] = '\0';
-        return 1;
-    }
+    /* Make sure we NUL terminate if we bail */
+    buf[0] = 0;
 
-    size = end - start;
-    size = size > buf_size ? buf_size : size;
+    if (start >= end)
+	    return 1;
+
+    /*
+     * Make sure we never narrow a 64bit to 32bit, in older kernels, 5.10,
+     * depending on the code clang-20+ emits, we might end up narrowing the
+     * computation, which makes the verifier lose track of bounds.
+     */
+    size = (u32)(end - start);
+    if (size == 0)
+            return 1;
+    size = size > ENV_MAX ? ENV_MAX : size;
 
     bpf_probe_read_user(buf, size, (void *)start);
 

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -389,6 +389,15 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
 
         ebpf_vl_fields__init(&event->vl_fields);
         field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_DNS_BODY);
+        /*
+         * 5.10 kernels on clang-20+, for $REASONS, will result in code here
+         * that loses track of cap_len, so cap_len will be unbound (R4 in
+         * bpf_skb_load_bytes()).
+         */
+        barrier_var(cap_len);
+        if (cap_len > MAX_DNS_PACKET ||
+            cap_len < (__u32)(sizeof(struct iphdr) + sizeof(udp) + 12))
+                goto ignore;
         if (bpf_skb_load_bytes(skb, 0, field->data, cap_len))
             goto ignore;
         ebpf_vl_field__set_size(&event->vl_fields, field, cap_len);

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -22,16 +22,6 @@
 /* tty_write */
 DECL_FIELD_OFFSET(iov_iter, __iov);
 
-// Limits on large things we send up as variable length parameters.
-//
-// These should be kept _well_ under half the size of the event_buffer_map or
-// the verifier will be unhappy due to bounds checks. Putting a cap on these
-// things also prevents any one process from DoS'ing and filling up the
-// ringbuffer with super rapid-fire events.
-#define ARGV_MAX 20480
-#define ENV_MAX 40960
-#define TTY_OUT_MAX 8192
-
 #define S_ISUID 0004000
 #define S_ISGID 0002000
 
@@ -155,12 +145,12 @@ int BPF_PROG(sched_process_exec,
 
     // argv
     field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_ARGV);
-    size  = ebpf_argv__fill(field->data, ARGV_MAX, task);
+    size  = ebpf_argv__fill(field->data, task);
     ebpf_vl_field__set_size(&event->vl_fields, field, size);
 
     // env
     field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_ENV);
-    size  = ebpf_env__fill(field->data, ENV_MAX, task);
+    size  = ebpf_env__fill(field->data, task);
     ebpf_vl_field__set_size(&event->vl_fields, field, size);
 
     // cwd
@@ -717,11 +707,18 @@ int BPF_KPROBE(kprobe__commit_creds, struct cred *new)
 
 #define MAX_NR_SEGS 8
 
+// This should be kept _well_ under half the size of the event_buffer_map or
+// the verifier will be unhappy due to bounds checks. Putting a cap on these
+// things also prevents any one process from DoS'ing and filling up the
+// ringbuffer with super rapid-fire events.
+#define TTY_OUT_MAX 8192u
+
 static int output_tty_event(struct ebpf_tty_dev *slave, const void *base, size_t base_len)
 {
     struct ebpf_process_tty_write_event *event;
     struct ebpf_varlen_field *field;
     const struct task_struct *task;
+    u32 len_cap;
     int ret = 0;
 
     event = get_event_buffer();
@@ -734,7 +731,6 @@ static int output_tty_event(struct ebpf_tty_dev *slave, const void *base, size_t
     event->hdr.type          = EBPF_EVENT_PROCESS_TTY_WRITE;
     event->hdr.ts            = bpf_ktime_get_ns();
     event->hdr.ts_boot       = bpf_ktime_get_boot_ns_helper();
-    u64 len_cap              = base_len > TTY_OUT_MAX ? TTY_OUT_MAX : base_len;
     event->tty_out_truncated = base_len > TTY_OUT_MAX ? base_len - TTY_OUT_MAX : 0;
     event->tty               = *slave;
     ebpf_pid_info__fill(&event->pids, task);
@@ -746,6 +742,18 @@ static int output_tty_event(struct ebpf_tty_dev *slave, const void *base, size_t
 
     // tty_out
     field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_TTY_OUT);
+
+    /*
+     * DO NOT REMOVE THE CASTS OR A BIG AND SCARY MONSTER WILL COME AND EAT YOU!
+     * Old verifiers will lose the bound tracking when narrowing a 64bit
+     * register to 32bit, len_cap must be used as 32bit in
+     * bpf_probe_read_user(), meaning when we narrow from 64bit->32bit, it loses
+     * all bound checking, so make sure this never happens by keeping it all on
+     * 32bit land. This also depends on the compiler, so make sure to test on
+     * clang-20+.
+     */
+    len_cap = (u32)((u32)base_len > TTY_OUT_MAX ? TTY_OUT_MAX : (u32)base_len);
+
     if (bpf_probe_read_user(field->data, len_cap, base)) {
         ret = 1;
         goto out;

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -125,10 +125,10 @@ struct perf_group_leader {
 /*
  * Forbid padding on samples/wire structures
  */
-#ifndef NO_PUSH_PRAGMA
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 10))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wpadded"
-#endif	/* NO_PUSH_PRAGMA */
+#endif
 
 struct exec_sample {
 	struct perf_sample_data_loc	filename;
@@ -189,9 +189,9 @@ struct exec_connector_sample {
 	u64				stack[55];	/* sync with kprobe_defs */
 };
 
-#ifndef NO_PUSH_PRAGMA
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 10))
 #pragma GCC diagnostic pop
-#endif	/* NO_PUSH_PRAGMA */
+#endif
 
 /*
  * End samples/wire/ structures

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -15,6 +15,9 @@
 
 #define E2BIG		7
 
+extern void bpf_preempt_disable(void) __ksym __weak;
+extern void bpf_preempt_enable(void) __ksym __weak;
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
@@ -36,17 +39,15 @@ struct rule_eval_loop_ctx {
 	struct nova_rule	*match;
 };
 
-extern void bpf_preempt_disable(void) __ksym __weak;
-
-static void preempt_disable(void)
+static void
+preempt_disable(void)
 {
 	if (bpf_ksym_exists(bpf_preempt_disable))
 		bpf_preempt_disable();
 }
 
-extern void bpf_preempt_enable(void) __ksym __weak;
-
-static void preempt_enable(void)
+static void
+preempt_enable(void)
 {
 	if (bpf_ksym_exists(bpf_preempt_enable))
 		bpf_preempt_enable();

--- a/quark-test.c
+++ b/quark-test.c
@@ -1279,21 +1279,24 @@ t_shm_open(const struct test *t, struct quark_queue_attr *qa)
 	const struct quark_event	*qev;
 	const struct quark_shm		*qshm;
 	int				 fd, fd2;
+	char				 path[512];
 
 	qa->flags |= QQ_SHM | QQ_FILE;
 
+	snprintf(path, sizeof(path), "/quark_test-%s-%d", __func__, getpid());
+	(void)shm_unlink(path);
 	/*
 	 * Probes are bugged, a O_CREAT that actually creates a file, shows up
 	 * as a FILE events, not a SHM_OPEN.
 	 * See https://github.com/elastic/quark/issues/256
 	 */
-	if ((fd = shm_open("/shm_open-ohmyohmy", O_CREAT | O_RDWR, 0600)) == -1)
+	if ((fd = shm_open(path, O_CREAT | O_RDWR, 0600)) == -1)
 		err(1, "shm_open");
 
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	if ((fd2 = shm_open("/shm_open-ohmyohmy", O_RDWR, 0600)) == -1)
+	if ((fd2 = shm_open(path, O_RDWR, 0600)) == -1)
 		err(1, "shm_open");
 
 	qev = drain_for_pid(&qq, getpid());
@@ -1301,11 +1304,12 @@ t_shm_open(const struct test *t, struct quark_queue_attr *qa)
 
 	assert(qev->events & QUARK_EV_SHM);
 	assert(qshm->kind == QUARK_SHM_SHM_OPEN);
-	assert(!strcmp(qshm->path, "/dev/shm/shm_open-ohmyohmy"));
+	assert(strlen(qshm->path) > strlen("/dev/shm"));
+	assert(!strcmp(qshm->path + strlen("/dev/shm"), path));
 
 	close(fd2);
 	close(fd);
-	if (shm_unlink("/shm_open-ohmyohmy") == -1)
+	if (shm_unlink(path) == -1)
 		err(1, "shm_unlink");
 
 	quark_queue_close(&qq);

--- a/quark.c
+++ b/quark.c
@@ -1273,7 +1273,7 @@ kube_handle_pod(struct quark_queue *qq, cJSON *json)
 static void
 parse_provider_id(struct quark_kube_node *node, const char *provider_id)
 {
-	char	*sep, *project_end;
+	const char	*sep, *project_end;
 
 	if ((sep = strstr(provider_id, "://")) == NULL)
 		return;
@@ -2315,8 +2315,7 @@ quark_cmdline_iter_init(struct quark_cmdline_iter *qcmdi,
 const char *
 quark_cmdline_iter_next(struct quark_cmdline_iter *qcmdi)
 {
-	char *p;
-	const char *arg;
+	const char	*p, *arg;
 
 	if (qcmdi->off >= qcmdi->cmdline_len)
 		return (NULL);

--- a/qutil.c
+++ b/qutil.c
@@ -309,7 +309,7 @@ qlog_func(int pri, int do_errno, const char *func, int lineno,
 const char *
 safe_basename(const char *path)
 {
-	char	*p;
+	const char	*p;
 
 	p = strrchr(path, '/');
 


### PR DESCRIPTION
Once upon a time this was a very simple group of commits, now it's a very simple group of commits + 1 not simple.

Each commit is independent:

* Minor style nits - easy peasy
* Fix golang builds on centos7 - easy peasy
* Improve t_shm_open() - easy peasy
* Update the docker builder to ubuntu26.04 - easy peasy
* Make sure our probes load on 5.10 and clang-20+ - **oh noes**

Here is the last commit log:
```
commit e47c20fbc10a9da4f433799f7a8c3a42a16fdc57 (HEAD -> cut-the-slack, origin/cut-the-slack)
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri Apr 24 11:20:56 2026 +0200

    Make sure our probes load on 5.10 and clang-20+

    5.10 and older backported kernels, like 4.18 will lose bound tracking of a
    register when it narrows from 64bit to 32bit, this makes the verifier freak out
    depending on how clang generates the code.

    We were lucky that clang-{18,19} emitted code the verifier was happy on 5.10.
    But on clang-{20,21} it will emit code the verifier complains about unbounded
    check. In the DNS case I had to add a barrier to force clang to not optimize the
    recomputation away. The others were easier and we fix it by just making sure we
    stay always on 32bit.

    Just to be clear, this is an issue on older (5.10ish) and depends on the emitted
    code.
```