### PR TITLE
Add stats to nova_rule evaluations/matches, guard libbpf cpus.

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -6,6 +6,7 @@
 #include <sys/mount.h>
 #include <sys/sysinfo.h>
 
+#include <assert.h>
 #include <ctype.h>
 #include <err.h>
 #include <errno.h>
@@ -1387,23 +1388,42 @@ static int
 bpf_queue_update_stats(struct quark_queue *qq)
 {
 	struct bpf_queue	*bqq  = qq->queue_be;
-	struct ebpf_event_stats	 pcpu_ees[libbpf_num_possible_cpus()];
+	struct ebpf_event_stats	*pcpu_ees;
 	u32			 zero = 0;
 	u64			 lost;
-	int			 i;
+	int			 i, num_cpus;
 
-	/* valgrind doesn't track that this will be updated below */
-	bzero(pcpu_ees, sizeof(pcpu_ees));
+	if ((num_cpus = libbpf_num_possible_cpus()) <= 0) {
+		qwarnx("bad libbpf_num_possible_cpus: %d", num_cpus);
+		return (-1);
+	}
+	if ((pcpu_ees = calloc(num_cpus, sizeof(*pcpu_ees))) == NULL) {
+		qwarn("calloc");
+		return (-1);
+	}
+
+#ifdef HAVE_STATIC_ASSERT
+	static_assert(sizeof(*pcpu_ees) % 8 == 0,
+	    "struct ebpf_event_stats must be 8 byte aligned");
+#endif
 
 	if (bpf_map__lookup_elem(bqq->probes->maps.ringbuf_stats, &zero,
-	    sizeof(zero), pcpu_ees, sizeof(pcpu_ees), 0) != 0)
-		return (-1);
+	    sizeof(zero), pcpu_ees, sizeof(*pcpu_ees) * num_cpus, 0) != 0) {
+		qwarn("bpf_map__lookup_elem");
+		goto fail;
+	}
 
-	for (i = 0, lost = 0; i < libbpf_num_possible_cpus(); i++)
+	for (i = 0, lost = 0; i < num_cpus; i++)
 		lost += pcpu_ees[i].lost;
 	qq->stats.lost = lost;
+	free(pcpu_ees);
 
 	return (0);
+
+fail:
+	free(pcpu_ees);
+
+	return (-1);
 }
 
 static void

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -445,6 +445,6 @@ struct ebpf_event_stats {
     uint64_t lost;          // lost events due to a full ringbuffer
     uint64_t sent;          // events sent through the ringbuffer
     uint64_t dns_zero_body; // indicates that the dns body of a sk_buff was unavailable
-};
+} __attribute__((aligned(8)));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -43,6 +43,13 @@ struct {
 	__uint(max_entries, NOVA_MAX_RULES);
 } ruleset SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, NOVA_MAX_RULES);
+	__type(key, __u32);
+	__type(value, struct nova_rule_pcpu);
+} ruleset_pcpu SEC(".maps");
+
 const volatile u_int	rules_active;
 
 /*
@@ -83,13 +90,18 @@ static int
 eval_loop(__u32 i, struct eval *eval)
 {
 	struct nova_rule	*rule;
+	struct nova_rule_pcpu	*rule_pcpu;
 	__u64			*v, matched;
 
 	if ((rule = bpf_map_lookup_elem(&ruleset, &i)) == NULL) {
 		bpf_printk("rule not found, this is a bug");
 		return (LOOP_CONTINUE);
 	}
-	rule->evals++;		/* XXX RACY XXX */
+	if ((rule_pcpu = bpf_map_lookup_elem(&ruleset_pcpu, &i)) == NULL) {
+		bpf_printk("rule_pcpu not found, this is a bug");
+		return (LOOP_CONTINUE);
+	}
+	rule_pcpu->evals++;
 
 	/*
 	 * matched is a bitmask of fields that match (are equal).
@@ -127,8 +139,8 @@ eval_loop(__u32 i, struct eval *eval)
 
 	matched &= eval->fields;
 	if ((matched & rule->fields) == rule->fields) {
-		rule->hits++;
-		eval->match = rule; /* XXX RACY XXX */
+		rule_pcpu->hits++;
+		eval->match = rule;
 		return (LOOP_STOP);
 	}
 

--- a/nova.h
+++ b/nova.h
@@ -9,6 +9,13 @@
 #pragma GCC diagnostic error "-Wpadded"
 #endif
 
+/*
+ * Redefine since we can't pull compat.h
+ */
+#ifndef __aligned
+#define __aligned(x)	__attribute__((aligned(x)))
+#endif	/* __aligned */
+
 #define NOVA_MAX_RULES	1024
 #define NOVA_MAX_PATHS	(NOVA_MAX_RULES * 2)
 #define NOVA_PATHLEN	250	/* including NUL */
@@ -52,8 +59,6 @@ struct path_lpm_key {
 #define PATH_LPM_KEYLEN (sizeof(struct path_lpm_key) - 4)
 
 struct nova_rule {
-	__u64	hits;			/* counter */
-	__u64	evals;			/* counter */
 	__u64	fields;			/* QUARK_RF_* bitmask */
 	__u64	poison_tag;		/* QUARK_RF_POISON */
 	__u32	number;			/* starting from 0 */
@@ -66,6 +71,11 @@ struct nova_rule {
 	__u32	pad0;
 	char	comm[16];		/* QUARK_RF_COMM */
 };
+
+struct nova_rule_pcpu {
+	__u64	hits;			/* counter */
+	__u64	evals;			/* counter */
+} __aligned(8);
 
 #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 10))
 #pragma GCC diagnostic pop

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -243,7 +243,55 @@ nova_queue_populate(struct quark_queue *qq)
 static int
 nova_queue_update_stats(struct quark_queue *qq)
 {
+	struct nova_queue	*nqq	  = qq->queue_be;
+	struct nova_bpf		*nova_bpf = nqq->nova_bpf;
+	struct nova_rule_pcpu	*rule_pcpu;
+	int			 num_cpus;
+	struct quark_rule	*qr;
+	u32			 i;
+	int			 j;
+
+	if (qq->ruleset == NULL)
+		return (0);
+
+	if ((num_cpus = libbpf_num_possible_cpus()) <= 0) {
+		qwarnx("bad libbpf_num_possible_cpus: %d", num_cpus);
+		return (-1);
+	}
+	if ((rule_pcpu = calloc(num_cpus, sizeof(*rule_pcpu))) == NULL) {
+		qwarn("calloc");
+		return (-1);
+	}
+#ifdef HAVE_STATIC_ASSERT
+	static_assert(sizeof(*rule_pcpu) % 8 == 0,
+	    "struct nova_rule_pcpu must be 8 byte aligned");
+#endif
+
+	for (i = 0; i < (u32)qq->ruleset->n_rules; i++) {
+		qr = qq->ruleset->rules + i;
+
+		qr->evals = 0;
+		qr->hits = 0;
+
+		if (bpf_map__lookup_elem(nova_bpf->maps.ruleset_pcpu, &i,
+		    sizeof(i), rule_pcpu, sizeof(*rule_pcpu) * num_cpus, 0) != 0) {
+			qwarn("bpf_map__lookup_elem");
+			goto fail;
+		}
+
+		for (j = 0; j < num_cpus; j++) {
+			qr->evals += rule_pcpu[j].evals;
+			qr->hits += rule_pcpu[j].hits;
+		}
+	}
+
+	free(rule_pcpu);
+
 	return (0);
+fail:
+	free(rule_pcpu);
+
+	return (-1);
 }
 
 static void

--- a/quark-test.c
+++ b/quark-test.c
@@ -2164,9 +2164,11 @@ t_trusted_pid(const struct test *t, struct quark_queue_attr *qa)
 static int
 t_nova(const struct test *t, struct quark_queue_attr *qa)
 {
-	struct quark_queue	 qq;
-	struct quark_ruleset	 ruleset;
-	char			*text_ruleset;
+	struct quark_queue		 qq;
+	struct quark_ruleset		 ruleset;
+	struct quark_queue_stats	 stats;
+	char				*text_ruleset;
+	size_t				 i;
 
 	if (!noforkflag)
 		errx(1, "please run me with -1");
@@ -2185,8 +2187,15 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 		err(1, "%s: quark_queue_open", t->name);
 	fprintf(stderr, "\nthis test is a placeholder for temporary fiddling!!!\n");
 	fprintf(stderr, "sleeping forevis...\n");
-	for (;;)
-		sleep(300);
+	for (;;) {
+		quark_queue_get_stats(&qq, &stats);
+		for (i = 0; i < qq.ruleset->n_rules; i++) {
+			printf("rule %zd: evals %llu hits %llu\n",
+			    i, qq.ruleset->rules[i].evals, qq.ruleset->rules[i].hits);
+		}
+		putchar('\n');
+		sleep(1);
+	}
 	quark_queue_close(&qq);
 
 	return (0);


### PR DESCRIPTION
Per cpu structures must be 8 byte aligned, otherwise libbpf will just bail with
EINVAL.

Print stats in the temporary test stub. For now to update the rule stats one has
to assume the side effect from quark_queue_get_stats(), maybe we should add a
button in the future.

While here, make sure libbpf_num_possible_cpus() returns a positive number, that
code has to open a file, if that fails, we would get a negative and then blow up
the stack, not really an issue since libbpf would likely fail to even load the
probes in that case, but still.
