### PR TITLE
Rename a bunch of fields

### DIFF
--- a/ecs.c
+++ b/ecs.c
@@ -642,8 +642,8 @@ ecs_process(struct quark_queue *qq, struct hanson *h,
 	if (qp->comm[0] != 0)
 		hanson_add_key_value(h, "name", qp->comm, first);
 
-	if (qp->filename != NULL)
-		hanson_add_key_value(h, "executable", qp->filename, first);
+	if (qp->exe != NULL)
+		hanson_add_key_value(h, "executable", qp->exe, first);
 
 	if (qp->cmdline != NULL) {
 		int				 count;

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -96,14 +96,14 @@ type Exit struct {
 
 // Process represents a single process.
 type Process struct {
-	Pid      uint32 // Always present
-	Proc     Proc   // Only meaningful if Proc.Valid (QUARK_F_PROC)
-	Exit     Exit   // Only meaningful if Exit.Valid (QUARK_F_EXIT)
-	Comm     string
-	Filename string
-	Cmdline  []string
-	Cwd      string
-	Cgroup   string
+	Pid     uint32 // Always present
+	Proc    Proc   // Only meaningful if Proc.Valid (QUARK_F_PROC)
+	Exit    Exit   // Only meaningful if Exit.Valid (QUARK_F_EXIT)
+	Comm    string
+	Exe     string
+	Cmdline []string
+	Cwd     string
+	Cgroup  string
 }
 
 // Socket represents a connection between two endpoints
@@ -508,8 +508,8 @@ func processFromC(cProcess *C.struct_quark_process) Process {
 		}
 	}
 	process.Comm = C.GoString(&cProcess.comm[0])
-	if cProcess.filename != nil {
-		process.Filename = C.GoString(cProcess.filename)
+	if cProcess.exe != nil {
+		process.Exe = C.GoString(cProcess.exe)
 	}
 	if cProcess.cmdline != nil && cProcess.cmdline_len > 0 {
 		b := C.GoBytes(unsafe.Pointer(cProcess.cmdline), C.int(cProcess.cmdline_len))

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -112,29 +112,29 @@ eval_loop(__u32 i, struct eval *eval)
 	 * FOO), we curb it later with matched &= eval->fields.
 	 */
 	matched = 0;
-	matched |= (__u64)(eval->pid == rule->pid) * QUARK_RF_PROCESS_PID;
-	matched |= (__u64)(eval->ppid == rule->ppid) * QUARK_RF_PROCESS_PPID;
-	matched |= (__u64)(eval->uid == rule->uid) * QUARK_RF_PROCESS_UID;
-	matched |= (__u64)(eval->gid == rule->gid) * QUARK_RF_PROCESS_GID;
-	matched |= (__u64)(eval->sid == rule->sid) * QUARK_RF_PROCESS_SID;
+	matched |= (__u64)(eval->pid == rule->pid) * QUARK_RF_PID;
+	matched |= (__u64)(eval->ppid == rule->ppid) * QUARK_RF_PPID;
+	matched |= (__u64)(eval->uid == rule->uid) * QUARK_RF_UID;
+	matched |= (__u64)(eval->gid == rule->gid) * QUARK_RF_GID;
+	matched |= (__u64)(eval->sid == rule->sid) * QUARK_RF_SID;
 	matched |= (__u64)(eval->poison_tag == rule->poison_tag) * QUARK_RF_POISON;
 
-	if (rule->fields & QUARK_RF_PROCESS_FILENAME &&
-	    eval->fields & QUARK_RF_PROCESS_FILENAME &&
+	if (rule->fields & QUARK_RF_EXE &&
+	    eval->fields & QUARK_RF_EXE &&
 	    eval->process_filename != NULL) {
-		eval->process_filename->meta = META_MAKE(i, META_RF_PROCESS_FILENAME);
+		eval->process_filename->meta = META_MAKE(i, META_RF_EXE);
 		eval->process_filename->prefixlen = PATH_LPM_KEYLEN * 8;
 		v = bpf_map_lookup_elem(&lpm_path, eval->process_filename);
-		matched |= (v != NULL) * QUARK_RF_PROCESS_FILENAME;
+		matched |= (v != NULL) * QUARK_RF_EXE;
 	}
 
-	if (rule->fields & QUARK_RF_FILE_PATH &&
-	    eval->fields & QUARK_RF_FILE_PATH &&
+	if (rule->fields & QUARK_RF_FILEPATH &&
+	    eval->fields & QUARK_RF_FILEPATH &&
 	    eval->file_path != NULL) {
-		eval->file_path->meta = META_MAKE(i, META_RF_FILE_PATH);
+		eval->file_path->meta = META_MAKE(i, META_RF_FILEPATH);
 		eval->file_path->prefixlen = PATH_LPM_KEYLEN * 8;
 		v = bpf_map_lookup_elem(&lpm_path, eval->file_path);
-		matched |= (v != NULL) * QUARK_RF_FILE_PATH;
+		matched |= (v != NULL) * QUARK_RF_FILEPATH;
 	}
 
 	matched &= eval->fields;
@@ -177,19 +177,19 @@ static void
 eval_init_task(struct eval *eval, struct task_struct *task)
 {
 	eval->pid = BPF_CORE_READ(task, tgid);
-	eval->fields |= QUARK_RF_PROCESS_PID;
+	eval->fields |= QUARK_RF_PID;
 	eval->ppid = BPF_CORE_READ(task, group_leader, real_parent, tgid);
-	eval->fields |= QUARK_RF_PROCESS_PPID;
+	eval->fields |= QUARK_RF_PPID;
 	eval->uid = BPF_CORE_READ(task, cred, uid.val);
-	eval->fields |= QUARK_RF_PROCESS_UID;
+	eval->fields |= QUARK_RF_UID;
 	eval->gid = BPF_CORE_READ(task, cred, gid.val);
-	eval->fields |= QUARK_RF_PROCESS_GID;
+	eval->fields |= QUARK_RF_GID;
 #if 0
 	eval->sid = 		/* XXX TODO XXX */
-	eval->fields |= QUARK_RF_PROCESS_SID;
+	eval->fields |= QUARK_RF_SID;
 #endif
 	if (BPF_CORE_READ_STR_INTO(eval->comm, task, comm) > 0)
-		eval->fields |= QUARK_RF_PROCESS_COMM;
+		eval->fields |= QUARK_RF_COMM;
 	/* TODO MORE TODO */
 }
 
@@ -211,7 +211,7 @@ int BPF_PROG(task_alloc, struct task_struct *task, __u64 clone_flags)
 		    sizeof(eval.process_filename->path)) <= 0)
 			bpf_printk("can't make filename");
 		else
-			eval.fields |= QUARK_RF_PROCESS_FILENAME;
+			eval.fields |= QUARK_RF_EXE;
 	}
 
 	r = eval_run(&eval);

--- a/nova.h
+++ b/nova.h
@@ -20,15 +20,15 @@
 #define NOVA_MAX_PATHS	(NOVA_MAX_RULES * 2)
 #define NOVA_PATHLEN	250	/* including NUL */
 
-#define QUARK_RF_PROCESS_PID		(1ULL << 0)
-#define QUARK_RF_PROCESS_PPID		(1ULL << 1)
-#define QUARK_RF_PROCESS_UID		(1ULL << 2)
-#define QUARK_RF_PROCESS_GID		(1ULL << 3)
-#define QUARK_RF_PROCESS_SID		(1ULL << 4)
-#define QUARK_RF_PROCESS_COMM		(1ULL << 5)
-#define QUARK_RF_PROCESS_FILENAME	(1ULL << 6)
-#define QUARK_RF_FILE_PATH		(1ULL << 7)
-#define QUARK_RF_POISON			(1ULL << 8)
+#define QUARK_RF_PID		(1ULL << 0)
+#define QUARK_RF_PPID		(1ULL << 1)
+#define QUARK_RF_UID		(1ULL << 2)
+#define QUARK_RF_GID		(1ULL << 3)
+#define QUARK_RF_SID		(1ULL << 4)
+#define QUARK_RF_COMM		(1ULL << 5)
+#define QUARK_RF_EXE		(1ULL << 6)
+#define QUARK_RF_FILEPATH	(1ULL << 7)
+#define QUARK_RF_POISON		(1ULL << 8)
 
 enum quark_rule_action {
 	QUARK_RA_INVALID,
@@ -46,8 +46,8 @@ struct path_lpm_key {
 /*
  * path_lpm_key.meta
  */
-#define META_RF_PROCESS_FILENAME	0x0001
-#define META_RF_FILE_PATH		0x0002
+#define META_RF_EXE			0x0001
+#define META_RF_FILEPATH		0x0002
 #define META_RF_MSK			0x000F
 #define META_RF_SHIFT			0
 #define META_RULE_MSK			0xFFF0

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -56,11 +56,11 @@ alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 #endif
 
 	switch (field->code) {
-	case QUARK_RF_PROCESS_FILENAME:
-		key.meta = META_MAKE(rule_i, META_RF_PROCESS_FILENAME);
+	case QUARK_RF_EXE:
+		key.meta = META_MAKE(rule_i, META_RF_EXE);
 		break;
-	case QUARK_RF_FILE_PATH:
-		key.meta = META_MAKE(rule_i, META_RF_FILE_PATH);
+	case QUARK_RF_FILEPATH:
+		key.meta = META_MAKE(rule_i, META_RF_FILEPATH);
 		break;
 	default:
 		qwarnx("unhandled code %llu", field->code);
@@ -104,31 +104,31 @@ nova_rule_from_quark(struct nova_queue *nqq,
 		field = qr->fields + i;
 
 		switch (field->code) {
-		case QUARK_RF_PROCESS_PID:
+		case QUARK_RF_PID:
 			nr->pid = field->id;
 			break;
-		case QUARK_RF_PROCESS_PPID:
+		case QUARK_RF_PPID:
 			nr->ppid = field->id;
 			break;
-		case QUARK_RF_PROCESS_UID:
+		case QUARK_RF_UID:
 			nr->uid = field->id;
 			break;
-		case QUARK_RF_PROCESS_GID:
+		case QUARK_RF_GID:
 			nr->gid = field->id;
 			break;
-		case QUARK_RF_PROCESS_SID:
+		case QUARK_RF_SID:
 			nr->sid = field->id;
 			break;
-		case QUARK_RF_PROCESS_COMM:
+		case QUARK_RF_COMM:
 			strlcpy(nr->comm, field->comm, sizeof(nr->comm));
 			break;
-		case QUARK_RF_PROCESS_FILENAME:
+		case QUARK_RF_EXE:
 			if ((alloc_path(nqq, qr->number, field)) == -1) {
-				qwarn("process_filename alloc_path");
+				qwarn("exe alloc_path");
 				return (-1);
 			}
 			break;
-		case QUARK_RF_FILE_PATH:
+		case QUARK_RF_FILEPATH:
 			if ((alloc_path(nqq, qr->number, field)) == -1) {
 				qwarn("file_path alloc_path");
 				return (-1);

--- a/parse.y
+++ b/parse.y
@@ -55,7 +55,7 @@ int	quark_lex(YYSTYPE *, struct quark_parser_ctx *);
 
 %token PASS DROP POISON ON ANY STRING
 %token PROCESS_PID PROCESS_PPID PROCESS_UID PROCESS_GID PROCESS_SID
-%token PROCESS_FILENAME FILE_PATH
+%token PROCESS_EXE FILE_PATH
 
 %%
 grammar:	/* empty  */
@@ -101,25 +101,25 @@ match:		matchfield {
 		} ;
 
 matchfield:	PROCESS_PID num_u32 {
-			$$.rf.code = QUARK_RF_PROCESS_PID;
+			$$.rf.code = QUARK_RF_PID;
 			$$.rf.pid = $2.num_u32;
 		} | PROCESS_PPID num_u32 {
-			$$.rf.code = QUARK_RF_PROCESS_PPID;
+			$$.rf.code = QUARK_RF_PPID;
 			$$.rf.pid = $2.num_u32;
 		} | PROCESS_UID num_u32 {
-			$$.rf.code = QUARK_RF_PROCESS_UID;
+			$$.rf.code = QUARK_RF_UID;
 			$$.rf.pid = $2.num_u32;
 		} | PROCESS_GID num_u32 {
-			$$.rf.code = QUARK_RF_PROCESS_GID;
+			$$.rf.code = QUARK_RF_GID;
 			$$.rf.pid = $2.num_u32;
 		} | PROCESS_SID num_u32 {
-			$$.rf.code = QUARK_RF_PROCESS_SID;
+			$$.rf.code = QUARK_RF_SID;
 			$$.rf.pid = $2.num_u32;
-		} | PROCESS_FILENAME STRING {
-			$$.rf.code = QUARK_RF_PROCESS_FILENAME;
+		} | PROCESS_EXE STRING {
+			$$.rf.code = QUARK_RF_EXE;
 			$$.rf.path =(char *)$2.str;
 		} | FILE_PATH STRING {
-			$$.rf.code = QUARK_RF_FILE_PATH;
+			$$.rf.code = QUARK_RF_FILEPATH;
 			$$.rf.path =(char *)$2.str;
 		} | POISON num_u64 {
 			$$.rf.code = QUARK_RF_POISON;
@@ -192,7 +192,7 @@ static struct keyword {
 	{ "process.uid",	PROCESS_UID },
 	{ "process.gid",	PROCESS_GID },
 	{ "process.sid",	PROCESS_SID },
-	{ "process.filename",	PROCESS_FILENAME },
+	{ "process.exe",	PROCESS_EXE },
 	{ "file.path",		FILE_PATH },
 };
 

--- a/quark-test.c
+++ b/quark-test.c
@@ -856,7 +856,7 @@ fork_exec_exit(const struct test *t, struct quark_queue_attr *qa, int relative)
 	assert(qp != NULL);
 	assert(qp->flags & QUARK_F_EXIT);
 	assert(qp->comm[0] != 0);
-	assert(qp->filename != NULL);
+	assert(qp->exe != NULL);
 	assert(qp->cmdline != NULL && qp->cmdline_len > 0);
 	assert(qp->cwd != NULL);
 	if (qa->flags & QQ_EBPF)
@@ -899,8 +899,8 @@ fork_exec_exit(const struct test *t, struct quark_queue_attr *qa, int relative)
 #endif
 	/* check strings */
 	assert(!strcmp(qp->comm, "true"));
-	assert(!strcmp(qp->filename, "/bin/true") ||
-	    !strcmp(qp->filename, "/usr/bin/true"));
+	assert(!strcmp(qp->exe, "/bin/true") ||
+	    !strcmp(qp->exe, "/usr/bin/true"));
 	/* check args */
 	quark_cmdline_iter_init(&qcmdi, qp->cmdline, qp->cmdline_len);
 	argc = 0;
@@ -1993,7 +1993,7 @@ t_rule_poison_existing(const struct test *t, struct quark_queue_attr *qa)
 	rule = quark_ruleset_append_rule(&ruleset, QUARK_RA_POISON, poison_tag);
 	assert(rule != NULL);
 	bzero(&rf, sizeof(rf));
-	rf.code = QUARK_RF_PROCESS_PID;
+	rf.code = QUARK_RF_PID;
 	rf.pid = getpid();
 	assert(!quark_rule_match_field(rule, rf));
 
@@ -2037,7 +2037,7 @@ t_rule_id(const struct test *t, struct quark_queue_attr *qa)
 	rule = quark_ruleset_append_rule(&ruleset, QUARK_RA_PASS, 0);
 	assert(rule != NULL);
 	bzero(&rf, sizeof(rf));
-	rf.code = QUARK_RF_PROCESS_UID;
+	rf.code = QUARK_RF_UID;
 	rf.id = uid;
 	assert(!quark_rule_match_field(rule, rf));
 
@@ -2094,12 +2094,12 @@ t_rule_parser(const struct test *t, struct quark_queue_attr *qa)
 		"pass on process.sid 11\n",
 		"drop on file.path /foo/bar\n",
 		"pass on file.path foo-bar\n",
-		"drop on process.filename /foo/bar\n",
-		"pass on process.filename foo-bar\n",
-		"drop on process.filename \"foo bar lero\"\n",
-		"pass on process.filename /foo/*\n",
-		"drop on process.filename \"/foo bar/*\"\n",
-		"pass on process.filename \\\nfoo",	/* line split by \ */
+		"drop on process.exe /foo/bar\n",
+		"pass on process.exe foo-bar\n",
+		"drop on process.exe \"foo bar lero\"\n",
+		"pass on process.exe /foo/*\n",
+		"drop on process.exe \"/foo bar/*\"\n",
+		"pass on process.exe \\\nfoo",	/* line split by \ */
 		NULL
 	};
 	char *bad_cases[] = {
@@ -2114,7 +2114,7 @@ t_rule_parser(const struct test *t, struct quark_queue_attr *qa)
 		"pass on process.pid \"1 \"2",
 		"drop on process.gid",
 		"drop on foobar\n",
-		"drop on process.filename",
+		"drop on process.exe",
 		"drop on file.name \"foo\n",
 		NULL
 	};
@@ -2174,11 +2174,11 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 		errx(1, "please run me with -1");
 
 	text_ruleset =
-	    "pass on process.filename /usr/bin/bash\n"
-	    "pass on process.filename /bin/bash\n"
-	    "pass on process.filename /usr/bin/mksh\n"
-	    "pass on process.filename /bin/mksh\n"
-	    "pass on process.filename /idontexist\n"
+	    "pass on process.exe /usr/bin/bash\n"
+	    "pass on process.exe /bin/bash\n"
+	    "pass on process.exe /usr/bin/mksh\n"
+	    "pass on process.exe /bin/mksh\n"
+	    "pass on process.exe /idontexist\n"
 	    "pass on any";
 	ruleset_from_string(&ruleset, text_ruleset);
 

--- a/quark.c
+++ b/quark.c
@@ -472,7 +472,7 @@ gc_collect(struct quark_queue *qq)
 static void
 process_free(struct quark_process *qp)
 {
-	free(qp->filename);
+	free(qp->exe);
 	free(qp->cwd);
 	free(qp->cmdline);
 	free(qp->cgroup);
@@ -523,9 +523,9 @@ process_cache_inherit(struct quark_queue *qq, struct quark_process *qp, int ppid
 	/* Ignore QUARK_F_PROC? as we always have it all on fork */
 
 	strlcpy(qp->comm, parent->comm, sizeof(qp->comm));
-	if (parent->filename != NULL) {
-		free(qp->filename);
-		qp->filename = strdup(parent->filename);
+	if (parent->exe != NULL) {
+		free(qp->exe);
+		qp->exe = strdup(parent->exe);
 	}
 	/* Do we really want CMDLINE? */
 	if (parent->cmdline != NULL) {
@@ -1794,8 +1794,8 @@ entry_leader_compute(struct quark_queue *qq, struct quark_process *qp)
 	tty = tty_type(qp->proc_tty_major, qp->proc_tty_minor);
 
 	basename = NULL;
-	if (qp->filename != NULL)
-		basename = strrchr(qp->filename, '/');
+	if (qp->exe != NULL)
+		basename = strrchr(qp->exe, '/');
 	if (basename == NULL)
 		basename = "";
 	else
@@ -1850,8 +1850,8 @@ entry_leader_compute(struct quark_queue *qq, struct quark_process *qp)
 		return (0);
 
 	p_basename = NULL;
-	if (parent->filename != NULL)
-		p_basename = strrchr(parent->filename, '/');
+	if (parent->exe != NULL)
+		p_basename = strrchr(parent->exe, '/');
 	if (p_basename == NULL)
 		p_basename = "";
 	else
@@ -1895,7 +1895,7 @@ entry_leader_compute(struct quark_queue *qq, struct quark_process *qp)
 
 	if (qp->proc_entry_leader == QUARK_ELT_UNKNOWN)
 		qwarnx("%d (%s) is UNKNOWN (tty=%d)",
-		    qp->pid, qp->filename ? qp->filename : "null", tty);
+		    qp->pid, qp->exe ? qp->exe : "null", tty);
 
 	return (0);
 }
@@ -2220,9 +2220,9 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		fl = "CWD";
 		PF(fl, "cwd=%s\n", qp->cwd);
 	}
-	if (qp->filename != NULL) {
-		fl = "FNAME";
-		PF(fl, "filename=%s\n", qp->filename);
+	if (qp->exe != NULL) {
+		fl = "EXE";
+		PF(fl, "exe=%s\n", qp->exe);
 	}
 	if (qp->env != NULL) {
 		fl = "ENV";
@@ -2340,14 +2340,14 @@ raw_event_process1(struct quark_queue *qq, struct raw_event *src,
 	struct quark_process	*qp;
 	struct raw_task		*raw_task;
 	char			*comm;
-	char			*filename;
+	char			*exe;
 	char			*args;
 	size_t			 args_len;
 
 	qp	 = (struct quark_process *)dst->process;
 	raw_task = NULL;
 	comm	 = NULL;
-	filename = NULL;
+	exe	 = NULL;
 	args	 = NULL;
 	args_len = 0;
 
@@ -2359,7 +2359,7 @@ raw_event_process1(struct quark_queue *qq, struct raw_event *src,
 		break;
 	case RAW_EXEC:
 		dst->events |= QUARK_EV_EXEC;
-		filename = src->exec.filename;
+		exe = src->exec.filename;
 		src->exec.filename = NULL;
 		if (src->exec.flags & RAW_EXEC_F_EXT) {
 			raw_task = &src->exec.ext.task;
@@ -2467,10 +2467,10 @@ raw_event_process1(struct quark_queue *qq, struct raw_event *src,
 		strlcpy(qp->comm, comm, sizeof(qp->comm));
 		comm = NULL;
 	}
-	if (filename != NULL) {
-		free(qp->filename);
-		qp->filename = filename;
-		filename = NULL;
+	if (exe != NULL) {
+		free(qp->exe);
+		qp->exe = exe;
+		exe = NULL;
 	}
 	if (args != NULL && args_len > 0) {
 		free(qp->cmdline);
@@ -2968,7 +2968,7 @@ sproc_pid(struct quark_queue *qq, struct sproc_socket_by_inode *by_inode,
 		qp->comm[0] = 0;
 	/* filename */
 	if (qreadlinkat(dfd, "exe", path, sizeof(path)) > 0)
-		qp->filename = strdup(path);
+		qp->exe = strdup(path);
 	/* cmdline */
 	sproc_cmdline(qp, dfd);
 	/* cwd */
@@ -3921,8 +3921,8 @@ quark_dump_process_cache_graph(struct quark_queue *qq, FILE *f)
 		if (color_index >= nitems(color_table)) /* paranoia */
 			color_index = 0;
 
-		if (qp->filename != NULL)
-			name = qp->filename;
+		if (qp->exe != NULL)
+			name = qp->exe;
 		else if (qp->comm[0] != 0)
 			name = qp->comm;
 		else
@@ -4768,8 +4768,8 @@ quark_ruleset_clear(struct quark_ruleset *ruleset)
 		rule = ruleset->rules + i;
 		for (j = 0; j < rule->n_fields; j++) {
 			switch (rule->fields[j].code) {
-			case QUARK_RF_FILE_PATH:		/* FALLTHROUGH */
-			case QUARK_RF_PROCESS_FILENAME:		/* FALLTHROUGH */
+			case QUARK_RF_FILEPATH:		/* FALLTHROUGH */
+			case QUARK_RF_EXE:		/* FALLTHROUGH */
 				free(rule->fields[j].path);
 				break;
 			default:
@@ -4837,28 +4837,28 @@ quark_rule_field_match(struct quark_rule *rule, struct quark_rule_field *field,
 	((_p) != NULL && ((_p)->flags & QUARK_F_PROC) && (_p)->_n == _v)
 
 	switch (field->code) {
-	case QUARK_RF_PROCESS_PID:
+	case QUARK_RF_PID:
 		if (qp != NULL)
 			return (qp->pid == field->pid);
 		break;
-	case QUARK_RF_PROCESS_PPID:
+	case QUARK_RF_PPID:
 		return (MATCH_PROC_FIELD(qp, proc_ppid, field->pid));
-	case QUARK_RF_PROCESS_FILENAME:
-		if (qp != NULL && qp->filename != NULL)
-			return (path_match(field, qp->filename));
+	case QUARK_RF_EXE:
+		if (qp != NULL && qp->exe != NULL)
+			return (path_match(field, qp->exe));
 		break;
-	case QUARK_RF_PROCESS_UID:
+	case QUARK_RF_UID:
 		return (MATCH_PROC_FIELD(qp, proc_uid, field->id));
-	case QUARK_RF_PROCESS_GID:
+	case QUARK_RF_GID:
 		return (MATCH_PROC_FIELD(qp, proc_gid, field->id));
-	case QUARK_RF_PROCESS_SID:
+	case QUARK_RF_SID:
 		return (MATCH_PROC_FIELD(qp, proc_sid, field->id));
 		break;
-	case QUARK_RF_PROCESS_COMM:
+	case QUARK_RF_COMM:
 		if (qp != NULL)
 			return (!strcmp(field->comm, qp->comm));
 		break;
-	case QUARK_RF_FILE_PATH:
+	case QUARK_RF_FILEPATH:
 		if (qev->file != NULL)
 			return (path_match(field, qev->file->path));
 		break;
@@ -4951,21 +4951,21 @@ quark_rule_match_field(struct quark_rule *rule, struct quark_rule_field rf)
 	path = NULL;
 
 	switch (rf.code) {
-	case QUARK_RF_PROCESS_PID:		/* FALLTHROUGH */
-	case QUARK_RF_PROCESS_PPID:
+	case QUARK_RF_PID:		/* FALLTHROUGH */
+	case QUARK_RF_PPID:
 		if (rf.pid == 0)
 			goto inval;
 		break;
-	case QUARK_RF_PROCESS_UID:		/* FALLTHROUGH */
-	case QUARK_RF_PROCESS_GID:		/* FALLTHROUGH */
-	case QUARK_RF_PROCESS_SID:
+	case QUARK_RF_UID:		/* FALLTHROUGH */
+	case QUARK_RF_GID:		/* FALLTHROUGH */
+	case QUARK_RF_SID:
 		break;
-	case QUARK_RF_PROCESS_COMM:
+	case QUARK_RF_COMM:
 		if (strlen(rf.comm) == 0)
 			goto inval;
 		break;
-	case QUARK_RF_PROCESS_FILENAME:		/* FALLTHROUGH */
-	case QUARK_RF_FILE_PATH:
+	case QUARK_RF_EXE:		/* FALLTHROUGH */
+	case QUARK_RF_FILEPATH:
 		if (rf.path == NULL || strlen(rf.path) == 0 ||
 		    strlen(rf.path) >= PATH_MAX)
 			goto inval;

--- a/quark.h
+++ b/quark.h
@@ -618,7 +618,7 @@ struct quark_process {
 	s32	 exit_code;
 	u64	 exit_time_event;
 	char	 comm[16];
-	char	*filename;
+	char	*exe;
 	size_t	 cmdline_len;
 	char	*cmdline;
 	char	*cwd;


### PR DESCRIPTION
Cut the _PROCESS_ from QUARK_RF_*, it's just bloat and PROCESS is too long, it
makes lines expand too much.

Also rename filename to exe, this is a breaking change.
Filename was inherited from the kprobe backend, where the kprobe itself calls it
filename, I can't stand it. EXE is more descriptive.
