### PR TITLE
Expand the ruleset to accept infix path matching

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -276,7 +276,7 @@ steps:
 
   - label: "quark-test on rhel 8.5 (no file)"
     key: test_rhel_8_5
-    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path"
+    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
     depends_on:
       - make_docker
     agents:
@@ -287,7 +287,7 @@ steps:
 
   - label: "quark-test on rhel 8.6 (no file)"
     key: test_rhel_8_6
-    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path"
+    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
     depends_on:
       - make_docker
     agents:
@@ -298,7 +298,7 @@ steps:
 
   - label: "quark-test on rhel 8.7 (no file)"
     key: test_rhel_8_7
-    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path"
+    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
     depends_on:
       - make_docker
     agents:

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -45,8 +45,12 @@ alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 	struct path_lpm_key	key;
 	u64			v = 1;
 
-	if (strlen(field->path) >= NOVA_PATHLEN)
+	if (strlen(field->wild.pre) >= NOVA_PATHLEN ||
+	    strlen(field->wild.post) >= NOVA_PATHLEN)
 		return (errno = E2BIG, -1);
+
+	if (field->wild.post_len != 0)
+		return (errno = ENOTSUP, -1);
 
 	bzero(&key, sizeof(key));
 
@@ -69,18 +73,12 @@ alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 
 	/*
 	 * Calculate prefixlen, we always include at least key.meta, and then
-	 * add a positive number related to wildcard_len.
+	 * add pre_len
 	 */
-	key.prefixlen = sizeof(key.meta);
-	if (field->wildcard_len == 0)
-		key.prefixlen += strlen(field->path) + 1;
-	else
-		key.prefixlen += field->wildcard_len;
-	if (strlcpy(key.path, field->path, sizeof(key.path)) >= sizeof(key.path))
-		return (errno = E2BIG, -1);
+	key.prefixlen = (sizeof(key.meta) + field->wild.pre_len) * 8;
 
-	/* prefixlen is in bits */
-	key.prefixlen *= 8;
+	if (strlcpy(key.path, field->wild.pre, sizeof(key.path)) >= sizeof(key.path))
+		return (errno = E2BIG, -1);
 
 	if (bpf_map__update_elem(nqq->nova_bpf->maps.lpm_path,
 	    &key, sizeof(key), &v, sizeof(v), BPF_ANY) != 0) {

--- a/parse.y
+++ b/parse.y
@@ -117,10 +117,10 @@ matchfield:	PROCESS_PID num_u32 {
 			$$.rf.pid = $2.num_u32;
 		} | PROCESS_EXE STRING {
 			$$.rf.code = QUARK_RF_EXE;
-			$$.rf.path =(char *)$2.str;
+			$$.rf.wild.pre = (char *)$2.str;
 		} | FILE_PATH STRING {
 			$$.rf.code = QUARK_RF_FILEPATH;
-			$$.rf.path =(char *)$2.str;
+			$$.rf.wild.pre = (char *)$2.str;
 		} | POISON num_u64 {
 			$$.rf.code = QUARK_RF_POISON;
 			$$.rf.poison_tag = $2.num_u64;

--- a/quark-test.c
+++ b/quark-test.c
@@ -1922,6 +1922,96 @@ t_rule_path(const struct test *t, struct quark_queue_attr *qa)
 }
 
 static int
+t_rule_path2(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	struct quark_ruleset		 ruleset;
+	struct quark_rule		*suff_rule, *inf_rule, *drop_rule;
+	char				 suff[] = "/tmp/quark-test-suff.XXXXXX";
+	char				 other[] = "/tmp/quark-test-other.XXXXXX";
+	char				 inf[512];
+	int				 suff_fd, other_fd, inf_fd;
+	char				*text_ruleset;
+
+	if ((suff_fd = mkstemp(suff)) == -1)
+		err(1, "mkstemp");
+	if ((other_fd = mkstemp(other)) == -1)
+		err(1, "mkstemp");
+	snprintf(inf, sizeof(inf), "/tmp/quark-test-%d-infix", getpid());
+	if ((inf_fd = open(inf, O_RDWR | O_CREAT, 0644)) == -1)
+		err(1, "open");
+
+	if (asprintf(&text_ruleset,
+	    "pass on process.pid %d file.path /tmp/quark-test-suff*\n"
+	    "pass on process.pid %d file.path /tmp/quark-test-*-infix\n"
+	    "drop on process.pid %d\n",
+	    getpid(), getpid(), getpid()) == -1)
+		err(1, "asprintf");
+	ruleset_from_string(&ruleset, text_ruleset);
+	free(text_ruleset);
+
+	assert(ruleset.n_rules == 3);
+
+	/* Assert suff_rule */
+	suff_rule = &ruleset.rules[0];
+	assert(suff_rule->action == QUARK_RA_PASS);
+	assert(suff_rule->n_fields == 2);
+
+	/* Assert inf_rule */
+	inf_rule = &ruleset.rules[1];
+	assert(inf_rule->action == QUARK_RA_PASS);
+	assert(inf_rule->n_fields == 2);
+
+	/* Assert drop_rule */
+	drop_rule = &ruleset.rules[2];
+	assert(drop_rule->action == QUARK_RA_DROP);
+	assert(drop_rule->n_fields == 1);
+
+	/* Start the ball */
+	qa->ruleset = &ruleset;
+	qa->flags |= QQ_FILE;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	/* Write to a other, this must be dropped */
+	assert(write(other_fd, "1", 1) == 1);
+	close(other_fd);
+	if (unlink(other) == -1)
+		err(1, "unlink");
+	/* Write to a suff file, this must pass */
+	assert(write(suff_fd, "1", 1) == 1);
+	close(suff_fd);
+	if (unlink(suff) == -1)
+		err(1, "unlink");
+	/* Write to a inf file, this must pass */
+	assert(write(inf_fd, "1", 1) == 1);
+	close(inf_fd);
+	if (unlink(inf) == -1)
+		err(1, "unlink");
+	/* Fetch suff event, other should have been dropped */
+	qev = drain_for_pid(&qq, getpid());
+	assert(qev->events & QUARK_EV_FILE);
+	assert(!strcmp(qev->file->path, suff));
+	/* Fetch inf event, other should have been dropped */
+	qev = drain_for_pid(&qq, getpid());
+	assert(qev->events & QUARK_EV_FILE);
+	assert(!strcmp(qev->file->path, inf));
+	/* Make sure it hits the rule once */
+	assert(suff_rule->hits == 1);
+	assert(inf_rule->hits == 1);
+	assert(drop_rule->hits == 1);
+	/* evals must be bigger than hits, since it must have dropped other */
+	assert(suff_rule->evals > 1);
+
+	quark_queue_close(&qq);
+	quark_ruleset_clear(&ruleset);
+
+	return (0);
+}
+
+static int
 t_rule_poison(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct quark_queue		 qq;
@@ -2095,6 +2185,9 @@ t_rule_parser(const struct test *t, struct quark_queue_attr *qa)
 		"drop on file.path /foo/bar\n",
 		"pass on file.path foo-bar\n",
 		"drop on process.exe /foo/bar\n",
+		"drop on process.exe /foo/*\n",
+		"drop on process.exe */bar\n",
+		"drop on process.exe /*/bar\n",
 		"pass on process.exe foo-bar\n",
 		"drop on process.exe \"foo bar lero\"\n",
 		"pass on process.exe /foo/*\n",
@@ -2108,6 +2201,11 @@ t_rule_parser(const struct test *t, struct quark_queue_attr *qa)
 		"pass\n",
 		"pass on",
 		"foo",
+		"drop on process.exe /foo/bar**\n",
+		"drop on process.exe **/foo/bar\n",
+		"drop on process.exe **/foo/**bar\n",
+		"drop on process.exe */foo/bar*\n",
+		"drop on process.exe /foo**/bar\n",
 		"pass on any any",
 		"pass on any process.pid 1\n",
 		"pass on process.pid 1 2",
@@ -2186,6 +2284,7 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 	    "pass on process.exe /bin/bc\n"
 	    "pass on process.exe /somethingreallyreallylong\n"
 	    "pass on process.exe /idontexist\n"
+	    "pass on process.exe /omginowc*andoinfix\n"
 	    "pass on any";
 	ruleset_from_string(&ruleset, text_ruleset);
 
@@ -2253,6 +2352,7 @@ struct test all_tests[] = {
 	T(t_hanson),
 	T(t_hanson_escape),
 	T_EBPF(t_rule_path),
+	T_EBPF(t_rule_path2),
 	T_EBPF(t_rule_poison),
 	T_EBPF(t_rule_poison_existing),
 	T_EBPF(t_rule_id),

--- a/quark.c
+++ b/quark.c
@@ -4786,8 +4786,7 @@ raw_event_tty(struct quark_queue *qq, struct raw_event *raw)
 void
 quark_ruleset_init(struct quark_ruleset *ruleset)
 {
-	ruleset->rules = NULL;
-	ruleset->n_rules = 0;
+	bzero(ruleset, sizeof(*ruleset));
 }
 
 void
@@ -4802,7 +4801,7 @@ quark_ruleset_clear(struct quark_ruleset *ruleset)
 			switch (rule->fields[j].code) {
 			case QUARK_RF_FILEPATH:		/* FALLTHROUGH */
 			case QUARK_RF_EXE:		/* FALLTHROUGH */
-				free(rule->fields[j].path);
+				free(rule->fields[j].wild.pre);
 				break;
 			default:
 				break;
@@ -4850,10 +4849,25 @@ quark_ruleset_parse(struct quark_ruleset *ruleset, FILE *in,
 static int
 path_match(struct quark_rule_field *field, const char *a)
 {
-	if (field->wildcard_len == 0)
-		return (!strcmp(field->path, a));
-	else
-		return (!strncmp(field->path, a, field->wildcard_len));
+	struct quark_wild	*w = &field->wild;
+	size_t			 alen;
+
+	/*
+	 * Include NUL in the comparison. Without it, "foo" would match "foobar"
+	 * as a prefix. pre_len includes the NUL when it's an exact match. If
+	 * post_len is 0, NUL is not included (hence zero), if post_len is
+	 * positive, NUL is included.
+	 */
+	alen = strlen(a) + 1;	/* include NUL */
+
+	if (w->pre_len + w->post_len > alen)
+		return (0);
+	if (memcmp(w->pre, a, w->pre_len) != 0)
+		return (0);
+	if (memcmp(w->post, a + alen - w->post_len, w->post_len) != 0)
+		return (0);
+
+	return (1);
 }
 
 /* 1 for match, 0 for non match */
@@ -4978,7 +4992,7 @@ quark_rule_match_field(struct quark_rule *rule, struct quark_rule_field rf)
 {
 	struct quark_rule_field	*new_fields;
 	size_t			 new_n_fields;
-	char			*path, *p;
+	char			*path, *star;
 
 	path = NULL;
 
@@ -4998,16 +5012,35 @@ quark_rule_match_field(struct quark_rule *rule, struct quark_rule_field rf)
 		break;
 	case QUARK_RF_EXE:		/* FALLTHROUGH */
 	case QUARK_RF_FILEPATH:
-		if (rf.path == NULL || strlen(rf.path) == 0 ||
-		    strlen(rf.path) >= PATH_MAX)
+		rf.wild.post = NULL;
+		rf.wild.pre_len = rf.wild.post_len = 0;
+
+		if (rf.wild.pre == NULL || strlen(rf.wild.pre) == 0 ||
+		    strlen(rf.wild.pre) >= PATH_MAX)
 			goto inval;
 		/* Save path in case we error out and need to free */
-		path = rf.path = strdup(rf.path);
-		if (rf.path == NULL)
+		path = rf.wild.pre = strdup(rf.wild.pre);
+		if (path == NULL)
 			goto bad;
-		rf.wildcard_len = 0;
-		if ((p = strchr(rf.path, '*')) != NULL)
-			rf.wildcard_len = p - rf.path;
+		/*
+		 * Split rf.wild.pre and rf.wild.post
+		 * as in foo*bar: pre = foo, post = bar
+		 */
+		rf.wild.post = rf.wild.pre + strlen(rf.wild.pre);
+		if ((star = strchr(rf.wild.pre, '*')) != NULL) {
+			*star = 0;
+			/* Only one * is allowed */
+			rf.wild.post = star + 1;
+			if (strchr(rf.wild.post, '*') != NULL)
+				goto bad;
+		}
+		/* Don't move this up, as the block above might shorten "pre" */
+		rf.wild.pre_len = strlen(rf.wild.pre);
+		rf.wild.post_len = strlen(rf.wild.post);
+		if (star == NULL)
+			rf.wild.pre_len++; /* Include NUL in the comparison */
+		if (rf.wild.post_len > 0)
+			rf.wild.post_len++; /* Include NUL in the comparison */
 		break;
 	case QUARK_RF_POISON:
 		if (rf.poison_tag == 0)

--- a/quark.c
+++ b/quark.c
@@ -3967,6 +3967,45 @@ quark_dump_process_cache_graph(struct quark_queue *qq, FILE *f)
 }
 #undef P
 
+/*
+ * Do a first pass of the ruleset in the existing process cache.
+ * Atm used only for poisoning existing processes.
+ * Be careful to only bump relevant rule counters.
+ */
+static int
+quark_queue_ruleset_prime(struct quark_queue *qq)
+{
+	struct quark_event	 qev;
+	struct quark_process	*qp;
+	struct quark_rule	*qr;
+	size_t			 i;
+
+	if (qq->ruleset == NULL)
+		return (0);
+
+	bzero(&qev, sizeof(qev));
+
+	RB_FOREACH(qp, process_by_pid, &qq->process_by_pid) {
+		qev.process = qp;
+		quark_ruleset_match(qq->ruleset, &qev);
+	}
+
+	/*
+	 * Reset all counters for non poison rules, this makes testing
+	 * and reasoning easier (code for: "I lost a lot of time trying
+	 * to figure why my counters were off").
+	 */
+	for (i = 0; i < qq->ruleset->n_rules; i++) {
+		qr = qq->ruleset->rules + i;
+		if (qr->action == QUARK_RA_POISON)
+			continue;
+		qr->hits = 0;
+		qr->evals = 0;
+	}
+
+	return (0);
+}
+
 int
 quark_queue_set_agg_matrix(struct quark_queue *qq,
     int parent, int child, quark_can_aggregate_fn fn)
@@ -4246,16 +4285,9 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	/*
 	 * Pass rules on all processes, so we can have match on poison rules
 	 */
-	if (qq->ruleset != NULL) {
-		struct quark_event	 qev;
-		struct quark_process	*qp;
-
-		bzero(&qev, sizeof(qev));
-
-		RB_FOREACH(qp, process_by_pid, &qq->process_by_pid) {
-			qev.process = qp;
-			quark_ruleset_match(qq->ruleset, &qev);
-		}
+	if (quark_queue_ruleset_prime(qq) == -1) {
+		qwarn("Can't prime ruleset");
+		goto fail;
 	}
 
 	return (0);

--- a/quark.h
+++ b/quark.h
@@ -771,16 +771,25 @@ struct quark_group {
 	char			*name;
 };
 
+/*
+ * post points into pre
+ */
+struct quark_wild {
+	char	*pre;		/* user input, like foo*bar */
+	size_t	 pre_len;
+	char	*post;
+	size_t	 post_len;
+};
+
 /* Rule Field */
 struct quark_rule_field {
 	u64		 code;
-	size_t		 wildcard_len;
 	union {
-		u32	 pid;
-		u64	 poison_tag;
-		char	*path;
-		u32	 id;
-		char	 comm[16];
+		u32			 pid;
+		u64			 poison_tag;
+		struct quark_wild	 wild;
+		u32			 id;
+		char			 comm[16];
 	};
 };
 


### PR DESCRIPTION
Extend the grammar to allow matching on paths like /home/*/foo, or /h**e/. This
is limited to a single *, this allows us to implement the matching quite fast
without backtracking and/or a regex machine.

This limitation will also make implementing this in bpf much easier.

Had to bloat quark_rule_field{} a bit with a quark_wild{} since we have to
describe way more things now. The structure grows considerably, expressing a
path took 16 bytes before, now it takes 32 :(. And it grows for every field
case, so very meh.

Next diffs will be adding this to QQ_NOVA.

Issue #316

+++

Only bump rule counters for poison rules on quark_queue_open()

On boot at quark_queue_open() we evaluate all rules against our cached process
for the sole purpose of poisoning processes.

While this 'works', it screwed up the rule counters and made writing tests for
it more painful. So make sure we reset those counters.

Issue #316
Issue #317

Issue #315 