### PR TITLE
Add tests for Fedora 44 and Ubuntu 26.04

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -241,6 +241,17 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
+  - label: "quark-test on fedora 44"
+    key: test_fedora_44
+    command: "./.buildkite/runtest_distro.sh fedora 44"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
   - label: "quark-test on rhel 8"
     key: test_rhel_8
     command: "./.buildkite/runtest_distro.sh rhel 8"
@@ -482,3 +493,14 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       enableNestedVirtualization: true
+
+#  - label: "quark-test on ubuntu 26.04"
+#    key: test_ubuntu_26_04
+#    command: "./.buildkite/runtest_distro.sh ubuntu 26.04"
+#    depends_on:
+#      - make_docker
+#    agents:
+#      image: family/core-ubuntu-2404
+#      provider: gcp
+#      machineType: n2-standard-2
+#      enableNestedVirtualization: true

--- a/krun-ubuntu.sh
+++ b/krun-ubuntu.sh
@@ -76,6 +76,7 @@ case "$UBUNTU_VERSION" in
 	22.04) CODENAME=jammy ;;
 	24.04) CODENAME=noble ;;
 	25.04) CODENAME=plucky ;;
+	26.04) CODENAME=resolute ;;
 	*) die "Unsupported Ubuntu version: $UBUNTU_VERSION" ;;
 esac
 


### PR DESCRIPTION
Fedora 44 passes all tests "6.19.14-300.fc44.x86_64"
Ubuntu 26.04 fails the file tests "7.0.0-14-generic"

So it's a fairly new breakage
