### PR TITLE
Fall back to renamed VFS probe symbols 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -494,13 +494,13 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
-#  - label: "quark-test on ubuntu 26.04"
-#    key: test_ubuntu_26_04
-#    command: "./.buildkite/runtest_distro.sh ubuntu 26.04"
-#    depends_on:
-#      - make_docker
-#    agents:
-#      image: family/core-ubuntu-2404
-#      provider: gcp
-#      machineType: n2-standard-2
-#      enableNestedVirtualization: true
+  - label: "quark-test on ubuntu 26.04"
+    key: test_ubuntu_26_04
+    command: "./.buildkite/runtest_distro.sh ubuntu 26.04"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1153,10 +1153,22 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	if (qq->flags & QQ_FILE) {
 		int use_fsnotify =
 		    (btf_number_of_params_of_ptr(btf, "inode_operations", "atomic_open") == 6);
+		int unlink_renamed =
+		    (btf_number_of_params(btf, "do_unlinkat") == -1);
+		int filp_open_renamed =
+		    (btf_number_of_params(btf, "do_filp_open") == -1);
+		int renameat2_renamed =
+		    (btf_number_of_params(btf, "do_renameat2") == -1);
 
 		if (use_fentry) {
-			bpf_program__set_autoload(p->progs.fentry__do_renameat2, 1);
-			bpf_program__set_autoload(p->progs.fentry__do_unlinkat, 1);
+			if (renameat2_renamed)
+				bpf_program__set_autoload(p->progs.fentry__filename_renameat2, 1);
+			else
+				bpf_program__set_autoload(p->progs.fentry__do_renameat2, 1);
+			if (unlink_renamed)
+				bpf_program__set_autoload(p->progs.fentry__filename_unlinkat, 1);
+			else
+				bpf_program__set_autoload(p->progs.fentry__do_unlinkat, 1);
 			if (use_fsnotify)
 				bpf_program__set_autoload(p->progs.fentry__fsnotify, 1);
 			bpf_program__set_autoload(p->progs.fentry__mnt_want_write, 1);
@@ -1164,7 +1176,10 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 			bpf_program__set_autoload(p->progs.fentry__vfs_unlink, 1);
 			bpf_program__set_autoload(p->progs.fexit__chmod_common, 1);
 			bpf_program__set_autoload(p->progs.fexit__chown_common, 1);
-			bpf_program__set_autoload(p->progs.fexit__do_filp_open, 1);
+			if (filp_open_renamed)
+				bpf_program__set_autoload(p->progs.fexit__do_file_open, 1);
+			else
+				bpf_program__set_autoload(p->progs.fexit__do_filp_open, 1);
 			bpf_program__set_autoload(p->progs.fexit__do_truncate, 1);
 			bpf_program__set_autoload(p->progs.fexit__vfs_rename, 1);
 			bpf_program__set_autoload(p->progs.fexit__vfs_unlink, 1);
@@ -1187,10 +1202,19 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 			bpf_program__set_autoload(p->progs.kretprobe__vfs_unlink, 1);
 			bpf_program__set_autoload(p->progs.kprobe__vfs_write, 1);
 			bpf_program__set_autoload(p->progs.kretprobe__vfs_write, 1);
-			bpf_program__set_autoload(p->progs.kprobe__do_renameat2, 1);
-			bpf_program__set_autoload(p->progs.kprobe__do_unlinkat, 1);
+			if (renameat2_renamed)
+				bpf_program__set_autoload(p->progs.kprobe__filename_renameat2, 1);
+			else
+				bpf_program__set_autoload(p->progs.kprobe__do_renameat2, 1);
+			if (unlink_renamed)
+				bpf_program__set_autoload(p->progs.kprobe__filename_unlinkat, 1);
+			else
+				bpf_program__set_autoload(p->progs.kprobe__do_unlinkat, 1);
 			bpf_program__set_autoload(p->progs.kprobe__mnt_want_write, 1);
-			bpf_program__set_autoload(p->progs.kretprobe__do_filp_open, 1);
+			if (filp_open_renamed)
+				bpf_program__set_autoload(p->progs.kretprobe__do_file_open, 1);
+			else
+				bpf_program__set_autoload(p->progs.kretprobe__do_filp_open, 1);
 		}
 
 		/* vfs_unlink() */

--- a/elastic-ebpf/GPL/Events/File/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/File/Probe.bpf.c
@@ -66,6 +66,30 @@ int BPF_KPROBE(kprobe__do_unlinkat)
     return r;
 }
 
+SEC("fentry/filename_unlinkat")
+int BPF_PROG(fentry__filename_unlinkat)
+{
+    int r;
+
+    preempt_disable();
+    r = do_unlinkat__enter();
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/filename_unlinkat")
+int BPF_KPROBE(kprobe__filename_unlinkat)
+{
+    int r;
+
+    preempt_disable();
+    r = do_unlinkat__enter();
+    preempt_enable();
+
+    return r;
+}
+
 static int mnt_want_write__enter(struct vfsmount *mnt)
 {
     struct ebpf_events_state *state = NULL;
@@ -460,6 +484,34 @@ int BPF_KRETPROBE(kretprobe__do_filp_open, struct file *ret)
     return r;
 }
 
+SEC("fexit/do_file_open")
+int BPF_PROG(fexit__do_file_open,
+             int dfd,
+             struct filename *pathname,
+             const struct open_flags *op,
+             struct file *ret)
+{
+    int r;
+
+    preempt_disable();
+    r = do_filp_open__exit(ret);
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kretprobe/do_file_open")
+int BPF_KRETPROBE(kretprobe__do_file_open, struct file *ret)
+{
+    int r;
+
+    preempt_disable();
+    r = do_filp_open__exit(ret);
+    preempt_enable();
+
+    return r;
+}
+
 static int do_renameat2__enter()
 {
     struct ebpf_events_state state = {};
@@ -494,6 +546,30 @@ int BPF_PROG(fentry__do_renameat2)
 
 SEC("kprobe/do_renameat2")
 int BPF_KPROBE(kprobe__do_renameat2)
+{
+    int r;
+
+    preempt_disable();
+    r = do_renameat2__enter();
+    preempt_enable();
+
+    return r;
+}
+
+SEC("fentry/filename_renameat2")
+int BPF_PROG(fentry__filename_renameat2)
+{
+    int r;
+
+    preempt_disable();
+    r = do_renameat2__enter();
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/filename_renameat2")
+int BPF_KPROBE(kprobe__filename_renameat2)
 {
     int r;
 


### PR DESCRIPTION
Newer kernels rename a few VFS helpers we attach to:
do_unlinkat → filename_unlinkat,
do_renameat2 → filename_renameat2.
do_filp_open → do_file_open,

The prototypes are unchanged, so the BPF program bodies are identical.

Add twin SEC entries in Probe.bpf.c that share the existing
__enter/__exit helpers, and BTF-detect each old name in
bpf_queue_open1() to autoload the right variant.

Relevant Linux commits:
https://github.com/torvalds/linux/commit/e50aae1d39ac37a95f453a699456b73dd07e3913
https://github.com/torvalds/linux/commit/e6d50234ccb9ff54addd579032a146aef52e7541
https://github.com/torvalds/linux/commit/541003b576c3e3c328314398a6df76eb3cebf847

Also, enabled 26.04 testing.