### PR TITLE
Nova path infix matching plus goodies

### DIFF
--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -17,31 +17,55 @@
 #define LOOP_STOP	1
 
 #define E2BIG		7
+#define PATH_MAX	4096
 
 #define MAX(_a, _b)	((_a) > (_b) ? (_a) : (_b))
 #define MIN(_a, _b)	((_a) < (_b) ? (_a) : (_b))
 
-#define PATH_LPM_KEYLEN							\
-	(sizeof(struct path_lpm_key) -					\
-	    sizeof(((struct path_lpm_key *)0)->prefixlen))
-#define PATH_LPM_PREFIXLEN(_b)						\
-	(MIN(PATH_LPM_KEYLEN,						\
-	    ((_b) + sizeof(((struct path_lpm_key *)0)->meta))) * 8)
+#define PATH_LPM_KEY_BITLEN	((sizeof(struct path_lpm_key) - 4) * 8)
 
 extern void bpf_preempt_disable(void) __ksym __weak;
 extern void bpf_preempt_enable(void) __ksym __weak;
 
+struct eval_path {
+	char			 full[PATH_MAX];
+	__u32			 full_len;
+	__u32			 pad0;
+	struct path_lpm_key	 pre;		/* QUARK_RF_* prefix */
+	struct path_lpm_key	 post;		/* QUARK_RF_* postfix */
+};
+
+/*
+ * Our rule evaluation context, we have a single instance of this throughout the
+ * evaluation phase.
+ * Don't forget to bump NOVA_PATH_FIELDS if you add another eval_path.
+ */
+struct eval {
+	/* fields is the bitmask of things that have been filled */
+	__u64			 fields;		/* QUARK_RF_* bitmask */
+	__u64			 poison_tag;		/* QUARK_RF_POISON */
+	__u32			 pid;			/* QUARK_RF_PID */
+	__u32			 ppid;			/* QUARK_RF_PPID */
+	__u32			 uid;			/* QUARK_RF_UID */
+	__u32			 gid;			/* QUARK_RF_GID */
+	__u32			 sid;			/* QUARK_RF_SID */
+	__u32			 pad0;
+	struct eval_path	 exe;			/* QUARK_RF_EXE */
+	struct eval_path	 filepath;		/* QUARK_RF_FILEPATH */
+	char			 comm[16];		/* QUARK_RF_COMM */
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 2);
+	__uint(max_entries, 1);
 	__type(key, __u32);
-	__type(value, struct path_lpm_key);
-} scratch_path SEC(".maps");
+	__type(value, struct eval);
+} scratch_eval SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__type(key, struct path_lpm_key);
-	__type(value, u64);
+	__type(value, __u32);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 	__uint(max_entries, NOVA_MAX_PATHS);
 } lpm_path SEC(".maps");
@@ -62,26 +86,6 @@ struct {
 
 const volatile u_int	rules_active;
 
-/*
- * Consider moving most of these to a map, currently we need them on the stack
- * which is limited to 512 bytes.
- */
-struct eval {
-	/* fields is the bitmask of things that have been filled */
-	__u64			 fields;		/* QUARK_RF_* bitmask */
-	__u64			 poison_tag;		/* QUARK_RF_POISON */
-	__u32			 pid;			/* QUARK_RF_PID */
-	__u32			 ppid;			/* QUARK_RF_PPID */
-	__u32			 uid;			/* QUARK_RF_UID */
-	__u32			 gid;			/* QUARK_RF_GID */
-	__u32			 sid;			/* QUARK_RF_SID */
-	__u32			 pad0;
-	struct path_lpm_key	*exe;			/* QUARK_RF_EXE */
-	struct path_lpm_key	*filepath;		/* QUARK_RF_FILEPATH */
-	struct nova_rule	*match;			/* result of eval_run */
-	char			 comm[16];		/* QUARK_RF_COMM */
-};
-
 static void
 preempt_disable(void)
 {
@@ -96,13 +100,74 @@ preempt_enable(void)
 		bpf_preempt_enable();
 }
 
-static int
-eval_loop(__u32 i, struct eval *eval)
+static __always_inline struct eval *
+eval_ctx(void)
 {
+	return (bpf_map_lookup_elem(&scratch_eval, &(int){0}));
+}
+
+/*
+ * 0 for no match
+ * 1 for match
+ */
+static int
+eval_path_match(struct eval_path *ep, struct nova_rule *rule, __u16 mcode)
+{
+	__u32	*v, post_len, start;
+
+	/*
+	 * Lookup prefix
+	 */
+	ep->pre.meta = META_MAKE(rule->number, mcode);
+	v = bpf_map_lookup_elem(&lpm_path, &ep->pre);
+	if (v == NULL)
+		return (0);
+	post_len = *v;
+	/*
+	 * No suffix, so it's a match
+	 */
+	if (post_len == 0)
+		return (1);
+	if (post_len > NOVA_PATHLEN)
+		post_len = NOVA_PATHLEN;
+	/*
+	 * Find the suffix start
+	 */
+	if (ep->full_len > post_len)
+		start = ep->full_len - post_len;
+	else
+		start = 0;
+	/*
+	 * Copy suffix so we can do a lookup
+	 */
+	if (bpf_probe_read_kernel_str(ep->post.path, post_len,
+	    &ep->full[start]) < 0) {
+		bpf_printk("can't make post rule %d", rule->number);
+		return (0);
+	}
+	/*
+	 * Build the key that would match this suffix in this rule, and do a
+	 * lookup.
+	 */
+	ep->post.meta = META_MAKE(rule->number, mcode | META_RF_POSTFIX);
+	v = bpf_map_lookup_elem(&lpm_path, &ep->post);
+	if (v == NULL)
+		return (0);
+
+	return (1);
+}
+
+static int
+eval_loop(__u32 i, struct nova_rule **match)
+{
+	struct eval		*eval;
 	struct nova_rule	*rule;
 	struct nova_rule_pcpu	*rule_pcpu;
-	__u64			*v;
 
+	if ((eval = eval_ctx()) == NULL) {
+		bpf_printk("no eval");
+		return (LOOP_CONTINUE);
+	}
 	if ((rule = bpf_map_lookup_elem(&ruleset, &i)) == NULL) {
 		bpf_printk("rule not found, this is a bug");
 		return (LOOP_CONTINUE);
@@ -130,29 +195,14 @@ eval_loop(__u32 i, struct eval *eval)
 	    eval->poison_tag != rule->poison_tag)
 		return (LOOP_CONTINUE);
 
-	if (rule->fields & QUARK_RF_EXE) {
-		if (eval->exe == NULL) {
-			bpf_printk("no exe rule %d", rule->number);
-			return (LOOP_CONTINUE);
-		}
-		eval->exe->meta = META_MAKE(i, META_RF_EXE);
-		v = bpf_map_lookup_elem(&lpm_path, eval->exe);
-		if (v == NULL)
-			return (LOOP_CONTINUE);
-	}
+	if ((rule->fields & QUARK_RF_EXE) &&
+	    !eval_path_match(&eval->exe, rule, META_RF_EXE))
+		return (LOOP_CONTINUE);
+	if ((rule->fields & QUARK_RF_FILEPATH) &&
+	    !eval_path_match(&eval->filepath, rule, META_RF_FILEPATH))
+		return (LOOP_CONTINUE);
 
-	if (rule->fields & QUARK_RF_FILEPATH) {
-		if (eval->filepath == NULL) {
-			bpf_printk("no filepath rule %d", rule->number);
-			return (LOOP_CONTINUE);
-		}
-		eval->filepath->meta = META_MAKE(i, META_RF_FILEPATH);
-		v = bpf_map_lookup_elem(&lpm_path, eval->filepath);
-		if (v == NULL)
-			return (LOOP_CONTINUE);
-	}
-
-	eval->match = rule;
+	*match = rule;
 	rule_pcpu->hits++;
 
 	return (LOOP_STOP);
@@ -161,27 +211,43 @@ eval_loop(__u32 i, struct eval *eval)
 static int
 eval_run(struct eval *eval)
 {
-	if (bpf_loop(rules_active, eval_loop, eval, 0) < 0) {
+	struct nova_rule	*match = NULL;
+
+	if (bpf_loop(rules_active, eval_loop, &match, 0) < 0) {
 		bpf_printk("bad bpf_loop");
 		return (0);
 	}
 
-	if (eval->match == NULL)
+	if (match == NULL)
 		return (0);
 
-	bpf_printk("rule %d matched! (0x%x)",
-	    eval->match->number, eval->match->fields);
+	bpf_printk("rule %d matched! (0x%x)", match->number, match->fields);
 
 	return (0);
 }
 
 static void
-eval_init(struct eval *eval)
+eval_path_init(struct eval_path *ep)
 {
+	ep->full_len = 0;
+	ep->full[0] = 0;
+	ep->pre.prefixlen = PATH_LPM_KEY_BITLEN;
+	ep->post.prefixlen = PATH_LPM_KEY_BITLEN;
+}
+
+static struct eval *
+eval_init(void)
+{
+	struct eval	*eval;
+
+	if ((eval = eval_ctx()) == NULL)
+		return (NULL);
+
 	eval->fields = 0;
-	eval->exe = bpf_map_lookup_elem(&scratch_path, &(int){0});
-	eval->filepath = bpf_map_lookup_elem(&scratch_path, &(int){1});
-	eval->match = NULL;
+	eval_path_init(&eval->exe);
+	eval_path_init(&eval->filepath);
+
+	return (eval);
 }
 
 static void
@@ -199,40 +265,56 @@ eval_init_task(struct eval *eval, struct task_struct *task)
 	eval->sid = 		/* XXX TODO XXX */
 	eval->fields |= QUARK_RF_SID;
 #endif
+	/* XXX NOT WORTH THE BRANCH? XXX */
 	if (BPF_CORE_READ_STR_INTO(eval->comm, task, comm) > 0)
 		eval->fields |= QUARK_RF_COMM;
 	/* TODO MORE TODO */
+}
+
+static int
+bprm_check1(struct linux_binprm *bprm, int ret)
+{
+	struct task_struct	*task = bpf_get_current_task_btf();
+	struct eval		*eval;
+	int			 r;
+	long			 len;
+
+	if ((eval = eval_init()) == NULL)
+		return (0);
+	eval_init_task(eval, task);
+
+	if (bprm->file == NULL)
+		goto noexe;
+
+	len = bpf_d_path(&bprm->file->f_path, eval->exe.full, PATH_MAX);
+	if (len < 0) {
+		bpf_printk("can't make executable 1");
+		goto noexe;
+	}
+	eval->exe.full_len = len;
+	len = bpf_probe_read_kernel_str(eval->exe.pre.path,
+	    sizeof(eval->exe.pre.path), eval->exe.full);
+	if (len < 0) {
+		bpf_printk("can't make executable 2");
+		goto noexe;
+	}
+
+	eval->fields |= QUARK_RF_EXE;
+noexe:
+	r = eval_run(eval);
+	r = 0; /* XXX r ignored for now */
+
+	return (r);
 }
 
 SEC("lsm/bprm_check_security")
 int
 BPF_PROG(bprm_check, struct linux_binprm *bprm, int ret)
 {
-	struct task_struct	*task = bpf_get_current_task_btf();
-	struct eval		 eval;
-	int			 r;
-	long			 len;
+	int	r;
 
 	preempt_disable();
-
-	eval_init(&eval);
-	eval_init_task(&eval, task);
-
-	if (bprm->file == NULL || eval.exe == NULL)
-		goto noexe;
-
-	len = bpf_d_path(&bprm->file->f_path,
-	    eval.exe->path, sizeof(eval.exe->path));
-	if (len < 0) {
-		bpf_printk("can't make executable");
-		goto noexe;
-	}
-	eval.exe->prefixlen = PATH_LPM_PREFIXLEN(len);
-	eval.fields |= QUARK_RF_EXE;
-noexe:
-	r = eval_run(&eval);
-	r = 0; /* XXX r ignored for now */
-
+	r = bprm_check1(bprm, ret);
 	preempt_enable();
 
 	return (r);

--- a/nova.h
+++ b/nova.h
@@ -16,9 +16,14 @@
 #define __aligned(x)	__attribute__((aligned(x)))
 #endif	/* __aligned */
 
-#define NOVA_MAX_RULES	1024
-#define NOVA_MAX_PATHS	(NOVA_MAX_RULES * 2)
-#define NOVA_PATHLEN	250	/* including NUL */
+#define NOVA_MAX_RULES		1024
+/*
+ * NOVA_PATH_FIELDS is how many META_RF_THINGs that are paths we have.
+ * NOVA_MAX_PATHS is two paths (prefix + suffix) per rule per field
+ */
+#define NOVA_PATH_FIELDS	2
+#define NOVA_MAX_PATHS		(NOVA_MAX_RULES * NOVA_PATH_FIELDS * 2)
+#define NOVA_PATHLEN		250	/* including NUL */
 
 #define QUARK_RF_PID		(1ULL << 0)
 #define QUARK_RF_PPID		(1ULL << 1)
@@ -37,6 +42,10 @@ enum quark_rule_action {
 	QUARK_RA_POISON,
 };
 
+/*
+ * path_lpm value is a __u32 which is the length of the suffix
+ * match. 0 means no suffix matching.
+ */
 struct path_lpm_key {
 	__u32	prefixlen;
 	__u16	meta;		/* upper 12 bits rule, 4 bits for type META_RF_*_* */
@@ -48,6 +57,7 @@ struct path_lpm_key {
  */
 #define META_RF_EXE			0x0001
 #define META_RF_FILEPATH		0x0002
+#define META_RF_POSTFIX			0x8000 /* ORed for a postfix */
 #define META_RF_MSK			0x000F
 #define META_RF_SHIFT			0
 #define META_RULE_MSK			0xFFF0

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -43,14 +43,11 @@ static int
 alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 {
 	struct path_lpm_key	key;
-	u64			v = 1;
+	u32			post_len;
 
 	if (strlen(field->wild.pre) >= NOVA_PATHLEN ||
 	    strlen(field->wild.post) >= NOVA_PATHLEN)
 		return (errno = E2BIG, -1);
-
-	if (field->wild.post_len != 0)
-		return (errno = ENOTSUP, -1);
 
 	bzero(&key, sizeof(key));
 
@@ -80,9 +77,37 @@ alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 	if (strlcpy(key.path, field->wild.pre, sizeof(key.path)) >= sizeof(key.path))
 		return (errno = E2BIG, -1);
 
+	/*
+	 * If there is no postfix, post_len is 0.
+	 */
+	post_len = field->wild.post_len;
+
+	/*
+	 * Install the prefix path
+	 */
 	if (bpf_map__update_elem(nqq->nova->maps.lpm_path,
-	    &key, sizeof(key), &v, sizeof(v), BPF_ANY) != 0) {
-		qwarn("bpf_map__update_elem %d", rule_i);
+	    &key, sizeof(key), &post_len, sizeof(post_len), BPF_ANY) != 0) {
+		qwarn("bpf_map__update_elem pre %d", rule_i);
+		return (-1);
+	}
+
+	/*
+	 * Maybe install the postfix path
+	 */
+	if (post_len == 0)
+		return (0);
+
+	key.meta |= META_RF_POSTFIX;
+	key.prefixlen = (sizeof(key.meta) + field->wild.post_len) * 8;
+
+	if (strlcpy(key.path, field->wild.post, sizeof(key.path)) >= sizeof(key.path))
+		return (errno = E2BIG, -1);
+
+	/* No post_len inside a postfix */
+	post_len = 0;
+	if (bpf_map__update_elem(nqq->nova->maps.lpm_path,
+	    &key, sizeof(key), &post_len, sizeof(post_len), BPF_ANY) != 0) {
+		qwarn("bpf_map__update_elem post %d", rule_i);
 		return (-1);
 	}
 

--- a/quark-test.c
+++ b/quark-test.c
@@ -2272,19 +2272,14 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 		errx(1, "please run me with -1");
 
 	text_ruleset =
-	    "pass on process.exe /usr/bin/bash\n"
-	    "pass on process.exe /bin/bash\n"
-	    "pass on process.exe /usr/bin/ls\n"
-	    "pass on process.exe /bin/ls\n"
+	    "pass on process.exe ishallnevermatch\n"
 	    "pass on process.exe /usr/bin/mksh\n"
-	    "pass on process.exe /bin/mksh\n"
+	    "pass on process.exe /usr/*/bash\n"
 	    "pass on process.exe /usr/bin/b*\n"
 	    "pass on process.exe /bin/b*\n"
 	    "pass on process.exe /usr/bin/bc\n"
 	    "pass on process.exe /bin/bc\n"
-	    "pass on process.exe /somethingreallyreallylong\n"
 	    "pass on process.exe /idontexist\n"
-	    "pass on process.exe /omginowc*andoinfix\n"
 	    "pass on any";
 	ruleset_from_string(&ruleset, text_ruleset);
 

--- a/quark.c
+++ b/quark.c
@@ -4880,7 +4880,7 @@ quark_rule_field_match(struct quark_rule *rule, struct quark_rule_field *field,
 	qp = qev->process;
 
 #define MATCH_PROC_FIELD(_p, _n, _v)					\
-	((_p) != NULL && ((_p)->flags & QUARK_F_PROC) && (_p)->_n == _v)
+	((_p) != NULL && ((_p)->flags & QUARK_F_PROC) && (_p)->_n == (_v))
 
 	switch (field->code) {
 	case QUARK_RF_PID:


### PR DESCRIPTION
This implements infix path matching for nova probes, so we can match on
/usr/*/ls for example.

We can currently match executables and file access paths, even though we only
have the probes for executables so far. The good news is that the verifier is
_very_ happy:
processed 1031 insns (limit 1000000) max_states_per_insn 5 total_states 88 peak_states 168 mark_read 0

I've also made tests adding 4 different paths per rule, and trying to match them
50x per rule, we went up to 15k instructions.

This also reduces stack space by ~90 bytes or so, instead of having eval on the
stack, put it in a map and look it up per iteration, also stop using scratch
maps, just add a big fat eval, this also makes the verifier much happier.

Also cut all this PATH_LPM_PREFIXLEN nonsense, just use the fixed maximum bit
length, all our keys have a NUL on it, so it makes no difference, the NUL
prevents us from going overboard.

Issue #315
