### PR TITLE
Improve the build, detect strlcpy and update alpine

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,9 +27,17 @@ steps:
       provider: gcp
       machineType: n2-standard-2
 
-  - label: "build amd64 in an alpine container"
-    key: make_alpine
+  - label: "build amd64 in an alpine container (no syslib)"
+    key: make_alpine_nosyslib
     command: "make alpine NO_GO=y WITH_BTFHUB=y"
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+
+  - label: "build amd64 in an alpine container (with syslib)"
+    key: make_alpine_syslib
+    command: "make alpine SYSLIB=y NO_GO=y WITH_BTFHUB=y"
     agents:
       image: family/core-ubuntu-2404
       provider: gcp

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,15 +1,19 @@
-FROM alpine:3.22
+FROM alpine:edge
 ENV HOME=/tmp/quark-builder
 RUN apk add 						\
 	bash						\
 	bison						\
-	clang						\
 	bpftool						\
+	cjson						\
+	cjson-dev					\
+	clang						\
 	gcc						\
 	go						\
-	libbsd						\
+	libbpf						\
+	libbpf-dev					\
 	libbsd-dev					\
+	linux-headers					\
+	m4                                              \
 	make						\
 	musl-fts					\
-	musl-fts-dev					\
-	m4
+	musl-fts-dev

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,10 @@ ifdef WITH_BTFHUB
 CPPFLAGS+= -DWITH_BTFHUB
 EXTRA_OPTIONS+= WITH_BTFHUB=$(WITH_BTFHUB)
 endif
-ifndef SYSLIB
+ifdef SYSLIB
+CPPFLAGS+= -DSYSLIB
+EXTRA_OPTIONS+= SYSLIB=$(SYSLIB)
+else
 CPPFLAGS+= -Iinclude
 endif
 
@@ -218,7 +221,9 @@ ALL_TARGETS+=quark-mon
 ALL_TARGETS+=quark-btf
 ALL_TARGETS+=quark-test
 ALL_TARGETS+=hanson-bench
-ifndef NO_GO
+ifdef NO_GO
+EXTRA_OPTIONS+= NO_GO=$(NO_GO)
+else
 ALL_TARGETS+=quark-kube-talker
 ALL_TARGETS+=quark-go-test
 endif
@@ -383,7 +388,7 @@ alpine: alpine-image clean-all
 	$(call msg,ALPINE-DOCKER-RUN,Dockerfile)
 	$(Q)$(DOCKER) run 				\
 		$(ALPINE_RUN_ARGS) $(SHELL)		\
-		-c "make $(EXTRA_OPTIONS) -C $(PWD) $(ALL_TARGETS) initramfs.gz"
+		-c "make $(EXTRA_OPTIONS) -C $(PWD) $(ALL_TARGETS)"
 
 alpine-image: clean-all
 	$(call msg,ALPINE-IMAGE,Dockerfile.alpine)

--- a/compat.c
+++ b/compat.c
@@ -1,10 +1,14 @@
 #include <sys/types.h>
 
 #include <ctype.h>
+#include <features.h>
 #include <string.h>
 
 #include "compat.h"
 
+#if !defined(SYSLIB) ||							\
+	(defined(__GLIBC__) &&						\
+	    (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 38)))
 /*
  * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
  *
@@ -105,6 +109,8 @@ strlcpy(char *dst, const char *src, size_t siz)
 
 	return(s - src - 1);	/* count does not include NUL */
 }
+
+#endif /* strlcpy, strlcat */
 
 /*
  * Copyright (c) 2004 Ted Unangst and Todd Miller

--- a/compat.h
+++ b/compat.h
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 
 /* Standard */
+#include <features.h>
 #include <stdio.h>
 #include <stdint.h>
 
@@ -57,8 +58,12 @@ typedef uintptr_t	__uintptr_t;	/* for freebsd_tree.h */
 #include "freebsd_queue.h"
 #include "freebsd_tree.h"
 
+#if !defined(SYSLIB) ||							\
+	(defined(__GLIBC__) &&						\
+	    (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 38)))
 size_t		strlcat(char *, const char *, size_t);
 size_t		strlcpy(char *, const char *, size_t);
+#endif /* strlcpy, strlcat */
 long long	strtonum(const char *, long long, long long, const char **);
 
 /*


### PR DESCRIPTION
This makes sure alpine can build both with and without SYSLIB, I had to remove
the initramfs.gz target there, but it shouldn't be an issue. While here, be bold
and use alpine:edge.

Detect strlcpy(3) and strlcat(3) since they're posix since 2023, finally the
future is here.
