### PR TITLE
Populate the ringbuffer in QQ_NOVA

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1031,7 +1031,6 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	struct bpf_queue		*bqq;
 	struct bpf_probes		*p;
 	struct bpf_program		*prog;
-	struct ring_buffer_opts		 ringbuf_opts;
 	int				 cgroup_fd, i, off, ringbuf_fd;
 	char				*cgroup_umount;
 	struct bpf_prog_skeleton	*ps;
@@ -1305,9 +1304,8 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		goto fail;
 	}
 
-	ringbuf_opts.sz = sizeof(ringbuf_opts);
 	bqq->ringbuf = ring_buffer__new(bpf_map__fd(p->maps.ringbuf),
-	    bpf_ringbuf_cb, qq, &ringbuf_opts);
+	    bpf_ringbuf_cb, qq, NULL);
 	if (bqq->ringbuf == NULL) {
 		qwarn("ring_buffer__new");
 		goto fail;

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -7,12 +7,16 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 
+/* XXX Remove me once we update our ancient vmlinux.h XXX */
+struct bpf_dynptr {
+	__u64 __opaque[2];
+} __attribute__((aligned(8)));
+
 #include "nova.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wpadded"
 
-/* XXX check if there isn't something like this on the headers XXX */
 #define LOOP_CONTINUE	0
 #define LOOP_STOP	1
 
@@ -26,6 +30,14 @@
 
 extern void bpf_preempt_disable(void) __ksym __weak;
 extern void bpf_preempt_enable(void) __ksym __weak;
+
+struct output {
+	__u32			head_len;
+	__u32			total_len;
+	__u32			var_off;
+	__u32			pad;
+	struct bpf_dynptr	dptr;
+};
 
 struct eval_path {
 	char			 full[PATH_MAX];
@@ -42,17 +54,11 @@ struct eval_path {
  */
 struct eval {
 	/* fields is the bitmask of things that have been filled */
-	__u64			 fields;		/* QUARK_RF_* bitmask */
-	__u64			 poison_tag;		/* QUARK_RF_POISON */
-	__u32			 pid;			/* QUARK_RF_PID */
-	__u32			 ppid;			/* QUARK_RF_PPID */
-	__u32			 uid;			/* QUARK_RF_UID */
-	__u32			 gid;			/* QUARK_RF_GID */
-	__u32			 sid;			/* QUARK_RF_SID */
-	__u32			 pad0;
-	struct eval_path	 exe;			/* QUARK_RF_EXE */
-	struct eval_path	 filepath;		/* QUARK_RF_FILEPATH */
-	char			 comm[16];		/* QUARK_RF_COMM */
+	__u64			fields;		/* QUARK_RF_* bitmask */
+	__u64			poison_tag;	/* QUARK_RF_POISON */
+	struct nova_task	nt;
+	struct eval_path	exe;		/* QUARK_RF_EXE */
+	struct eval_path	filepath;	/* QUARK_RF_FILEPATH */
 };
 
 struct {
@@ -84,6 +90,11 @@ struct {
 	__type(value, struct nova_rule_pcpu);
 } ruleset_pcpu SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 8 * 1024 * 1024);
+} output_ring SEC(".maps");
+
 const volatile u_int	rules_active;
 
 static void
@@ -98,6 +109,83 @@ preempt_enable(void)
 {
 	if (bpf_ksym_exists(bpf_preempt_enable))
 		bpf_preempt_enable();
+}
+
+static __u64
+ktime_get_boot_ns(void)
+{
+	if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns))
+		return (bpf_ktime_get_boot_ns());
+	else
+		return (0);
+}
+
+static void
+task_to_nova(struct task_struct *task, struct nova_task *nt)
+{
+	const struct cred	*cred;
+	struct task_struct	*gl;
+	struct signal_struct	*sig;
+	struct pid		*pgid_pid, *sid_pid;
+	int			 e_pgid, e_sid;
+	struct tty_struct	*tty;
+	const struct tty_driver *tty_driver;
+	const struct nsproxy	*ns;
+	struct pid		*pid;
+	int			 pid_level;
+
+	__builtin_memset(nt, 0, sizeof(*nt));
+
+	if (bpf_core_enum_value_exists(enum pid_type, PIDTYPE_PGID))
+		e_pgid = bpf_core_enum_value(enum pid_type, PIDTYPE_PGID);
+	else
+		e_pgid = PIDTYPE_PGID;
+	if (bpf_core_enum_value_exists(enum pid_type, PIDTYPE_SID))
+		e_sid = bpf_core_enum_value(enum pid_type, PIDTYPE_SID);
+	else
+		e_sid = PIDTYPE_SID;
+
+	cred = BPF_CORE_READ(task, cred);
+	gl = BPF_CORE_READ(task, group_leader);
+	sig = BPF_CORE_READ(gl, signal);
+	pgid_pid = BPF_CORE_READ(sig, pids[e_pgid]);
+	sid_pid  = BPF_CORE_READ(sig, pids[e_sid]);
+	tty = BPF_CORE_READ(sig, tty);
+	tty_driver = BPF_CORE_READ(tty, driver);
+	ns = BPF_CORE_READ(task, nsproxy);
+	pid = BPF_CORE_READ(task, thread_pid);
+
+	bpf_core_read(&nt->cap_eff, sizeof(nt->cap_eff), &cred->cap_effective);
+	bpf_core_read(&nt->cap_perm, sizeof(nt->cap_perm), &cred->cap_permitted);
+
+	nt->start_time_ns = BPF_CORE_READ(gl, start_time);
+	nt->tid = BPF_CORE_READ(task, pid);
+	nt->pid = BPF_CORE_READ(task, tgid);
+	nt->ppid = BPF_CORE_READ(gl, real_parent, tgid);
+	nt->uid = BPF_CORE_READ(cred, uid.val);
+	nt->gid = BPF_CORE_READ(cred, gid.val);
+	nt->suid = BPF_CORE_READ(cred, suid.val);
+	nt->sgid = BPF_CORE_READ(cred, sgid.val);
+	nt->euid = BPF_CORE_READ(cred, euid.val);
+	nt->egid = BPF_CORE_READ(cred, egid.val);
+	nt->pgid = BPF_CORE_READ(pgid_pid, numbers[0].nr);
+	nt->sid = BPF_CORE_READ(sid_pid, numbers[0].nr);
+	nt->tty_major = BPF_CORE_READ(tty_driver, major);
+	nt->tty_minor = BPF_CORE_READ(tty_driver, minor_start);
+	nt->tty_minor += BPF_CORE_READ(tty, index);
+	nt->uts_inonum = BPF_CORE_READ(ns, uts_ns, ns.inum);
+	nt->ipc_inonum = BPF_CORE_READ(ns, ipc_ns, ns.inum);
+	nt->mnt_inonum = BPF_CORE_READ(ns, mnt_ns, ns.inum);
+	nt->net_inonum = BPF_CORE_READ(ns, net_ns, ns.inum);
+	nt->cgroup_inonum = BPF_CORE_READ(ns, cgroup_ns, ns.inum);
+	nt->time_inonum = BPF_CORE_READ(ns, time_ns, ns.inum);
+	if (pid != NULL) {
+		pid_level = BPF_CORE_READ(pid, level);
+		nt->pid_inonum = BPF_CORE_READ(pid,
+		    numbers[pid_level].ns, ns.inum);
+	} else
+		nt->pid_inonum = 0;
+	BPF_CORE_READ_STR_INTO(&nt->comm, task, comm);
 }
 
 static __always_inline struct eval *
@@ -181,15 +269,15 @@ eval_loop(__u32 i, struct nova_rule **match)
 	if ((eval->fields & rule->fields) != rule->fields)
 		return (LOOP_CONTINUE);
 
-	if (rule->fields & QUARK_RF_PID && eval->pid != rule->pid)
+	if (rule->fields & QUARK_RF_PID && eval->nt.pid != rule->pid)
 		return (LOOP_CONTINUE);
-	if (rule->fields & QUARK_RF_PPID && eval->ppid != rule->ppid)
+	if (rule->fields & QUARK_RF_PPID && eval->nt.ppid != rule->ppid)
 		return (LOOP_CONTINUE);
-	if (rule->fields & QUARK_RF_UID && eval->uid != rule->uid)
+	if (rule->fields & QUARK_RF_UID && eval->nt.uid != rule->uid)
 		return (LOOP_CONTINUE);
-	if (rule->fields & QUARK_RF_GID && eval->gid != rule->gid)
+	if (rule->fields & QUARK_RF_GID && eval->nt.gid != rule->gid)
 		return (LOOP_CONTINUE);
-	if (rule->fields & QUARK_RF_SID && eval->sid != rule->sid)
+	if (rule->fields & QUARK_RF_SID && eval->nt.sid != rule->sid)
 		return (LOOP_CONTINUE);
 	if (rule->fields & QUARK_RF_POISON &&
 	    eval->poison_tag != rule->poison_tag)
@@ -219,11 +307,11 @@ eval_run(struct eval *eval)
 	}
 
 	if (match == NULL)
-		return (0);
+		return (QUARK_RA_PASS);
 
 	bpf_printk("rule %d matched! (0x%x)", match->number, match->fields);
 
-	return (0);
+	return (match->action);
 }
 
 static void
@@ -233,6 +321,28 @@ eval_path_init(struct eval_path *ep)
 	ep->full[0] = 0;
 	ep->pre.prefixlen = PATH_LPM_KEY_BITLEN;
 	ep->post.prefixlen = PATH_LPM_KEY_BITLEN;
+}
+
+static int
+eval_path_prepare(struct eval_path *dst, struct path *src)
+{
+	long	len, full_len;
+
+	full_len = bpf_d_path(src, dst->full, PATH_MAX);
+	if (full_len < 0) {
+		bpf_printk("can't make path 1");
+		return (-1);
+	}
+	len = bpf_probe_read_kernel_str(dst->pre.path,
+	    sizeof(dst->pre.path), dst->full);
+	if (len < 0) {
+		bpf_printk("can't make path 2");
+		return (-1);
+	}
+
+	dst->full_len = full_len;
+
+	return (0);
 }
 
 static struct eval *
@@ -253,22 +363,73 @@ eval_init(void)
 static void
 eval_init_task(struct eval *eval, struct task_struct *task)
 {
-	eval->pid = BPF_CORE_READ(task, tgid);
-	eval->fields |= QUARK_RF_PID;
-	eval->ppid = BPF_CORE_READ(task, group_leader, real_parent, tgid);
-	eval->fields |= QUARK_RF_PPID;
-	eval->uid = BPF_CORE_READ(task, cred, uid.val);
-	eval->fields |= QUARK_RF_UID;
-	eval->gid = BPF_CORE_READ(task, cred, gid.val);
-	eval->fields |= QUARK_RF_GID;
-#if 0
-	eval->sid = 		/* XXX TODO XXX */
-	eval->fields |= QUARK_RF_SID;
-#endif
-	/* XXX NOT WORTH THE BRANCH? XXX */
-	if (BPF_CORE_READ_STR_INTO(eval->comm, task, comm) > 0)
-		eval->fields |= QUARK_RF_COMM;
-	/* TODO MORE TODO */
+	task_to_nova(task, &eval->nt);
+	eval->fields |= QUARK_RF_PID | QUARK_RF_PPID | QUARK_RF_UID | QUARK_RF_GID;
+}
+
+static __always_inline void *
+output_reserve(struct output *o, __u32 head_len, __u32 total_len)
+{
+	struct nova_event	*ev;
+
+	o->head_len = head_len;
+	o->total_len = total_len;
+	o->var_off = o->head_len;
+
+	if (bpf_ringbuf_reserve_dynptr(&output_ring,
+	    o->total_len, 0, &o->dptr) != 0)
+		return (NULL);
+
+	if ((ev = bpf_dynptr_data(&o->dptr, 0, head_len)) == NULL)
+		return (NULL);
+
+	__builtin_memset(ev, 0, head_len);
+
+	ev->ts = bpf_ktime_get_ns();
+	ev->ts_boot = ktime_get_boot_ns();
+
+	return (ev);
+}
+
+static __always_inline void
+output_discard(struct output *o)
+{
+	bpf_ringbuf_discard_dynptr(&o->dptr, 0);
+}
+
+/*
+ * Writes src into output, fills in nv with offsets so userland can fetch it,
+ * src_len_max is max storage len of src_len.
+ */
+static __always_inline long
+output_vl_write(struct output *o, struct nova_vl *nv,
+    void *src, __u32 src_len, const __u32 src_len_max)
+{
+	long err;
+
+	nv->len = 0;
+	nv->off = 0;
+
+	if (src_len == 0)
+		return (0);
+	if (src_len > src_len_max)
+		return (-E2BIG);
+
+	err = bpf_dynptr_write(&o->dptr, o->var_off, src, src_len, 0);
+	if (err != 0)
+		return (err);
+
+	nv->len = src_len;
+	nv->off = o->var_off;
+	o->var_off += src_len;
+
+	return (0);
+}
+
+static __always_inline void
+output_submit(struct output *o)
+{
+	bpf_ringbuf_submit_dynptr(&o->dptr, 0);
 }
 
 static int
@@ -276,8 +437,10 @@ bprm_check1(struct linux_binprm *bprm, int ret)
 {
 	struct task_struct	*task = bpf_get_current_task_btf();
 	struct eval		*eval;
+	struct eval_path	*exe;
+	struct output		 o;
+	struct nova_exec	*exec;
 	int			 r;
-	long			 len;
 
 	if ((eval = eval_init()) == NULL)
 		return (0);
@@ -286,25 +449,42 @@ bprm_check1(struct linux_binprm *bprm, int ret)
 	if (bprm->file == NULL)
 		goto noexe;
 
-	len = bpf_d_path(&bprm->file->f_path, eval->exe.full, PATH_MAX);
-	if (len < 0) {
+	exe = &eval->exe;
+	if (eval_path_prepare(exe, &bprm->file->f_path) != 0) {
 		bpf_printk("can't make executable 1");
-		goto noexe;
-	}
-	eval->exe.full_len = len;
-	len = bpf_probe_read_kernel_str(eval->exe.pre.path,
-	    sizeof(eval->exe.pre.path), eval->exe.full);
-	if (len < 0) {
-		bpf_printk("can't make executable 2");
 		goto noexe;
 	}
 
 	eval->fields |= QUARK_RF_EXE;
 noexe:
 	r = eval_run(eval);
-	r = 0; /* XXX r ignored for now */
 
-	return (r);
+	if (r != QUARK_RA_PASS)
+		goto done;
+
+	exec = output_reserve(&o, sizeof(*exec),
+	    sizeof(*exec) + exe->full_len);
+	if (exec == NULL)
+		goto discard;
+	/*
+	 * Borrow nova_task from eval
+	 */
+	exec->nt = eval->nt;
+	if (output_vl_write(&o, &exec->exe, exe->full,
+	    exe->full_len, PATH_MAX) != 0)
+		goto discard;
+
+	exec->ev.kind = NOVA_EXEC;
+
+	output_submit(&o);
+
+done:
+	return (0);	/* Always pass for now */
+
+discard:
+	output_discard(&o);
+
+	return (0);	/* Always pass for now */
 }
 
 SEC("lsm/bprm_check_security")

--- a/nova.h
+++ b/nova.h
@@ -82,6 +82,60 @@ struct nova_rule {
 struct nova_rule_pcpu {
 	__u64	hits;			/* counter */
 	__u64	evals;			/* counter */
+};
+
+enum nova_kind {
+	NOVA_INVALID,
+	NOVA_FORK,
+	NOVA_EXEC,
+	NOVA_EXIT,
+	NOVA_MAX,
+};
+
+struct nova_vl {
+	__u32	off;
+	__u32	len;
+};
+
+struct nova_task {
+	__u64	cap_perm;
+	__u64	cap_eff;
+	__u64	start_time_ns;
+	__u32	tid;
+	__u32	pid;		/* QUARK_RF_PID */
+	__u32	ppid;		/* QUARK_RF_PPID */
+	__u32	uid;		/* QUARK_RF_UID */
+	__u32	gid;		/* QUARK_RF_GID */
+	__u32	suid;
+	__u32	sgid;
+	__u32	euid;
+	__u32	egid;
+	__u32	pgid;
+	__u32	sid;		/* QUARK_RF_SID */
+	__u32	tty_major;
+	__u32	tty_minor;
+	__u32	uts_inonum;
+	__u32	ipc_inonum;
+	__u32	mnt_inonum;
+	__u32	net_inonum;
+	__u32	cgroup_inonum;
+	__u32	time_inonum;
+	__u32	pid_inonum;
+	char	comm[16];
+};
+
+struct nova_event {
+	__u16	kind;		/* user filled */
+	__u16	pad1;		/* zeroed */
+	__u32	pad2;		/* zeroed */
+	__u64	ts;		/* auto */
+	__u64	ts_boot;	/* auto */
+} __aligned(8);
+
+struct nova_exec {
+	struct nova_event	ev;
+	struct nova_task	nt;
+	struct nova_vl		exe;
 } __aligned(8);
 
 #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 10))

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -21,7 +21,8 @@
 #include "nova_skel.h"
 
 struct nova_queue {
-	struct nova	*nova;
+	struct nova		*nova;
+	struct ring_buffer	*ringbuf;
 };
 
 static int	nova_queue_populate(struct quark_queue *);
@@ -100,6 +101,8 @@ alloc_path(struct nova_queue *nqq, int rule_i, struct quark_rule_field *field)
 	key.meta |= META_RF_POSTFIX;
 	key.prefixlen = (sizeof(key.meta) + field->wild.post_len) * 8;
 
+	/* Don't leak pre bytes into post, so zero it */
+	bzero(key.path, sizeof(key.path));
 	if (strlcpy(key.path, field->wild.post, sizeof(key.path)) >= sizeof(key.path))
 		return (errno = E2BIG, -1);
 
@@ -225,6 +228,110 @@ load_ruleset(struct quark_queue *qq, struct nova_queue *nqq)
 	return (0);
 }
 
+static const char *
+nova_kind_str(enum nova_kind kind)
+{
+	switch (kind) {
+	case NOVA_FORK:
+		return ("NOVA_FORK");
+	case NOVA_EXEC:
+		return ("NOVA_EXEC");
+	case NOVA_EXIT:
+		return ("NOVA_EXIT");
+	default:
+		return ("?");
+	}
+}
+
+/*
+ * nova_vl to char *
+ * NOTE: if we pass qq here we could add some basic bound checks for rogue
+ * events.
+ */
+static const char *
+vltoc(void *vnev, struct nova_vl *vl)
+{
+	struct nova_event	*nev = vnev;
+
+	if (vl->len == 0)
+		return (NULL);
+
+	return (((const char *)nev) + vl->off);
+}
+
+static int
+nova_ringbuf_cb(void *vqq, void *vdata, size_t len)
+{
+	/* struct quark_queue	*qq = vqq; */
+	struct nova_event	*nev;
+	struct nova_task	*nt;
+	struct nova_exec	*exec;
+
+	nev = vdata;
+	nt = NULL;
+
+	printf("nova event %s len=%zd ts=%llu ts_boot=%llu ",
+	    nova_kind_str(nev->kind), len, nev->ts, nev->ts_boot);
+
+	switch (nev->kind) {
+	case NOVA_EXEC:
+		exec = (struct nova_exec *)nev;
+		nt = &exec->nt;
+		printf("exe=%s cap_eff=0x%llx cap_perm=0x%llx uid=%d gid=%d comm=%s",
+		    vltoc(exec, &exec->exe), nt->cap_eff, nt->cap_perm, nt->uid,
+		    nt->gid, nt->comm);
+		break;
+	default:
+		putchar('?');
+		break;
+	}
+
+	putchar('\n');
+
+	return (0);
+}
+
+static int
+ringbuf_setup(struct quark_queue *qq, struct nova_queue *nqq)
+{
+	int			ringbuf_fd;
+	struct epoll_event	ev;
+
+	nqq->ringbuf = ring_buffer__new(bpf_map__fd(nqq->nova->maps.output_ring),
+	    nova_ringbuf_cb, qq, NULL);
+	if (nqq->ringbuf == NULL) {
+		qwarn("can't setup ringbuf");
+		goto fail;
+	}
+
+	ringbuf_fd = ring_buffer__epoll_fd(nqq->ringbuf);
+	if (ringbuf_fd < 0) {
+		qwarnx("ring_buffer__epoll_fd failed");
+		goto fail;
+	}
+	bzero(&ev, sizeof(ev));
+	ev.events = EPOLLIN;
+	ev.data.fd = ringbuf_fd;
+	if (epoll_ctl(qq->epollfd, EPOLL_CTL_ADD, ringbuf_fd, &ev) == -1) {
+		qwarn("epoll_ctl");
+		goto fail;
+	}
+	/*
+	 * FUTURE: if you add code here, you must undo the epoll_ctl() above in
+	 * fail:
+	 */
+
+	return (0);
+fail:
+	if (nqq->ringbuf != NULL) {
+		/* this closes ringbuf_fd! */
+		ring_buffer__free(nqq->ringbuf);
+		nqq->ringbuf = NULL;
+	}
+
+	return (-1);
+}
+
 int
 nova_queue_open(struct quark_queue *qq)
 {
@@ -253,6 +360,8 @@ nova_queue_open(struct quark_queue *qq)
 		goto fail;
 	if (load_ruleset(qq, nqq) == -1)
 		goto fail;
+	if (ringbuf_setup(qq, nqq) == -1)
+		goto fail;
 	if (nova__attach(nqq->nova) != 0)
 		goto fail;
 
@@ -268,7 +377,19 @@ fail:
 static int
 nova_queue_populate(struct quark_queue *qq)
 {
-	return (0);
+	struct nova_queue	*nqq = qq->queue_be;
+	int			 npop, space_left;
+
+	space_left =
+	    qq->flags & QQ_BYPASS ? 1 :
+	    qq->length >= qq->max_length ? 0 :
+	    qq->max_length - qq->length;
+	if (space_left == 0)
+		return (0);
+
+	npop = ring_buffer__consume_n(nqq->ringbuf, space_left);
+
+	return (npop < 0 ? -1 : npop);
 }
 
 static int
@@ -301,14 +422,14 @@ nova_queue_update_stats(struct quark_queue *qq)
 	for (i = 0; i < (u32)qq->ruleset->n_rules; i++) {
 		qr = qq->ruleset->rules + i;
 
-		qr->evals = 0;
-		qr->hits = 0;
-
 		if (bpf_map__lookup_elem(nova->maps.ruleset_pcpu, &i,
 		    sizeof(i), rule_pcpu, sizeof(*rule_pcpu) * num_cpus, 0) != 0) {
 			qwarn("bpf_map__lookup_elem");
 			goto fail;
 		}
+
+		qr->evals = 0;
+		qr->hits = 0;
 
 		for (j = 0; j < num_cpus; j++) {
 			qr->evals += rule_pcpu[j].evals;
@@ -332,8 +453,26 @@ nova_queue_close(struct quark_queue *qq)
 
 	if (nqq == NULL)
 		return;
+	if (nqq->nova != NULL) {
+		nova__destroy(nqq->nova);
+		nqq->nova = NULL;
+	}
 
-	nova__destroy(nqq->nova);
+	if (nqq->ringbuf != NULL) {
+		int	ringbuf_fd;
+
+		ringbuf_fd = ring_buffer__epoll_fd(nqq->ringbuf);
+		if (ringbuf_fd >= 0) {
+			if (epoll_ctl(qq->epollfd, EPOLL_CTL_DEL, ringbuf_fd,
+			    NULL) == -1)
+				qwarn("epoll_ctl EPOLL_CTL_DEL");
+		}
+
+		/* this closes ringbuf_fd! */
+		ring_buffer__free(nqq->ringbuf);
+		nqq->ringbuf = NULL;
+	}
+
 	free(nqq);
 	qq->queue_be = NULL;
 }

--- a/quark-test.c
+++ b/quark-test.c
@@ -2370,6 +2370,7 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 	fprintf(stderr, "\nthis test is a placeholder for temporary fiddling!!!\n");
 	fprintf(stderr, "sleeping forevis...\n");
 	for (;;) {
+		(void)quark_queue_get_event(&qq);
 		quark_queue_get_stats(&qq, &stats);
 		for (i = 0; i < qq.ruleset->n_rules; i++) {
 			printf("rule %zd: evals %llu hits %llu\n",


### PR DESCRIPTION
```
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Mon May 18 13:31:23 2026 +0200

    Populate the ringbuffer in QQ_NOVA

    This diff starts putting things into the ringbuffer, which means also adding the
    code for retrieving "most" of the task fields so far, see task_to_nova().

    There are still missing fields, like cwd and env, these will come later.

    The API for outputing things in the ringbuffer is called "output", it mimicks
    the same underlying helpers:
        ouput_reserve -> bpf_ringbuf_reserve_dynptr
        output_discard -> bpf_ringbuf_discard_dynptr
        output_submit -> bpf_ringbuf_submit_dynptr

    The API does a bit more than just calling the helper, and we also do it so we
    can support kernels that don't have dynptr ([5.17:5.19[). In the future I can
    add code below this API to handle the case without dynptr.

    Why is dynptr cool?
    The old bpf_ringbuf_reserve() needs a compile time constant for reserve(),
    meaning we can't reserve some length bytes stored in a variable, it needs to be
    a compile time constant. That's why the old probes have to copy everything in a
    temporary buffer, then do bpf_ringbuf_output(), because that one accepts a
    runtime length.

    Dynptr solves exactly that, the verifier knows how to track then length so we
    can use it in runtime, which means saving _full_ copy of the event for
    every event.

    We do variable length data, like paths and long strings, with a struct nova_vl,
    which can be written with output_vl_write(). nova_vl is stashed inside the
    actual event and contains offset and length so userland can call vltoc() (see
    nova_queue.c). This fixes a long standing grip I had with the old probes where
    you had to loop to find fields.

    struct eval{} now has the task fields in struct nova_task nt, we assemble nt
    once, which later is copied to the output buffer. This kinda sucks, and I tried
    really hard to do evaluation inside the ringbuffer itself, but it's not feasible
    for a myriad of reasons (trust me bro), the main one being we would have to
    reserve the maximum possible size of an event.

```