### PR TITLE
Give probes running in softirq context their own output buffer.

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1260,7 +1260,12 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
 	    get_nprocs_conf()) != 0) {
-		qwarn("bpf_map__set_max_entries");
+		qwarn("bpf_map__set_max_entries event_buffer_map");
+		goto fail;
+	}
+	if (bpf_map__set_max_entries(p->maps.event_buffer_map_softirq,
+	    get_nprocs_conf()) != 0) {
+		qwarn("bpf_map__set_max_entries event_buffer_map_softirq");
 		goto fail;
 	}
 

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -296,6 +296,9 @@ static int skb_peel_nexthdr(struct __sk_buff *skb, u8 wanted)
 }
 #endif
 
+/*
+ * See cgroub_skb/egress, pretty please.
+ */
 static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
 {
     struct udphdr udp;
@@ -344,10 +347,10 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
         goto ignore;
 
     /*
-     * Needed for kernels prior to f79efcb0075a20633cbf9b47759f2c0d538f78d8
+     * Needed for kernels prior to cd17d38f8b28f808c368121041c0a4fa91757e0d
      * bpf: Permits pointers on stack for helper calls
      */
-    sk_addr = bpf_map_lookup_elem(&scratch64, &zero);
+    sk_addr = bpf_map_lookup_elem(&scratch64_softirq, &zero);
     if (sk_addr == NULL)
         goto ignore;
     *sk_addr = (u64)sk;
@@ -375,7 +378,7 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
      * bpf_skb_load_bytes() down below to think cap_len can be zero.
      */
     if (cap_len >= (sizeof(struct iphdr) + sizeof(udp) + 12)) {
-        event = get_event_buffer();
+        event = get_event_buffer_softirq();
         if (event == NULL)
             goto ignore;
 
@@ -409,6 +412,14 @@ ignore:
     return (1);
 }
 
+/*
+ * This probe can and will trigger from softirq, this means it actually
+ * interrupts and runs interleaved with whatever probe the cpu happened to be
+ * running. Therefore you *MUST* not use any of the per cpu data structures that
+ * the other probes do, *DON'T* use get_event_buffer(), use
+ * get_event_buffer_softirq(), make sure you do the same for other scratch maps
+ * or any other shared data.
+ */
 SEC("cgroup_skb/egress")
 int skb_egress(struct __sk_buff *skb)
 {
@@ -421,6 +432,9 @@ int skb_egress(struct __sk_buff *skb)
     return r;
 }
 
+/*
+ * See cgroub_skb/egress, pretty please.
+ */
 SEC("cgroup_skb/ingress")
 int skb_ingress(struct __sk_buff *skb)
 {

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -188,6 +188,13 @@ struct {
     __uint(max_entries, 1);
 } scratch64 SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, 1);
+} scratch64_softirq SEC(".maps");
+
 /* Trusted Apps - list of trusted pids */
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);

--- a/elastic-ebpf/GPL/Events/Varlen.h
+++ b/elastic-ebpf/GPL/Events/Varlen.h
@@ -66,6 +66,19 @@ static void *get_event_buffer()
     return bpf_map_lookup_elem(&event_buffer_map, &key);
 }
 
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(key_size, sizeof(int));
+    __uint(value_size, EVENT_BUFFER_SIZE);
+    __uint(max_entries, 0); // Will be resized by userspace to $(nproc)
+} event_buffer_map_softirq SEC(".maps");
+
+static void *get_event_buffer_softirq(void)
+{
+    int key = bpf_get_smp_processor_id();
+    return bpf_map_lookup_elem(&event_buffer_map_softirq, &key);
+}
+
 struct ebpf_varlen_field *ebpf_vl_field__add(struct ebpf_varlen_fields_start *fields,
                                              enum ebpf_varlen_field_type type)
 {


### PR DESCRIPTION
Turns out bpf probes do not disable bottom half/softirq interrupts.
All probes use a per cpu output event buffer for staging the data to be put in
the ringbuffer.

Since softirq probes (cgroup_skb/egress, cgroup_skb/ingress) can run on top of a
kprobe/fentry probe (all the other ones), they end up racing the event buffer.

This diff makes softirq probes use their own output buffer event_buffer_map_softirq.
