### PR TITLE
tty: support old tty_write signature on RHEL 8

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1241,10 +1241,18 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	}
 
 	if (qq->flags & QQ_TTY) {
-		if (use_fentry)
-			bpf_program__set_autoload(p->progs.fentry__tty_write, 1);
-		else
-			bpf_program__set_autoload(p->progs.kprobe__tty_write, 1);
+		int tty_write_nparams = btf_number_of_params(btf, "tty_write");
+		if (tty_write_nparams != 4) {
+			if (use_fentry)
+				bpf_program__set_autoload(p->progs.fentry__tty_write, 1);
+			else
+				bpf_program__set_autoload(p->progs.kprobe__tty_write, 1);
+		} else {
+			if (use_fentry)
+				bpf_program__set_autoload(p->progs.fentry__tty_write_old_sig, 1);
+			else
+				bpf_program__set_autoload(p->progs.kprobe__tty_write_old_sig, 1);
+		}
 	}
 
 	if (qq->flags & QQ_PTRACE) {

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -882,3 +882,68 @@ int BPF_KPROBE(kprobe__tty_write, struct kiocb *iocb, struct iov_iter *from)
 
     return r;
 }
+
+static int tty_write_old__enter(struct file *file, const char *buf, size_t count)
+{
+    if (is_consumer()) {
+        goto out;
+    }
+
+    struct tty_file_private *tfp = (struct tty_file_private *)BPF_CORE_READ(file, private_data);
+    struct tty_struct *tty       = BPF_CORE_READ(tfp, tty);
+
+    bool is_master;
+    int type, subtype;
+    struct ebpf_tty_dev master = {};
+    struct ebpf_tty_dev slave  = {};
+    struct tty_driver *driver = BPF_CORE_READ(tty, driver);
+
+    if (driver == NULL)
+        goto out;
+
+    type    = BPF_PROBE_READ(driver, type);
+    subtype = BPF_PROBE_READ(driver, subtype);
+    is_master = type == OLD_TTY_DRIVER_TYPE_PTY && subtype == OLD_PTY_TYPE_MASTER;
+
+    if (is_master) {
+        struct tty_struct *tmp = BPF_CORE_READ(tty, link);
+        ebpf_tty_dev__fill(&master, tty);
+        ebpf_tty_dev__fill(&slave, tmp);
+    } else
+        ebpf_tty_dev__fill(&slave, tty);
+
+    if (slave.major == 0 && slave.minor == 0)
+        goto out;
+
+    if ((is_master && !(master.termios.c_lflag & ECHO)) && !(slave.termios.c_lflag & ECHO))
+        goto out;
+
+    (void)output_tty_event(&slave, buf, count);
+
+out:
+    return 0;
+}
+
+SEC("fentry/tty_write")
+int BPF_PROG(fentry__tty_write_old_sig, struct file *file, const char *buf, size_t count)
+{
+    int r;
+
+    preempt_disable();
+    r = tty_write_old__enter(file, buf, count);
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/tty_write")
+int BPF_KPROBE(kprobe__tty_write_old_sig, struct file *file, const char *buf, size_t count)
+{
+    int r;
+
+    preempt_disable();
+    r = tty_write_old__enter(file, buf, count);
+    preempt_enable();
+
+    return r;
+}


### PR DESCRIPTION
## Description
Get tty probes working on old kernels.

Running `quark-test` from main on RHEL 8:
```
$ sudo ./quark-test t_tty
t_tty @ ebpf...................oh hai from the tty test oh hai from the tty test oh hai from the tty test failed
quark-test: drain_for_pid: Timer expired
1 failures
```
Running `quark-test` from this branch on RHEL 8:
```
$ sudo ./quark-test t_tty
t_tty @ ebpf...................oh hai from the tty test oh hai from the tty test oh hai from the tty test ok
0 failures
```

I manually forced fentry and kprobe (re-compiled) and got the same successful output.

I considered consolidating `tty_write__enter` and `tty_write_old__enter` as there is some duplicate logic, but it was kind of ugly. The new function is pretty simple.  

## Bot Summary
RHEL 8 (kernel 4.18) uses the old tty_write calling convention: tty_write(struct file*, const char*, size_t, loff_t*)

The existing kprobe__tty_write expects the newer write_iter convention (kiocb, iov_iter) introduced around Linux 5.10. On RHEL 8, the probe read garbage from the wrong argument registers, causing driver == NULL checks to silently drop every tty IO event.

Add kprobe__tty_write_old_sig that takes file, buf, count directly, avoiding iov_iter unwrapping entirely.

In bpf_queue.c, use btf_number_of_params(btf, "tty_write") to distinguish the two calling conventions at load time:
- 2 params: new write_iter convention → load kprobe__tty_write
- 4 params: old file/buf/count/ppos   → load kprobe__tty_write_old_sig
- -1 (no BTF): attempt new-sig probe anyway

