### PR TITLE
Use nested context for dns probes

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -414,17 +414,8 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		packet->origin = QUARK_PACKET_ORIGIN_DNS;
 		packet->orig_len = dns->orig_len;
 		packet->cap_len = cap_len;
+		memcpy(packet->data, dns->packet, cap_len);
 
-		FOR_EACH_VARLEN_FIELD(dns->vl_fields, field) {
-			switch (field->type) {
-			case EBPF_VL_FIELD_DNS_BODY:
-				memcpy(packet->data, field->data, cap_len);
-				break;
-			default:
-				qwarnx("unhandled field type %d", field->type);
-				goto bad;
-			}
-		}
 		break;
 	}
 	case EBPF_EVENT_FILE_CREATE: /* FALLTHROUGH */
@@ -1269,11 +1260,6 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
 	    get_nprocs_conf()) != 0) {
 		qwarn("bpf_map__set_max_entries event_buffer_map");
-		goto fail;
-	}
-	if (bpf_map__set_max_entries(p->maps.event_buffer_map_softirq,
-	    get_nprocs_conf()) != 0) {
-		qwarn("bpf_map__set_max_entries event_buffer_map_softirq");
 		goto fail;
 	}
 

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -437,7 +437,7 @@ struct ebpf_dns_event {
     uint32_t cap_len;
     uint32_t orig_len;
     enum ebpf_net_packet_direction direction;
-    struct ebpf_varlen_fields_start vl_fields;
+    char packet[]; // must be last
 } __attribute__((packed));
 
 // Basic event statistics

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -29,6 +29,50 @@ struct {
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } sk_to_tgid SEC(".maps");
 
+struct dns_ctx {
+    /*
+     * which nest index we are, only meaningful on the first one,
+     * saves having a map just to store an int
+     */
+    u32 nest;
+    u64 scratch64;
+    struct ebpf_dns_event event; /* must be last */
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(struct dns_ctx) + MAX_DNS_PACKET);
+    __uint(max_entries, 3);
+} dns_ctx_map SEC(".maps");
+
+struct dns_ctx *
+get_dns_ctx(void)
+{
+    struct dns_ctx *ctx, *zero_ctx;
+
+    zero_ctx = bpf_map_lookup_elem(&dns_ctx_map, &(int){0});
+    if (zero_ctx == NULL)
+        return (NULL);
+    ctx = bpf_map_lookup_elem(&dns_ctx_map, &zero_ctx->nest);
+    if (ctx == NULL)
+        return (NULL);
+    zero_ctx->nest++;
+
+    return (ctx);
+}
+
+void
+put_dns_ctx(void)
+{
+	struct dns_ctx *zero_ctx;
+
+	zero_ctx = bpf_map_lookup_elem(&dns_ctx_map, &(int){0});
+	if (zero_ctx == NULL)
+		return;
+	zero_ctx->nest--;
+}
+
 static int inet_csk_accept__exit(struct sock *sk)
 {
     if (!sk)
@@ -299,14 +343,13 @@ static int skb_peel_nexthdr(struct __sk_buff *skb, u8 wanted)
 /*
  * See cgroub_skb/egress, pretty please.
  */
-static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
+static int skb_in_or_egress(struct __sk_buff *skb, int direction,
+    struct dns_ctx *ctx)
 {
     struct udphdr udp;
     struct bpf_sock *sk;
-    u32 *tgid, cap_len, zero = 0;
-    u64 *sk_addr;
+    u32 *tgid, cap_len;
     struct ebpf_dns_event *event;
-    struct ebpf_varlen_field *field;
 
     if (skb->family != AF_INET && skb->family != AF_INET6)
         goto ignore;
@@ -350,11 +393,8 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
      * Needed for kernels prior to cd17d38f8b28f808c368121041c0a4fa91757e0d
      * bpf: Permits pointers on stack for helper calls
      */
-    sk_addr = bpf_map_lookup_elem(&scratch64_softirq, &zero);
-    if (sk_addr == NULL)
-        goto ignore;
-    *sk_addr = (u64)sk;
-    tgid     = bpf_map_lookup_elem(&sk_to_tgid, sk_addr);
+    ctx->scratch64 = (u64)sk;
+    tgid = bpf_map_lookup_elem(&sk_to_tgid, &ctx->scratch64);
     if (tgid == NULL)
         goto ignore;
 
@@ -378,9 +418,7 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
      * bpf_skb_load_bytes() down below to think cap_len can be zero.
      */
     if (cap_len >= (sizeof(struct iphdr) + sizeof(udp) + 12)) {
-        event = get_event_buffer_softirq();
-        if (event == NULL)
-            goto ignore;
+        event = &ctx->event;
 
         event->hdr.type    = EBPF_EVENT_NETWORK_DNS_PKT;
         event->hdr.ts      = bpf_ktime_get_ns();
@@ -388,10 +426,8 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
         event->tgid        = *tgid;
         event->cap_len     = cap_len;
         event->orig_len    = skb->len;
-        event->direction   = ingress ? EBPF_NETWORK_DIR_INGRESS : EBPF_NETWORK_DIR_EGRESS;
+        event->direction   = direction;
 
-        ebpf_vl_fields__init(&event->vl_fields);
-        field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_DNS_BODY);
         /*
          * 5.10 kernels on clang-20+, for $REASONS, will result in code here
          * that loses track of cap_len, so cap_len will be unbound (R4 in
@@ -401,11 +437,10 @@ static int skb_in_or_egress(struct __sk_buff *skb, int ingress)
         if (cap_len > MAX_DNS_PACKET ||
             cap_len < (__u32)(sizeof(struct iphdr) + sizeof(udp) + 12))
                 goto ignore;
-        if (bpf_skb_load_bytes(skb, 0, field->data, cap_len))
+        if (bpf_skb_load_bytes(skb, 0, event->packet, cap_len))
             goto ignore;
-        ebpf_vl_field__set_size(&event->vl_fields, field, cap_len);
 
-        ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+        ebpf_ringbuf_write(&ringbuf, event, sizeof(*event) + cap_len, 0);
     }
 
 ignore:
@@ -413,23 +448,27 @@ ignore:
 }
 
 /*
- * This probe can and will trigger from softirq, this means it actually
- * interrupts and runs interleaved with whatever probe the cpu happened to be
- * running. Therefore you *MUST* not use any of the per cpu data structures that
- * the other probes do, *DON'T* use get_event_buffer(), use
- * get_event_buffer_softirq(), make sure you do the same for other scratch maps
- * or any other shared data.
+ * This probe can and will trigger from softirq as well as process context!
+ * Which means it actually interrupts and runs interleaved with whatever probe
+ * the cpu happened to be running. This also means egress/ingress can nest onto
+ * *anything*, including another egress/ingress, or a fork, exec or
+ * *anything*. Therefore you *MUST* not use any of the per cpu data structures
+ * that the others probes do *DON'T* use get_event_buffer(). Use get_dns_ctx()
+ * and put_dns_ctx() to properly nest it.
  */
 SEC("cgroup_skb/egress")
 int skb_egress(struct __sk_buff *skb)
 {
-    int r;
+    struct dns_ctx *ctx;
 
     preempt_disable();
-    r = skb_in_or_egress(skb, 0);
+    if ((ctx = get_dns_ctx()) != NULL) {
+        skb_in_or_egress(skb, EBPF_NETWORK_DIR_EGRESS, ctx);
+        put_dns_ctx();
+    }
     preempt_enable();
 
-    return r;
+    return 1;
 }
 
 /*
@@ -438,19 +477,22 @@ int skb_egress(struct __sk_buff *skb)
 SEC("cgroup_skb/ingress")
 int skb_ingress(struct __sk_buff *skb)
 {
-    int r;
+    struct dns_ctx *ctx;
 
     preempt_disable();
-    r = skb_in_or_egress(skb, 1);
+    if ((ctx = get_dns_ctx()) != NULL) {
+        skb_in_or_egress(skb, EBPF_NETWORK_DIR_INGRESS, ctx);
+        put_dns_ctx();
+    }
     preempt_enable();
 
-    return r;
+    return 1;
 }
 
 static int sk_maybe_save_tgid(struct bpf_sock *sk)
 {
-    u32 tgid, zero = 0;
-    u64 *sk_addr;
+    u32 tgid;
+    struct dns_ctx *ctx;
 
     if (sk->protocol != IPPROTO_UDP)
         return (1);
@@ -464,11 +506,12 @@ static int sk_maybe_save_tgid(struct bpf_sock *sk)
      * Needed for kernels prior to f79efcb0075a20633cbf9b47759f2c0d538f78d8
      * bpf: Permits pointers on stack for helper calls
      */
-    sk_addr = bpf_map_lookup_elem(&scratch64, &zero);
-    if (sk_addr == NULL)
+    ctx = get_dns_ctx();
+    if (ctx == NULL)
         return (1);
-    *sk_addr = (u64)sk;
-    bpf_map_update_elem(&sk_to_tgid, sk_addr, &tgid, BPF_ANY);
+    ctx->scratch64 = (u64)sk;
+    bpf_map_update_elem(&sk_to_tgid, &ctx->scratch64, &tgid, BPF_ANY);
+    put_dns_ctx();
 
     return (1);
 }
@@ -528,8 +571,7 @@ int sock_create(struct bpf_sock *sk)
 SEC("cgroup/sock_release")
 int sock_release(struct bpf_sock *sk)
 {
-    u32 zero = 0;
-    u64 *sk_addr;
+    struct dns_ctx *ctx;
 
     preempt_disable();
     if (sk->protocol != IPPROTO_UDP)
@@ -539,11 +581,12 @@ int sock_release(struct bpf_sock *sk)
      * Needed for kernels prior to f79efcb0075a20633cbf9b47759f2c0d538f78d8
      * bpf: Permits pointers on stack for helper calls
      */
-    sk_addr = bpf_map_lookup_elem(&scratch64, &zero);
-    if (sk_addr == NULL)
+    ctx = get_dns_ctx();
+    if (ctx == NULL)
         goto out;
-    *sk_addr = (u64)sk;
-    bpf_map_delete_elem(&sk_to_tgid, sk_addr);
+    ctx->scratch64 = (u64)sk;
+    bpf_map_delete_elem(&sk_to_tgid, &ctx->scratch64);
+    put_dns_ctx();
 
 out:
     preempt_enable();

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -180,21 +180,6 @@ static long ebpf_events_scratch_space__set(enum ebpf_events_state_op op,
     return bpf_map_update_elem(&elastic_ebpf_events_scratch_space, &key, ss, BPF_ANY);
 }
 
-/* Scratch 64bits as an array, as bpf_get_current_pid_tgid is not always available */
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, u32);
-    __type(value, u64);
-    __uint(max_entries, 1);
-} scratch64 SEC(".maps");
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, u32);
-	__type(value, u64);
-	__uint(max_entries, 1);
-} scratch64_softirq SEC(".maps");
-
 /* Trusted Apps - list of trusted pids */
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);

--- a/elastic-ebpf/GPL/Events/Varlen.h
+++ b/elastic-ebpf/GPL/Events/Varlen.h
@@ -66,19 +66,6 @@ static void *get_event_buffer()
     return bpf_map_lookup_elem(&event_buffer_map, &key);
 }
 
-struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY);
-    __uint(key_size, sizeof(int));
-    __uint(value_size, EVENT_BUFFER_SIZE);
-    __uint(max_entries, 0); // Will be resized by userspace to $(nproc)
-} event_buffer_map_softirq SEC(".maps");
-
-static void *get_event_buffer_softirq(void)
-{
-    int key = bpf_get_smp_processor_id();
-    return bpf_map_lookup_elem(&event_buffer_map_softirq, &key);
-}
-
 struct ebpf_varlen_field *ebpf_vl_field__add(struct ebpf_varlen_fields_start *fields,
                                              enum ebpf_varlen_field_type type)
 {


### PR DESCRIPTION
Things are worse than f6284da030a07912131b9e17ac7c1efc48f80e3b

These probes can actually trigger from process context as well as softirq
context.

The most normal path for skb_egress is to trigger from process context:
write(2) -> sock_write().... -> udp_output() -> ip_output()....
or whatever the hell linux calls it.

But skb_egress can also trigger from an actual softirq, imagine sending a
TCP_ACK for an incoming packet that is being processed at softirq.
Important: not only skb_egress can race against skb_ingress, skb_egress can race
against skb_egress as well! The bottom half is not disabled in the output path.

The skb_ingress path seems to be similar, it can trigger both from softirq and
process context. The softirq is the normal case, think of a packet hitting the
card and then dispatching a softirq. The process context can happen when a
write() to localhost short-circuits two processes.

Instead of trying to figure out all the possible combinations, rewrite the DNS
events to use nested contexts, even though we only need 2, use 3, because well,
because yes. This means any combination with anything should work well.
