### PR TITLE
Add FORK and EXIT NOVA probes, plus cwd and some simplification

### DIFF
--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -21,6 +21,7 @@ struct bpf_dynptr {
 #define LOOP_STOP	1
 
 #define E2BIG		7
+#define ENOBUFS		105
 #define PATH_MAX	4096
 
 #define MAX(_a, _b)	((_a) > (_b) ? (_a) : (_b))
@@ -59,6 +60,7 @@ struct eval {
 	struct nova_task	nt;
 	struct eval_path	exe;		/* QUARK_RF_EXE */
 	struct eval_path	filepath;	/* QUARK_RF_FILEPATH */
+	struct eval_path	cwd;
 };
 
 struct {
@@ -323,8 +325,10 @@ eval_path_init(struct eval_path *ep)
 	ep->post.prefixlen = PATH_LPM_KEY_BITLEN;
 }
 
+#define EP_BASIC	0
+#define EP_ALL		1
 static int
-eval_path_prepare(struct eval_path *dst, struct path *src)
+eval_path_prepare(struct eval_path *dst, struct path *src, int mode)
 {
 	long	len, full_len;
 
@@ -333,6 +337,8 @@ eval_path_prepare(struct eval_path *dst, struct path *src)
 		bpf_printk("can't make path 1");
 		return (-1);
 	}
+	if (mode == EP_BASIC)
+		goto done;
 	len = bpf_probe_read_kernel_str(dst->pre.path,
 	    sizeof(dst->pre.path), dst->full);
 	if (len < 0) {
@@ -340,6 +346,7 @@ eval_path_prepare(struct eval_path *dst, struct path *src)
 		return (-1);
 	}
 
+done:
 	dst->full_len = full_len;
 
 	return (0);
@@ -426,6 +433,15 @@ output_vl_write(struct output *o, struct nova_vl *nv,
 	return (0);
 }
 
+/*
+ * Writes path into output, fills in nv.
+ */
+static __always_inline long
+output_vl_path(struct output *o, struct nova_vl *nv, struct eval_path *src)
+{
+	return (output_vl_write(o, nv, src->full, src->full_len, PATH_MAX));
+}
+
 static __always_inline void
 output_submit(struct output *o)
 {
@@ -433,13 +449,41 @@ output_submit(struct output *o)
 }
 
 static int
+output_task_event(__u16 kind, struct eval *eval)
+{
+	struct output		 o;
+	struct nova_task_event	*nte;
+
+	nte = output_reserve(&o, sizeof(*nte),
+	    sizeof(*nte) + eval->exe.full_len + eval->cwd.full_len);
+	if (nte == NULL)
+		goto discard;
+	/*
+	 * Borrow nova_task from eval
+	 */
+	nte->nt = eval->nt;
+	if (output_vl_path(&o, &nte->nt.vl_exe, &eval->exe) != 0)
+		goto discard;
+	if (output_vl_path(&o, &nte->nt.vl_cwd, &eval->cwd) != 0)
+		goto discard;
+
+	nte->ev.kind = kind;
+
+	output_submit(&o);
+
+	return (0);
+
+discard:
+	output_discard(&o);
+
+	return (-1);
+}
+
+static int
 bprm_check1(struct linux_binprm *bprm, int ret)
 {
 	struct task_struct	*task = bpf_get_current_task_btf();
 	struct eval		*eval;
-	struct eval_path	*exe;
-	struct output		 o;
-	struct nova_exec	*exec;
 	int			 r;
 
 	if ((eval = eval_init()) == NULL)
@@ -449,42 +493,26 @@ bprm_check1(struct linux_binprm *bprm, int ret)
 	if (bprm->file == NULL)
 		goto noexe;
 
-	exe = &eval->exe;
-	if (eval_path_prepare(exe, &bprm->file->f_path) != 0) {
+	if (eval_path_prepare(&eval->exe, &bprm->file->f_path, EP_ALL) != 0) {
 		bpf_printk("can't make executable 1");
 		goto noexe;
 	}
 
 	eval->fields |= QUARK_RF_EXE;
 noexe:
+	if (eval_path_prepare(&eval->cwd, &task->fs->pwd, EP_BASIC) != 0)
+		bpf_printk("can't cwd");
+
 	r = eval_run(eval);
 
 	if (r != QUARK_RA_PASS)
 		goto done;
 
-	exec = output_reserve(&o, sizeof(*exec),
-	    sizeof(*exec) + exe->full_len);
-	if (exec == NULL)
-		goto discard;
-	/*
-	 * Borrow nova_task from eval
-	 */
-	exec->nt = eval->nt;
-	if (output_vl_write(&o, &exec->exe, exe->full,
-	    exe->full_len, PATH_MAX) != 0)
-		goto discard;
-
-	exec->ev.kind = NOVA_EXEC;
-
-	output_submit(&o);
+	if (output_task_event(NOVA_EXEC, eval) == -1)
+		bpf_printk("can't output NOVA_EXEC");
 
 done:
-	return (0);	/* Always pass for now */
-
-discard:
-	output_discard(&o);
-
-	return (0);	/* Always pass for now */
+	return (ret);	/* Always pass for now */
 }
 
 SEC("lsm/bprm_check_security")
@@ -499,6 +527,93 @@ BPF_PROG(bprm_check, struct linux_binprm *bprm, int ret)
 
 	return (r);
 }
+
+/*
+ * TODO this is wrong, task_alloc() happens before pid allocation, so we have to
+ * emit the event _after_ in another probe, but we have to block and collect
+ * executable here.
+ */
+static int
+task_alloc1(struct task_struct *task, int ret)
+{
+	struct eval		*eval;
+	int			 r;
+
+	if ((eval = eval_init()) == NULL)
+		return (0);
+	eval_init_task(eval, task);
+
+	if (eval_path_prepare(&eval->exe, &task->mm->exe_file->f_path,
+	    EP_ALL) != 0) {
+		bpf_printk("can't make executable 1");
+		goto noexe;
+	}
+	eval->fields |= QUARK_RF_EXE;
+noexe:
+	if (eval_path_prepare(&eval->cwd, &task->fs->pwd, EP_BASIC) != 0)
+		bpf_printk("can't cwd");
+
+	r = eval_run(eval);
+
+	if (r != QUARK_RA_PASS)
+		goto done;
+
+	if (output_task_event(NOVA_FORK, eval) == -1)
+		bpf_printk("can't output NOVA_FORK");
+
+done:
+	return (ret);	/* Always pass for now */
+}
+
+SEC("lsm/task_alloc")
+int
+BPF_PROG(task_alloc, struct task_struct *child, unsigned long clone_flags,
+    int ret)
+{
+	int	r;
+
+	preempt_disable();
+	r = task_alloc1(child, ret);
+	preempt_enable();
+
+	return (r);
+}
+
+static int
+task_exit1(struct task_struct *task)
+{
+	struct eval *eval;
+	int          r;
+
+	if ((eval = eval_init()) == NULL)
+		return (0);
+	eval_init_task(eval, task);
+
+	eval->nt.exit_code = BPF_CORE_READ(task, exit_code);
+
+	r = eval_run(eval);
+	if (r != QUARK_RA_PASS)
+		return (0);
+
+	if (output_task_event(NOVA_EXIT, eval) == -1)
+		bpf_printk("can't output NOVA_EXIT");
+
+	return (0);
+}
+
+SEC("tp_btf/sched_process_exit")
+int
+BPF_PROG(sched_exit, struct task_struct *task)
+{
+	int r;
+
+	preempt_disable();
+	r = task_exit1(task);
+	preempt_enable();
+
+	return (r);
+}
+
 
 #pragma GCC diagnostic pop
 

--- a/nova.h
+++ b/nova.h
@@ -98,30 +98,34 @@ struct nova_vl {
 };
 
 struct nova_task {
-	__u64	cap_perm;
-	__u64	cap_eff;
-	__u64	start_time_ns;
-	__u32	tid;
-	__u32	pid;		/* QUARK_RF_PID */
-	__u32	ppid;		/* QUARK_RF_PPID */
-	__u32	uid;		/* QUARK_RF_UID */
-	__u32	gid;		/* QUARK_RF_GID */
-	__u32	suid;
-	__u32	sgid;
-	__u32	euid;
-	__u32	egid;
-	__u32	pgid;
-	__u32	sid;		/* QUARK_RF_SID */
-	__u32	tty_major;
-	__u32	tty_minor;
-	__u32	uts_inonum;
-	__u32	ipc_inonum;
-	__u32	mnt_inonum;
-	__u32	net_inonum;
-	__u32	cgroup_inonum;
-	__u32	time_inonum;
-	__u32	pid_inonum;
-	char	comm[16];
+	struct nova_vl	vl_exe;
+	struct nova_vl	vl_cwd;
+	__u64		cap_perm;
+	__u64		cap_eff;
+	__u64		start_time_ns;
+	__u32		tid;
+	__u32		pid;	/* QUARK_RF_PID */
+	__u32		ppid;	/* QUARK_RF_PPID */
+	__u32		uid;	/* QUARK_RF_UID */
+	__u32		gid;	/* QUARK_RF_GID */
+	__u32		suid;
+	__u32		sgid;
+	__u32		euid;
+	__u32		egid;
+	__u32		pgid;
+	__u32		sid;	/* QUARK_RF_SID */
+	__u32		tty_major;
+	__u32		tty_minor;
+	__u32		uts_inonum;
+	__u32		ipc_inonum;
+	__u32		mnt_inonum;
+	__u32		net_inonum;
+	__u32		cgroup_inonum;
+	__u32		time_inonum;
+	__u32		pid_inonum;
+	__u32		exit_code;
+	__u32		pad0;
+	char		comm[16];
 };
 
 struct nova_event {
@@ -132,10 +136,9 @@ struct nova_event {
 	__u64	ts_boot;	/* auto */
 } __aligned(8);
 
-struct nova_exec {
+struct nova_task_event {
 	struct nova_event	ev;
 	struct nova_task	nt;
-	struct nova_vl		exe;
 } __aligned(8);
 
 #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 10))

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -265,21 +265,24 @@ nova_ringbuf_cb(void *vqq, void *vdata, size_t len)
 	/* struct quark_queue	*qq = vqq; */
 	struct nova_event	*nev;
 	struct nova_task	*nt;
-	struct nova_exec	*exec;
+	struct nova_task_event	*nte;
 
 	nev = vdata;
 	nt = NULL;
+	nte = NULL;
 
 	printf("nova event %s len=%zd ts=%llu ts_boot=%llu ",
 	    nova_kind_str(nev->kind), len, nev->ts, nev->ts_boot);
 
 	switch (nev->kind) {
-	case NOVA_EXEC:
-		exec = (struct nova_exec *)nev;
-		nt = &exec->nt;
-		printf("exe=%s cap_eff=0x%llx cap_perm=0x%llx uid=%d gid=%d comm=%s",
-		    vltoc(exec, &exec->exe), nt->cap_eff, nt->cap_perm, nt->uid,
-		    nt->gid, nt->comm);
+	case NOVA_FORK:		/* FALLTHROUGH */
+	case NOVA_EXEC:		/* FALLTHROUGH */
+	case NOVA_EXIT:
+		nte = (struct nova_task_event *)nev;
+		nt = &nte->nt;
+		printf("pid=%d exe=%s cap_eff=0x%llx cap_perm=0x%llx uid=%d gid=%d comm=%s cwd=%s ",
+		    nt->pid, vltoc(nte, &nt->vl_exe), nt->cap_eff, nt->cap_perm, nt->uid,
+		    nt->gid, nt->comm, vltoc(nte, &nt->vl_cwd));
 		break;
 	default:
 		putchar('?');


### PR DESCRIPTION
This expands a bit of the infrastructure to generalize task events.

struct eval{} will likely become the probe context, I've added cwd there but we
won't be able to eval on cwd, there's no reason to. In the future we rename this
to nova_ctx {} or something.

We add FORK and EXIT here, they are not entirely complete, like EXEC there are
still some missing data in the event, like env and cgroup_path.

For now we just send the child process in FORK, but more work is needed, same
for EXEC, I just dont' want to pile up more in this diff.

We can't call bpf_d_path() from EXIT probe as it is not an allowed helper, so
don't send cwd and exe, it's fine for now but we might want to fix it.

Issue #315
