### PR TITLE
Emit fork from a trace probe on nova

### DIFF
--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -529,6 +529,49 @@ BPF_PROG(bprm_check, struct linux_binprm *bprm, int ret)
 }
 
 /*
+ * TODO stop evaluating things twice, store the result from the lsm probe
+ * somewhere and retrieve here.
+ */
+static int
+sched_process_fork1(struct task_struct *parent, struct task_struct *child)
+{
+	struct eval		*eval;
+	int			 r;
+
+	if ((eval = eval_init()) == NULL)
+		return (0);
+	eval_init_task(eval, child);
+
+	r = eval_run(eval);
+
+	if (r != QUARK_RA_PASS)
+		goto done;
+
+	/*
+	 * TODO: missing cwd
+	 */
+
+	if (output_task_event(NOVA_FORK, eval) == -1)
+		bpf_printk("can't output NOVA_FORK");
+
+done:
+	return (0);
+}
+
+SEC("tp_btf/sched_process_fork")
+int
+BPF_PROG(sched_process_fork, struct task_struct *parent,
+    struct task_struct *child)
+{
+	int	r;
+
+	preempt_disable();
+	r = sched_process_fork1(parent, child);
+	preempt_enable();
+
+	return (r);
+}
+/*
  * TODO this is wrong, task_alloc() happens before pid allocation, so we have to
  * emit the event _after_ in another probe, but we have to block and collect
  * executable here.
@@ -558,8 +601,7 @@ noexe:
 	if (r != QUARK_RA_PASS)
 		goto done;
 
-	if (output_task_event(NOVA_FORK, eval) == -1)
-		bpf_printk("can't output NOVA_FORK");
+	/* output emited from sched_proc_fork */
 
 done:
 	return (ret);	/* Always pass for now */

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -113,6 +113,18 @@ preempt_enable(void)
 		bpf_preempt_enable();
 }
 
+static void
+probe_prologue(void)
+{
+	preempt_disable();
+}
+
+static void
+probe_epilogue(void)
+{
+	preempt_enable();
+}
+
 static __u64
 ktime_get_boot_ns(void)
 {
@@ -521,9 +533,9 @@ BPF_PROG(bprm_check, struct linux_binprm *bprm, int ret)
 {
 	int	r;
 
-	preempt_disable();
+	probe_prologue();
 	r = bprm_check1(bprm, ret);
-	preempt_enable();
+	probe_epilogue();
 
 	return (r);
 }
@@ -565,9 +577,9 @@ BPF_PROG(sched_process_fork, struct task_struct *parent,
 {
 	int	r;
 
-	preempt_disable();
+	probe_prologue();
 	r = sched_process_fork1(parent, child);
-	preempt_enable();
+	probe_epilogue();
 
 	return (r);
 }
@@ -614,9 +626,9 @@ BPF_PROG(task_alloc, struct task_struct *child, unsigned long clone_flags,
 {
 	int	r;
 
-	preempt_disable();
+	probe_prologue();
 	r = task_alloc1(child, ret);
-	preempt_enable();
+	probe_epilogue();
 
 	return (r);
 }
@@ -649,13 +661,12 @@ BPF_PROG(sched_exit, struct task_struct *task)
 {
 	int r;
 
-	preempt_disable();
+	probe_prologue();
 	r = task_exit1(task);
-	preempt_enable();
+	probe_epilogue();
 
 	return (r);
 }
-
 
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
Two relatively easy commits

commit 1a377c7ecaefe7bf187cb7469b052a7b4684b53b
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri May 29 08:48:09 2026 +0200

    Nova: preempt_{disable,enable} -> probe_{prologue,epilogue}

    Not just a rename, preparation for having more things, like counters and
    whatnot.

commit fe31a2785ba24e0fe5e0a592c1555f72374577c1
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri May 29 08:42:39 2026 +0200

    Emit fork from a trace probe on nova

    task_alloc()@lsm happens pre pid allocation so we're basically sending a parent
    event, so move it to a trace probe.

    There's still things missing, especially cwd, which we might need to stash
    somewhere and retrieve as we can't bpf_d_path() there.

    Issue #315


