### PR TITLE
Put a clang version floor + update copyrights

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -93,3 +93,7 @@ Changes from 0.5 to 0.6
   o Aggregation matrix can now be tunned via
     quark_Queue_set_agg_matrix(3).
   o libbpf has been updated.
+
+Changes from 0.6 to 0.7
+~~~~~~~~~~~~~~~~~~~~~~~
+  o BPF_CC is gone, just use CLANG='zig cc' now.

--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ man-embedder: man-embedder.c
 
 manpages.h: man-embedder display_man.c quark-btf.8 quark-mon.8 quark-test.8
 	$(Q)echo '// SPDX-License-Identifier: Apache-2.0' > $@
-	$(Q)echo '/* Copyright (c) 2024 Elastic NV */' >> $@
+	$(Q)echo '/* Copyright (c) 2024-2026 Elastic NV */' >> $@
 	$(Q)echo '' >> $@
 	$(call msg,MAN-EMB,quark-btf.8)
 	$(Q)./man-embedder quark-btf.8 MAN_QUARK_BTF >> $@

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ PWD= $(shell pwd)
 HTML2MARKDOWN?= html2markdown
 SUDO?= sudo
 GO?= go
+CLANG?= clang
+BPFTOOL?= bpftool
+BPF_ARCH?= bpf # Zig cc calls this bpfel
+DOCKER?= docker
+CLANG_MINVER:= 17 # 16 will produce broken probes
 
 # Normalize ARCH
 ifeq ($(shell uname -m), x86_64)
@@ -44,6 +49,23 @@ endif
 
 define assert_no_syslib
   $(if $(SYSLIB), $(error cant build target $@ with SYSLIB))
+endef
+
+#
+# This is written as a function since we must check it inside the
+# target, not as a dependency, otherwise our fragile container targets
+# will break. centos7 has no clang, we build the probes on a different
+# container, so we can't check_clang before actually deciding to build
+# it.
+#
+define check_clang
+	@CLANG_MAJOR=$$(echo '__clang_major__' | $(CLANG) -E -P -x c - 2>/dev/null); \
+	if test -z "$$CLANG_MAJOR"; then \
+		echo "cannot run $(CLANG), is it installed?"; exit 1; \
+	fi; \
+	if test $$(expr $$CLANG_MAJOR \< $(CLANG_MINVER)) = 1; then \
+		echo "need $(CLANG) >= $(CLANG_MINVER), got $$CLANG_MAJOR"; exit 1; \
+	fi
 endef
 
 ifdef SYSLIB
@@ -108,12 +130,6 @@ CDIAGFLAGS+= -Wno-unused-parameter
 ifdef CENTOS7
 CDIAGFLAGS+= -Wno-inline
 endif
-
-CLANG?= clang
-BPFTOOL?= bpftool
-BPF_CC?= $(CLANG)
-BPF_ARCH?= bpf # Zig cc calls this bpfel
-DOCKER?= docker
 
 # All EEBPF files we track for dependency
 EEBPF_FILES:= $(shell find elastic-ebpf)
@@ -274,8 +290,9 @@ bpf_probes_skel.h: bpf_probes.o
 	$(Q)$(BPFTOOL) gen skeleton $^ > $@
 
 bpf_probes.o: $(BPFPROBES_DEPS)
-	$(call msg,BPF_CC,$@)
-	$(Q)$(BPF_CC)								\
+	$(call check_clang)
+	$(call msg,CLANG,$@)
+	$(Q)$(CLANG)								\
 		-g -O2								\
 		-target $(BPF_ARCH)						\
 		-D__KERNEL__							\
@@ -294,8 +311,9 @@ nova_skel.h: nova.bpf.o
 	$(Q)$(BPFTOOL) gen skeleton $^ name nova > $@
 
 nova.bpf.o: $(NOVA_DEPS)
-	$(call msg,BPF_CC,$@)
-	$(Q)$(BPF_CC)								\
+	$(call check_clang)
+	$(call msg,CLANG,$@)
+	$(Q)$(CLANG)								\
 		-g -O2								\
 		-target $(BPF_ARCH)						\
 		-Ielastic-ebpf/contrib/vmlinux/$(ARCH_ALT)			\

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/epoll.h>
 #include <sys/param.h>

--- a/compat.h
+++ b/compat.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #ifndef _COMPAT_H_
 #define _COMPAT_H_

--- a/elastic-ebpf/sync.sh
+++ b/elastic-ebpf/sync.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2024 Elastic NV
+# Copyright (c) 2024-2026 Elastic NV
 
 Script=$(basename $0)
 

--- a/genbtf.sh
+++ b/genbtf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2024 Elastic NV
+# Copyright (c) 2024-2026 Elastic NV
 
 Script=${0##*/}
 
@@ -82,7 +82,7 @@ fi
 
 cat <<EOF
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include "quark.h"
 

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2024 Elastic NV
+// Copyright (c) 2024-2026 Elastic NV
 
 //go:build linux && (amd64 || arm64)
 

--- a/go/quark/quark_test.go
+++ b/go/quark/quark_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2024 Elastic NV
+// Copyright (c) 2024-2026 Elastic NV
 
 package quark
 

--- a/hanson-bench.c
+++ b/hanson-bench.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <err.h>
 #include <errno.h>

--- a/init.c
+++ b/init.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <linux/reboot.h>
 

--- a/kprobe_defs.h
+++ b/kprobe_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #ifndef _KPROBE_DEFS_H
 #define _KPROBE_DEFS_H

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <linux/perf_event.h>
 #include <linux/hw_breakpoint.h>

--- a/man-embedder.c
+++ b/man-embedder.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <err.h>
 #include <errno.h>

--- a/qbtf.c
+++ b/qbtf.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <err.h>
 #include <errno.h>

--- a/quark-btf.c
+++ b/quark-btf.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <err.h>
 #include <errno.h>
@@ -26,7 +26,7 @@ disply_version(void)
 {
 	printf("%s-%s\n", program_invocation_short_name, QUARK_VERSION);
 	printf("License: Apache-2.0\n");
-	printf("Copyright (c) 2024 Elastic NV\n");
+	printf("Copyright (c) 2024-2026 Elastic NV\n");
 
 	exit(0);
 }

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <err.h>
 #include <errno.h>
@@ -108,7 +108,7 @@ display_version(void)
 {
 	printf("%s-%s\n", program_invocation_short_name, QUARK_VERSION);
 	printf("License: Apache-2.0\n");
-	printf("Copyright (c) 2024 Elastic NV\n");
+	printf("Copyright (c) 2024-2026 Elastic NV\n");
 
 	exit(0);
 }

--- a/quark-test.c
+++ b/quark-test.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <asm/termbits.h>
 
@@ -412,7 +412,7 @@ display_version(void)
 {
 	printf("%s-%s\n", program_invocation_short_name, QUARK_VERSION);
 	printf("License: Apache-2.0\n");
-	printf("Copyright (c) 2024 Elastic NV\n");
+	printf("Copyright (c) 2024-2026 Elastic NV\n");
 
 	exit(0);
 }

--- a/quark.c
+++ b/quark.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/epoll.h>
 #include <sys/param.h>

--- a/quark.h
+++ b/quark.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #ifndef _QUARK_H_
 #define _QUARK_H_

--- a/qutil.c
+++ b/qutil.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (c) 2024 Elastic NV */
+/* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/resource.h>
 


### PR DESCRIPTION
Prevent people from compiling quark with ancient clang

This puts a floor of clang-17 in our build system, clang-16 produces probes that
won't load on some kernels.

Also remove BPF_CC, as CLANG='zig cc' works just fine.

++

Update copyrights
