### PR TITLE
Add a target for quark-bin.tar.gz

### DIFF
--- a/.buildkite/runtestgo.sh
+++ b/.buildkite/runtestgo.sh
@@ -15,10 +15,10 @@ sudo apt-get install -y 				\
 	cpio						\
 	gcc						\
 	golang						\
-	linux-tools-6.11.0-26-generic			\
+	linux-tools-7.0.0-14-generic			\
 	make						\
 	m4						\
 	valgrind
 
-make test-go BPFTOOL="/usr/lib/linux-tools/6.11.0-26-generic/bpftool"
+make test-go BPFTOOL="/usr/lib/linux-tools/7.0.0-14-generic/bpftool"
 exit $?

--- a/.buildkite/runvalgrind.sh
+++ b/.buildkite/runvalgrind.sh
@@ -18,10 +18,10 @@ sudo apt-get install -y 				\
 	clang						\
 	cpio						\
 	gcc						\
-	linux-tools-6.11.0-26-generic			\
+	linux-tools-7.0.0-14-generic			\
 	make						\
 	m4						\
 	valgrind
 
-make test-valgrind BPFTOOL="/usr/lib/linux-tools/6.11.0-26-generic/bpftool"
+make test-valgrind BPFTOOL="/usr/lib/linux-tools/7.0.0-14-generic/bpftool"
 exit $?

--- a/Makefile
+++ b/Makefile
@@ -532,6 +532,10 @@ quark-test-static: quark-test.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
 		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
+quark-bin.tar.gz: quark-test quark-test-static quark-mon quark-mon-static quark-btf quark-btf-static
+	$(call msg,TAR,$@)
+	$(Q)tar -czf $@ $^
+
 # kube-talker does not use quark-go
 quark-kube-talker: $(GO_FILES)
 	$(call msg,GO,$@)
@@ -619,6 +623,7 @@ clean:
 		quark-btf-static	\
 		quark-test		\
 		quark-test-static	\
+		quark-bin.tar.gz	\
 		quark-kube-talker	\
 		quark-go-test		\
 		true			\


### PR DESCRIPTION
Related to issue #330

Trivial target for having all our binaries in a tarball so we can have a nightly
build in github.
