### PR TITLE
Added a github workflow for building and publishing quark-bin.tar.gz nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
       - name: Check actor permissions
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.publish == true
         run: |
           ROLE=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.role_name')
           if [[ "$ROLE" != "admin" ]]; then
-            echo "Only repository admins can trigger this workflow manually (got: $ROLE)"
+            echo "Only repository admins can publish a nightly release (got: $ROLE)"
             exit 1
           fi
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,14 +13,77 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-      - name: Stub
-        run: echo "nightly build stub"
+      - name: Check actor permissions
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ROLE=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.role_name')
+          if [[ "$ROLE" != "admin" ]]; then
+            echo "Only repository admins can trigger this workflow manually (got: $ROLE)"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build Ubuntu Docker image
+        run: make docker-image
+
+      - name: Build CentOS 7 Docker image
+        run: make centos7-image
+
+      - name: Build BPF probes in Ubuntu container
+        run: |
+          docker run \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            -u "$(id -u):$(id -g)" \
+            quark-builder \
+            sh -c "make -C $(pwd) bpf_probes.o bpf_probes_skel.h nova.bpf.o nova_skel.h"
+
+      - name: Build quark-bin.tar.gz in CentOS 7 container
+        run: |
+          docker run \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            -u "$(id -u):$(id -g)" \
+            -e CENTOS7=y \
+            centos7-quark-builder \
+            sh -c "make -j1 NO_GO=y -C $(pwd) quark-bin.tar.gz"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: quark-bin
+          path: quark-bin.tar.gz
 
   release:
     needs: build
     if: github.event_name == 'schedule' || inputs.publish == true
     runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'nightly-release' || '' }}
+    permissions:
+      contents: write
+
     steps:
-      - name: Stub
-        run: echo "nightly release stub"
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: quark-bin
+
+      - name: Upload nightly release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: nightly
+          name: Nightly Build
+          prerelease: true
+          make_latest: false
+          body: "Automated nightly build from commit ${{ github.sha }}"
+          files: quark-bin.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      artifact_name: ${{ steps.stamp.outputs.artifact_name }}
+      datestamp: ${{ steps.stamp.outputs.datestamp }}
 
     steps:
       - name: Check actor permissions
@@ -33,36 +36,20 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build Ubuntu Docker image
-        run: make docker-image
-
-      - name: Build CentOS 7 Docker image
-        run: make centos7-image
-
-      - name: Build BPF probes in Ubuntu container
+      - name: Make quark-bin.tar.gz
+        id: stamp
         run: |
-          docker run \
-            -v "$(pwd):$(pwd)" \
-            -w "$(pwd)" \
-            -u "$(id -u):$(id -g)" \
-            quark-builder \
-            sh -c "make -C $(pwd) bpf_probes.o bpf_probes_skel.h nova.bpf.o nova_skel.h"
-
-      - name: Build quark-bin.tar.gz in CentOS 7 container
-        run: |
-          docker run \
-            -v "$(pwd):$(pwd)" \
-            -w "$(pwd)" \
-            -u "$(id -u):$(id -g)" \
-            -e CENTOS7=y \
-            centos7-quark-builder \
-            sh -c "make -j1 NO_GO=y -C $(pwd) quark-bin.tar.gz"
+          make quark-bin.tar.gz
+          DATESTAMP=$(date +%Y-%m-%d)
+          mv quark-bin.tar.gz quark-bin-${DATESTAMP}.tar.gz
+          echo "artifact_name=quark-bin-${DATESTAMP}.tar.gz" >> $GITHUB_OUTPUT
+          echo "datestamp=${DATESTAMP}" >> $GITHUB_OUTPUT
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: quark-bin
-          path: quark-bin.tar.gz
+          name: ${{ steps.stamp.outputs.artifact_name }}
+          path: ${{ steps.stamp.outputs.artifact_name }}
 
   release:
     needs: build
@@ -74,16 +61,16 @@ jobs:
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: quark-bin
+          name: ${{ needs.build.outputs.artifact_name }}
 
       - name: Upload nightly release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
-          name: Nightly Build
+          name: Nightly Build ${{ needs.build.outputs.datestamp }}
           prerelease: true
           make_latest: false
-          body: "Automated nightly build from commit ${{ github.sha }}"
-          files: quark-bin.tar.gz
+          body: "Automated nightly build ${{ needs.build.outputs.datestamp }} from commit ${{ github.sha }}"
+          files: ${{ needs.build.outputs.artifact_name }}


### PR DESCRIPTION
This PR adds a github workflow for building and publishing quark-bin.tar.gz nightly.

This workflow can only be triggered by users with admin role for now.

Following the same rules in Makefile to build CentOS and Ubuntu containers and use them to build quark. 

I'm not 100% sure, if I have to build this from CentOS 7. I see that quark-builder is using Ubuntu 26.04