### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,14 @@ on:
         description: 'Publish the nightly release after building'
         type: boolean
         default: false
+      verbose:
+        description: 'Enable verbose build output (V=1)'
+        type: boolean
+        default: false
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     outputs:
@@ -36,10 +40,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install build dependencies
+        run: sudo apt update && sudo apt install -y bison bpftool clang
+
       - name: Make quark-bin.tar.gz
         id: stamp
         run: |
-          make quark-bin.tar.gz
+          make quark-bin.tar.gz ${{ inputs.verbose && 'V=1' || '' }}
           DATESTAMP=$(date +%Y-%m-%d)
           mv quark-bin.tar.gz quark-bin-${DATESTAMP}.tar.gz
           echo "artifact_name=quark-bin-${DATESTAMP}.tar.gz" >> $GITHUB_OUTPUT
@@ -54,7 +61,7 @@ jobs:
   release:
     needs: build
     if: github.event_name == 'schedule' || inputs.publish == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: ${{ github.event_name == 'workflow_dispatch' && 'nightly-release' || '' }}
     permissions:
       contents: write


### PR DESCRIPTION
This PR adds following fixes / enhancements for nightly build workflow:
- [x] Add verbose option that adds `V=1` to `make quark-bin.tar.gz`
- [x] Use ubuntu-26.04 image
- [x] Fix build by installing build dependencies:  `bison`, `bpftool`, and `clang`

New nightly build is available in https://github.com/elastic/quark/releases/tag/nightly

Confirmed that there is only one nightly build
<img width="905" height="345" alt="image" src="https://github.com/user-attachments/assets/3cb84c5e-5639-4e48-b224-cd68120fd463" />



Confirmed that each nightly build replaces the previous one.
<img width="905" height="1142" alt="image" src="https://github.com/user-attachments/assets/8e2373c8-7b3b-4a63-922d-9a498bcc2aad" />
