### PR TITLE
Improve nightly

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -3,7 +3,7 @@ ENV HOME=/tmp/centos7-quark-builder
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
-RUN yum install -y bison gcc make m4 less curl
+RUN yum install -y bison gcc make m4 less curl glibc-static
 RUN cd /tmp && curl -L -O https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go1.26.2.linux-amd64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,16 @@ BPFTOOL?= bpftool
 BPF_ARCH?= bpf # Zig cc calls this bpfel
 DOCKER?= docker
 CLANG_MINVER:= 17 # 16 will produce broken probes
+BIN_FILES=  quark-btf
+BIN_FILES+= quark-mon
+BIN_FILES+= quark-test
+BIN_FILES+= hanson-bench
+ifndef SYSLIB
+BIN_FILES+= quark-btf-static
+BIN_FILES+= quark-mon-static
+BIN_FILES+= quark-test-static
+endif
+TARBALL_FILES=$(BIN_FILES) quark-mon.8 quark-test.8 quark-btf.8
 
 # Normalize ARCH
 ifeq ($(shell uname -m), x86_64)
@@ -233,10 +243,7 @@ DOCS_HTML+= $(patsubst %.7,docs/%.7.html,$(wildcard *.7))
 DOCS_HTML+= $(patsubst %.8,docs/%.8.html,$(wildcard *.8))
 
 ALL_TARGETS+=$(LIBQUARK_TARGET)
-ALL_TARGETS+=quark-mon
-ALL_TARGETS+=quark-btf
-ALL_TARGETS+=quark-test
-ALL_TARGETS+=hanson-bench
+ALL_TARGETS+=$(BIN_FILES)
 ifdef NO_GO
 EXTRA_OPTIONS+= NO_GO=$(NO_GO)
 else
@@ -517,24 +524,40 @@ quark-test: quark-test.c manpages.h $(LIBQUARK_TARGET)
 quark-mon-static: quark-mon.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -DNO_PRIVDROP $(CDIAGFLAGS) \
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -DSTATIC -DNO_PRIVDROP $(CDIAGFLAGS) \
 		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
 quark-btf-static: quark-btf.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -DSTATIC $(CDIAGFLAGS) \
 		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
 quark-test-static: quark-test.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)
 	$(call assert_no_syslib)
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -DSTATIC $(CDIAGFLAGS) \
 		-static -o $@ $< $(LIBQUARK_STATIC_BIG) $(EXTRA_LDFLAGS)
 
-quark-bin.tar.gz: quark-test quark-test-static quark-mon quark-mon-static quark-btf quark-btf-static
+quark-bin.tar.gz: $(TARBALL_FILES)
+	$(call msg,RM,quark-bin)
+	$(Q)rm -rf quark-bin
+	$(call msg,MKDIR,quark-bin)
+	$(Q)mkdir quark-bin
+	$(Q)cp $(TARBALL_FILES) quark-bin/
 	$(call msg,TAR,$@)
-	$(Q)tar -czf $@ $^
+	$(Q)tar -czvf $@ quark-bin
+
+quark-bin-glibc2.17.tar.gz: centos7
+	$(call msg,RM,quark-bin-glibc2.17)
+	$(Q)rm -rf quark-bin-glibc2.17
+	$(call msg,MKDIR,quark-bin-glibc2.17)
+	$(Q)mkdir quark-bin-glibc2.17
+	$(Q)cp $(TARBALL_FILES) quark-bin-glibc2.17/
+	$(call msg,TAR,$@)
+	$(Q)tar -czvf $@ quark-bin-glibc2.17
+	$(call msg,RM,quark-bin-glibc2.17)
+	$(Q)rm -rf quark-bin-glibc2.17
 
 # kube-talker does not use quark-go
 quark-kube-talker: $(GO_FILES)
@@ -624,13 +647,14 @@ clean:
 		quark-test		\
 		quark-test-static	\
 		quark-bin.tar.gz	\
+		quark-bin-glibc2.17.tar.gz \
 		quark-kube-talker	\
 		quark-go-test		\
 		true			\
 		bpf_probes_skel.h	\
 		nova_skel.h		\
 		init
-	$(Q)rm -rf initramfs
+	$(Q)rm -rf initramfs quark-bin quark-bin-glibc2.17
 
 clean-all: clean
 	$(call msg,CLEAN-ALL)

--- a/quark-btf.c
+++ b/quark-btf.c
@@ -236,6 +236,12 @@ main(int argc, char *argv[])
 	int			 ch;
 	const char		*path = NULL;
 
+	if (argc == 2 &&
+	    (!strcmp(argv[1], "--help") ||
+	    !strcmp(argv[1], "-help") ||
+	    !strcmp(argv[1], "help")))
+		display_man();
+
 	while ((ch = getopt(argc, argv, "bf:ghlvV")) != -1) {
 		switch (ch) {
 		case 'b':

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -179,6 +179,12 @@ main(int argc, char *argv[])
 	kube_config = NULL;
 	print_event = print_dump;
 
+	if (argc == 2 &&
+	    (!strcmp(argv[1], "--help") ||
+	    !strcmp(argv[1], "-help") ||
+	    !strcmp(argv[1], "help")))
+		display_man();
+
 	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsvV")) != -1) {
 		const char *errstr;
 

--- a/quark-test.c
+++ b/quark-test.c
@@ -2822,6 +2822,12 @@ main(int argc, char *argv[])
 	fancy_tty = probe_fancy_tty();
 	in_valgrind = getenv("VALGRIND") != NULL;
 
+	if (argc == 2 &&
+	    (!strcmp(argv[1], "--help") ||
+	    !strcmp(argv[1], "-help") ||
+	    !strcmp(argv[1], "help")))
+		display_man();
+
 	while ((ch = getopt(argc, argv, "1bhklntvVx:")) != -1) {
 		switch (ch) {
 		case '1':


### PR DESCRIPTION
commit 1645adbc1f95fa22f8baee424f4bdb831b5a4a8b
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri Jun 19 13:50:57 2026 +0200

    Enhance the tarballs and add a quark-bin-glibc2.17.tar.gz

    Static linking in linux is a bit of a mess, it's too easy to include a symbol
    that shouldn't and whatnot.

    So stop trying, people should just use the glibc2.17 binaries that should
run on
    any linux from the past 12 years or so.

    Also add the manpages to the tarballs.


++


commit 9fba203ea803f827656e00a066755961f645ab57 (HEAD -> more-nightly)
Author: Christiano Haesbaert <haesbaert@elastic.co>
Date:   Fri Jun 19 17:07:21 2026 +0200

    Customers and support may not be used with BSD opts, give them a freebie.

    With this we display the manpages with "-help" "--help" or "help" as argv[1].
