### PR TITLE
fix nightly always-publishing: targetCommitish returns branch name not SHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
             echo "should_build=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          LAST_SHA=$(gh release view nightly --json targetCommitish --jq '.targetCommitish' 2>/dev/null || echo "")
+          LAST_SHA=$(gh api repos/${{ github.repository }}/git/refs/tags/nightly --jq '.object.sha' 2>/dev/null || echo "")
           if [[ -n "$LAST_SHA" && "$LAST_SHA" == "${{ github.sha }}" ]]; then
             echo "should_build=false" >> $GITHUB_OUTPUT
             echo "Commit ${{ github.sha }} already built — skipping."


### PR DESCRIPTION
Nightly build kept on building even though we had the guard.

The previous logic I had was invalid, returning branch name instead of commit hash.

This new command retrieves the valid hash from nightly release.

```
> gh api repos/elastic/quark/git/refs/tags/nightly --jq '.object.sha'
64bba4b87e1ff5c60d7179a48e97e75b9188add0
```