### PR TITLE
Adding initial TLS attach/detach mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,8 +344,6 @@ parse.tab.c: parse.y quark.h
 	$(call msg,BISON,$@)
 	$(Q)bison parse.y
 
-parse.tab.o: CDIAGFLAGS += -Wno-unused-but-set-variable
-
 DOCKER_RUN_ARGS=$(QDOCKER)				\
 		-v $(PWD):$(PWD)			\
 		-w $(PWD)				\

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,8 @@ endif
 
 # OpenSSL is only used by quark-test's TLS e2e tests, and only linked into
 # the dynamic quark-test binary, never quark-test-static: OpenSSL 3.x loads
-# providers dynamically at runtime, so static-linking it is not viable.
-# Detected via pkg-config; if absent, the TLS e2e tests are simply not
-# compiled in (see HAVE_OPENSSL guards in quark-test.c).
+# providers dynamically at runtime, so static-linking it is not viable. If
+# absent, the TLS e2e tests are simply not compiled in.
 PKG_CONFIG?= pkg-config
 HAVE_OPENSSL:= $(shell $(PKG_CONFIG) --exists openssl 2>/dev/null && echo 1)
 ifeq ($(HAVE_OPENSSL),1)
@@ -473,18 +472,13 @@ test-kernel: initramfs.gz
 # loading these BTF modules, making valgrind spit thousands of false
 # positives.
 #
-#
-# The TLS e2e tests (t_tls_load/t_tls_conn/t_tls_call/t_tls_multichunk/
-# t_tls_truncated/t_tls_multiproc) are excluded here: uprobes and valgrind's ptrace-based
+# The TLS e2e tests are excluded here: uprobes and valgrind's ptrace-based
 # tracing fundamentally conflict at the kernel breakpoint (int3/SIGTRAP)
 # level, independent of --trace-children=no (a forked child still dies
 # with SIGTRAP the instant it hits an attached uprobe, e.g. SSL_new). This
 # is a documented upstream limitation, not something fixable from quark's
 # or the test's side; see valgrind bug 466172 for the same pattern with
-# bpftrace. Re-enabling these under valgrind isn't on the table; getting
-# real dynamic leak coverage for the TLS path needs a non-ptrace-based
-# tool (AddressSanitizer/LeakSanitizer is the candidate) -- tracked as a
-# backlog item, not done yet.
+# bpftrace.
 #
 test-valgrind: quark-test
 	$(SUDO) VALGRIND=1 QUARK_BTF_PATH=/sys/kernel/btf/vmlinux	\

--- a/Makefile
+++ b/Makefile
@@ -474,14 +474,9 @@ test-kernel: initramfs.gz
 # loading these BTF modules, making valgrind spit thousands of false
 # positives.
 #
-# The TLS e2e tests are excluded here: uprobes and valgrind's ptrace-based
-# tracing fundamentally conflict at the kernel breakpoint (int3/SIGTRAP)
-# level, independent of --trace-children=no (a forked child still dies
-# with SIGTRAP the instant it hits an attached uprobe, e.g. SSL_new). This
-# is a documented upstream limitation, not something fixable from quark's
-# or the test's side; see valgrind bug 466172 for the same pattern with
-# bpftrace.
-#
+# The TLS e2e tests are excluded here: uprobes and valgrind's ptrace-based will cause a SIGTRAP to be sent to the child process.
+# Any recommendations on how to approach it?
+
 test-valgrind: quark-test
 	$(SUDO) VALGRIND=1 QUARK_BTF_PATH=/sys/kernel/btf/vmlinux	\
 		valgrind						\

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,18 @@ ifdef CENTOS7
 CDIAGFLAGS+= -Wno-inline
 endif
 
+# OpenSSL is only used by quark-test's TLS e2e tests, and only linked into
+# the dynamic quark-test binary, never quark-test-static: OpenSSL 3.x loads
+# providers dynamically at runtime, so static-linking it is not viable.
+# Detected via pkg-config; if absent, the TLS e2e tests are simply not
+# compiled in (see HAVE_OPENSSL guards in quark-test.c).
+PKG_CONFIG?= pkg-config
+HAVE_OPENSSL:= $(shell $(PKG_CONFIG) --exists openssl 2>/dev/null && echo 1)
+ifeq ($(HAVE_OPENSSL),1)
+OPENSSL_CFLAGS:= $(shell $(PKG_CONFIG) --cflags openssl) -DHAVE_OPENSSL
+OPENSSL_LIBS:= $(shell $(PKG_CONFIG) --libs openssl) -ldl
+endif
+
 # All EEBPF files we track for dependency
 EEBPF_FILES:= $(shell find elastic-ebpf)
 EEBPF_INCLUDES:= -Ielastic-ebpf/GPL/Events -Ielastic-ebpf/contrib/vmlinux/$(ARCH_ALT)
@@ -461,6 +473,19 @@ test-kernel: initramfs.gz
 # loading these BTF modules, making valgrind spit thousands of false
 # positives.
 #
+#
+# The TLS e2e tests (t_tls_load/t_tls_conn/t_tls_call/t_tls_multichunk/
+# t_tls_truncated/t_tls_multiproc) are excluded here: uprobes and valgrind's ptrace-based
+# tracing fundamentally conflict at the kernel breakpoint (int3/SIGTRAP)
+# level, independent of --trace-children=no (a forked child still dies
+# with SIGTRAP the instant it hits an attached uprobe, e.g. SSL_new). This
+# is a documented upstream limitation, not something fixable from quark's
+# or the test's side; see valgrind bug 466172 for the same pattern with
+# bpftrace. Re-enabling these under valgrind isn't on the table; getting
+# real dynamic leak coverage for the TLS path needs a non-ptrace-based
+# tool (AddressSanitizer/LeakSanitizer is the candidate) -- tracked as a
+# backlog item, not done yet.
+#
 test-valgrind: quark-test
 	$(SUDO) VALGRIND=1 QUARK_BTF_PATH=/sys/kernel/btf/vmlinux	\
 		valgrind						\
@@ -469,8 +494,10 @@ test-valgrind: quark-test
 		--leak-check=full					\
 		--error-exitcode=1					\
 		./quark-test -1						\
-		2>&1
-# | grep -v "^--.*WARNING: unhandled eBPF command"
+		-x t_tls_load -x t_tls_conn -x t_tls_call		\
+		-x t_tls_multichunk -x t_tls_truncated			\
+		-x t_tls_multiproc					\
+		2>&1 |grep -v "^--.*WARNING: unhandled eBPF command"
 
 initramfs:
 	mkdir -p initramfs/bin
@@ -518,8 +545,8 @@ quark-btf: quark-btf.c manpages.h $(LIBQUARK_TARGET)
 
 quark-test: quark-test.c manpages.h $(LIBQUARK_TARGET)
 	$(call msg,CC,$@)
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(CDIAGFLAGS) \
-		-o $@ $< $(LIBQUARK_TARGET) $(EXTRA_LDFLAGS)
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(OPENSSL_CFLAGS) $(CDIAGFLAGS) \
+		-o $@ $< $(LIBQUARK_TARGET) $(EXTRA_LDFLAGS) $(OPENSSL_LIBS)
 
 quark-mon-static: quark-mon.c manpages.h $(LIBQUARK_STATIC_BIG)
 	$(call msg,CC,$@)

--- a/Makefile
+++ b/Makefile
@@ -474,9 +474,6 @@ test-kernel: initramfs.gz
 # loading these BTF modules, making valgrind spit thousands of false
 # positives.
 #
-# The TLS e2e tests are excluded here: uprobes and valgrind's ptrace-based will cause a SIGTRAP to be sent to the child process.
-# Any recommendations on how to approach it?
-
 test-valgrind: quark-test
 	$(SUDO) VALGRIND=1 QUARK_BTF_PATH=/sys/kernel/btf/vmlinux	\
 		valgrind						\
@@ -484,13 +481,7 @@ test-valgrind: quark-test
 		--child-silent-after-fork=yes				\
 		--leak-check=full					\
 		--error-exitcode=1					\
-		./quark-test -1						\
-		-x t_tls_load -x t_tls_conn -x t_tls_call		\
-		-x t_tls_late_adopt					\
-		-x t_tls_multichunk -x t_tls_truncated			\
-		-x t_tls_multiproc					\
-		-x t_tls_attach_sym -x t_tls_attach_sym_missing		\
-		2>&1 |grep -vE "^--[0-9]+-- WARNING: unhandled eBPF command"
+		./quark-test -1
 
 initramfs:
 	mkdir -p initramfs/bin

--- a/Makefile
+++ b/Makefile
@@ -489,9 +489,11 @@ test-valgrind: quark-test
 		--error-exitcode=1					\
 		./quark-test -1						\
 		-x t_tls_load -x t_tls_conn -x t_tls_call		\
+		-x t_tls_late_adopt					\
 		-x t_tls_multichunk -x t_tls_truncated			\
 		-x t_tls_multiproc					\
-		2>&1 |grep -v "^--.*WARNING: unhandled eBPF command"
+		-x t_tls_attach_sym -x t_tls_attach_sym_missing		\
+		2>&1 |grep -vE "^--[0-9]+-- WARNING: unhandled eBPF command"
 
 initramfs:
 	mkdir -p initramfs/bin

--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,8 @@ parse.tab.c: parse.y quark.h
 	$(call msg,BISON,$@)
 	$(Q)bison parse.y
 
+parse.tab.o: CDIAGFLAGS += -Wno-unused-but-set-variable
+
 DOCKER_RUN_ARGS=$(QDOCKER)				\
 		-v $(PWD):$(PWD)			\
 		-w $(PWD)				\

--- a/bpf_probes.c
+++ b/bpf_probes.c
@@ -12,3 +12,4 @@ struct {
 #include "Process/Probe.bpf.c"
 #include "Network/Probe.bpf.c"
 #include "File/Probe.bpf.c"
+#include "TLS/Probe.bpf.c"

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -23,11 +23,9 @@
 
 /*
  * One TLS uprobe attachment: the six links minted by a single
- * quark_queue_tls_attach for one binary path. Attach is system-wide per
- * binary, so a process may be asked to instrument several distinct binaries;
- * each gets its own record on bqq->tls_attachments. The skeleton keeps only a
- * single link slot per program, which a second path would overwrite and leak,
- * so the links are owned here instead.
+ * quark_queue_tls_attach for one binary path. The skeleton keeps only a single
+ * link slot per program, which a second path would overwrite and leak, so the
+ * links are owned here instead.
  */
 struct tls_attachment {
 	TAILQ_ENTRY(tls_attachment)	 entry;
@@ -928,10 +926,7 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		 * A dropped chunk that isn't the last one in the call is a
 		 * hole with more data after it - same hazard as a chunk that
 		 * silently never arrived at all. Only the trailing case is
-		 * safe (equivalent to a clean max_tls_call cap). This covers
-		 * the case where this node ends up being the chain head, or
-		 * a non-head child that was already known-bad before
-		 * quark_can_aggregate_tls() ever runs.
+		 * safe (equivalent to a clean max_tls_call cap).
 		 */
 		qtc->gap = (qtc->dropped && chunk->chunk_idx != chunk->chunk_total - 1) ? 1 : 0;
 		qtc->data_len = data_len;
@@ -1747,9 +1742,7 @@ tls_attachment_destroy(struct tls_attachment *ta)
 }
 
 /*
- * Detach every TLS uprobe attachment. Each quark_queue_tls_attach appended one
- * record, so tear them all down; the skeleton's single link slot per program
- * cannot track more than one path. Called from bpf_queue_close.
+ * Detach every TLS uprobe attachment. Called from bpf_queue_close.
  */
 static void
 quark_queue_tls_detach(struct bpf_queue *bqq)
@@ -1764,8 +1757,7 @@ quark_queue_tls_detach(struct bpf_queue *bqq)
 
 /*
  * Thin wrapper over bpf_program__attach_uprobe that warns naming the probe on
- * failure, so a bad offset or missing permission is logged the same way every
- * other attach in this file is, instead of bubbling up a bare NULL.
+ * failure.
  */
 static struct bpf_link *
 tls_attach_uprobe(struct bpf_program *prog, int retprobe, const char *path,
@@ -1781,10 +1773,8 @@ tls_attach_uprobe(struct bpf_program *prog, int retprobe, const char *path,
 }
 
 /*
- * path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. SSL_new is
- * attached as a uretprobe only (the SSL* it returns is what everything keys
- * on), SSL_free as a uprobe only, and read/write as entry+return pairs.
- * Attaches system-wide (pid=-1): if multiple tracked processes share the same
+ * path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. Attaches
+ * system-wide (pid=-1): if multiple tracked processes share the same
  * binary/library, callers should resolve and attach once per distinct path,
  * not once per process.
  */
@@ -1802,11 +1792,8 @@ quark_queue_tls_attach(struct quark_queue *qq, const char *path,
 		return (-1);
 
 	/*
-	 * The six links go into a per-attach record rather than the skeleton's
-	 * single link slot per program: attach is system-wide per binary, so a
-	 * second path reusing the same program would overwrite the first's link
-	 * and leak it. On any failure the partially populated record is rolled
-	 * back by tls_attachment_destroy.
+	 * On any failure the partially populated record is rolled back by
+	 * tls_attachment_destroy.
 	 */
 	if ((ta->links[0] = tls_attach_uprobe(
 	    p->progs.uretprobe__ssl_new, 1, path, ssl_new_off,

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -24,9 +24,7 @@
 /*
  * One TLS uprobe attachment: the links minted by a single attach call. The
  * skeleton keeps only a single link slot per program, which a second attach
- * would overwrite and leak, so the links are owned here instead. Offset attach
- * uses six (SSL_new/read/write/free); symbol attach can use up to ten (adding
- * the optional SSL_read_ex/SSL_write_ex pair). Unused slots stay NULL.
+ * would overwrite and leak, so the links are owned here instead. Unused slots stay NULL.
  *
  * pid is the process the uprobes are scoped to, or -1 for a system-wide attach.
  */
@@ -196,13 +194,9 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		ebpf_ctx_to_task(qq, &ebpf_ctx, &raw->task);
 
 		/*
-		 * A process that opened TLS connections is dying: reclaim any
-		 * it left behind. SSL_free already removes entries on a clean
-		 * close, but a process killed with live SSL objects (e.g.
-		 * SIGKILL) never runs it -- this exit hook, which the kernel
-		 * guarantees even for SIGKILL, is the backstop. The probe-
-		 * maintained tls_conn_tgids index gates the sweep with an O(1)
-		 * lookup so unrelated exits don't scan the connection map.
+		 * This does an O(1) lookup to check if the related tgid has any connections left behind.
+		 * It's better to do this here than in users-space (which would be similar to the existing socket cache).
+		 * The reclaim has some slight overhead, but only runs when necessary and only when enabled.
 		 */
 		if (qq->flags & QQ_TLS) {
 			struct bpf_probes	*p;
@@ -930,9 +924,8 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		qtc->dropped = chunk->dropped ? 1 : 0;
 		/*
 		 * A dropped chunk that isn't the last one in the call is a
-		 * hole with more data after it - same hazard as a chunk that
-		 * silently never arrived at all. Only the trailing case is
-		 * safe (equivalent to a clean max_tls_call cap).
+		 * hole with more data after it, mainly useful for userspace that
+		 * is interested in parsing the raw data to reconstruct the call.
 		 */
 		qtc->gap = (qtc->dropped && chunk->chunk_idx != chunk->chunk_total - 1) ? 1 : 0;
 		qtc->data_len = data_len;
@@ -1250,7 +1243,7 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		    "inet_csk_accept") == -1)
 			goto fail;
 	}
-
+	
 	if (qq->flags & QQ_FILE) {
 		int use_fsnotify =
 		    (btf_number_of_params_of_ptr(btf, "inode_operations", "atomic_open") == 6);

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -29,14 +29,11 @@
  * the optional SSL_read_ex/SSL_write_ex pair). Unused slots stay NULL.
  *
  * pid is the process the uprobes are scoped to, or -1 for a system-wide attach.
- * auto_tracked is set when the attach added pid to the tracked_tgids allow-list
- * itself (every pid-scoped attach does), so detach knows to undo it.
  */
 struct quark_tls_attachment {
 	TAILQ_ENTRY(quark_tls_attachment)	 entry;
 	struct bpf_link				*links[10];
 	int					 pid;
-	int					 auto_tracked;
 };
 
 struct bpf_queue {
@@ -115,8 +112,7 @@ ebpf_ctx_to_task(struct quark_queue *qq, struct ebpf_ctx *ebpf_ctx, struct raw_t
 	}
 }
 
-static int	tls_track_tgid(struct bpf_probes *, u32);
-static void	tls_forget_tgid(struct bpf_probes *, u32);
+static void	tls_reclaim_conns(struct bpf_probes *, u32);
 static void	tls_attachment_destroy(struct quark_tls_attachment *);
 static void	tls_detach_all(struct bpf_queue *);
 
@@ -200,22 +196,24 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		ebpf_ctx_to_task(qq, &ebpf_ctx, &raw->task);
 
 		/*
-		 * A tracked process is dying: stop tracking it and reclaim any
-		 * TLS connections it left behind. SSL_free already removes
-		 * entries on a clean close, but a process killed with live SSL
-		 * objects (e.g. SIGKILL) never runs it -- this exit hook, which
-		 * the kernel guarantees even for SIGKILL, is the backstop.
+		 * A process that opened TLS connections is dying: reclaim any
+		 * it left behind. SSL_free already removes entries on a clean
+		 * close, but a process killed with live SSL objects (e.g.
+		 * SIGKILL) never runs it -- this exit hook, which the kernel
+		 * guarantees even for SIGKILL, is the backstop. The probe-
+		 * maintained tls_conn_tgids index gates the sweep with an O(1)
+		 * lookup so unrelated exits don't scan the connection map.
 		 */
 		if (qq->flags & QQ_TLS) {
 			struct bpf_probes	*p;
 			u8			 v;
 
 			if ((p = quark_get_bpf_probes(qq)) != NULL &&
-			    p->maps.tracked_tgids != NULL &&
-			    bpf_map__lookup_elem(p->maps.tracked_tgids,
+			    p->maps.tls_conn_tgids != NULL &&
+			    bpf_map__lookup_elem(p->maps.tls_conn_tgids,
 			    &exit->pids.tgid, sizeof(exit->pids.tgid),
 			    &v, sizeof(v), 0) == 0)
-				tls_forget_tgid(p, exit->pids.tgid);
+				tls_reclaim_conns(p, exit->pids.tgid);
 		}
 
 		break;
@@ -1655,43 +1653,13 @@ quark_queue_trusted_pid_add(struct quark_queue *qq, u32 pid)
 }
 
 /*
- * Add tgid to the TLS capture allow-list. Shared by the public track call and
- * by every pid-scoped attach, which tracks its target itself.
- */
-static int
-tls_track_tgid(struct bpf_probes *p, u32 tgid)
-{
-	struct bpf_map	*m;
-	u8		 v;
-
-	if ((m = p->maps.tracked_tgids) == NULL)
-		return (errno = EINVAL, -1);
-	v = 1;
-	if (bpf_map__update_elem(m, &tgid, sizeof(tgid),
-	    &v, sizeof(v), BPF_ANY) < 0)
-		return (-1);
-
-	return (0);
-}
-
-int
-quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
-{
-	struct bpf_probes	*p;
-
-	if ((p = quark_get_bpf_probes(qq)) == NULL)
-		return (-1);
-
-	return (tls_track_tgid(p, tgid));
-}
-
-/*
- * Stop tracking tgid and reclaim every TLS connection it owns. The tls_conns
- * key mirrors struct tls_ssl_key in TLS/Probe.bpf.c; keep the layout in sync.
- * Collect-then-delete because deleting while iterating disturbs get_next_key.
+ * Reclaim every TLS connection tgid owns and drop it from the tls_conn_tgids
+ * GC index. The tls_conns key mirrors struct tls_ssl_key in TLS/Probe.bpf.c;
+ * keep the layout in sync. Collect-then-delete because deleting while iterating
+ * disturbs get_next_key.
  */
 static void
-tls_forget_tgid(struct bpf_probes *p, u32 tgid)
+tls_reclaim_conns(struct bpf_probes *p, u32 tgid)
 {
 	struct tls_ssl_key {
 		u32	tgid;
@@ -1702,8 +1670,7 @@ tls_forget_tgid(struct bpf_probes *p, u32 tgid)
 	size_t		 nmatch;
 	int		 i, full;
 
-	/* Drop the allow-list entry first so no new connection is minted. */
-	if ((m = p->maps.tracked_tgids) != NULL)
+	if ((m = p->maps.tls_conn_tgids) != NULL)
 		(void)bpf_map__delete_elem(m, &tgid, sizeof(tgid), 0);
 
 	if ((m = p->maps.tls_conns) == NULL)
@@ -1732,20 +1699,6 @@ tls_forget_tgid(struct bpf_probes *p, u32 tgid)
 	} while (full);
 }
 
-int
-quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
-{
-	struct bpf_probes	*p;
-
-	if ((p = quark_get_bpf_probes(qq)) == NULL)
-		return (-1);
-	if (p->maps.tracked_tgids == NULL)
-		return (errno = EINVAL, -1);
-	tls_forget_tgid(p, tgid);
-
-	return (0);
-}
-
 /*
  * Destroy one attachment's uprobe links and free the record. Safe on a
  * partially populated record: unset slots are NULL and bpf_link__destroy(NULL)
@@ -1767,8 +1720,7 @@ tls_attachment_destroy(struct quark_tls_attachment *ta)
 
 /*
  * Detach every TLS uprobe attachment. Called from bpf_queue_close, where the
- * maps are about to be destroyed anyway, so it only frees the links and skips
- * the per-attachment untrack/sweep that quark_queue_tls_detach does.
+ * maps are about to be destroyed anyway, so it only frees the links.
  */
 static void
 tls_detach_all(struct bpf_queue *bqq)
@@ -1782,36 +1734,19 @@ tls_detach_all(struct bpf_queue *bqq)
 }
 
 /*
- * Detach a single attachment and reclaim what it owns. A pid-scoped attach
- * tracked its target itself; drop that tracking (which also sweeps the tgid's
- * live connections) unless another attachment still covers the same pid.
+ * Detach a single attachment: remove it and destroy its uprobe links. Any
+ * connections its process still holds are reclaimed when that process exits
+ * (via the tls_conn_tgids-gated exit sweep), so nothing is swept here.
  */
 void
 quark_queue_tls_detach(struct quark_queue *qq, struct quark_tls_attachment *ta)
 {
-	struct bpf_queue		*bqq = qq->queue_be;
-	struct quark_tls_attachment	*other;
-	struct bpf_probes		*p;
-	int				 still_tracked;
+	struct bpf_queue	*bqq = qq->queue_be;
 
 	if (ta == NULL)
 		return;
 
 	TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
-
-	if (ta->auto_tracked && ta->pid >= 0 &&
-	    (p = quark_get_bpf_probes(qq)) != NULL) {
-		still_tracked = 0;
-		TAILQ_FOREACH(other, &bqq->tls_attachments, entry) {
-			if (other->pid == ta->pid) {
-				still_tracked = 1;
-				break;
-			}
-		}
-		if (!still_tracked)
-			tls_forget_tgid(p, (u32)ta->pid);
-	}
-
 	tls_attachment_destroy(ta);
 }
 
@@ -1854,38 +1789,13 @@ tls_attach_uprobe_sym(struct bpf_program *prog, int retprobe, int pid,
 }
 
 /*
- * Finish an attach: for a pid-scoped attach, track the target so the shared
- * probes capture it and its connections are swept on exit. Links the record
- * into the queue on success, rolls it back on failure.
- */
-static struct quark_tls_attachment *
-tls_attach_commit(struct bpf_queue *bqq, struct bpf_probes *p,
-    struct quark_tls_attachment *ta)
-{
-	if (ta->pid >= 0) {
-		if (tls_track_tgid(p, (u32)ta->pid) != 0)
-			goto fail;
-		ta->auto_tracked = 1;
-	}
-
-	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
-
-	return (ta);
-
-fail:
-	tls_attachment_destroy(ta);
-	return (NULL);
-}
-
-/*
  * Offset attach: path plus SSL_new, SSL_read, SSL_write, SSL_free file offsets,
- * all required. pid == -1 attaches system-wide, and capture is then gated by
- * the tracked_tgids allow-list the caller manages with quark_queue_track_tgid.
- * pid >= 0 scopes the uprobes to that process and tracks it automatically.
- * Callers are recommended to track attachments by (dev, inode, offset) and
- * attach once per such tuple, not once per process; the kernel refcounts
- * uprobes by (inode, offset) only. Returns an opaque handle, or NULL with
- * errno set on failure.
+ * all required. pid == -1 attaches system-wide, so every process hitting these
+ * offsets is captured (subject only to the trusted-pid deny-list); pid >= 0
+ * scopes the uprobes to that process. Callers are recommended to track
+ * attachments by (dev, inode, offset) and attach once per such tuple, not once
+ * per process; the kernel refcounts uprobes by (inode, offset) only. Returns an
+ * opaque handle, or NULL with errno set on failure.
  */
 struct quark_tls_attachment *
 quark_queue_tls_attach(struct quark_queue *qq, int pid, const char *path,
@@ -1930,7 +1840,9 @@ quark_queue_tls_attach(struct quark_queue *qq, int pid, const char *path,
 	    "uprobe__ssl_free")) == NULL)
 		goto fail;
 
-	return (tls_attach_commit(bqq, p, ta));
+	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
+
+	return (ta);
 
 fail:
 	tls_attachment_destroy(ta);
@@ -1969,9 +1881,8 @@ tls_attach_sym_ex(struct bpf_probes *p, struct quark_tls_attachment *ta,
 /*
  * Symbol attach for a shared library (e.g. libssl). Resolves SSL_new, SSL_free,
  * SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex (optional) by
- * name in path. pid must be >= 0: the uprobes are scoped to that process and it
- * is tracked automatically, so no allow-list management is needed. Returns an
- * opaque handle, or NULL with errno set on failure.
+ * name in path. pid must be >= 0: the uprobes are scoped to that process.
+ * Returns an opaque handle, or NULL with errno set on failure.
  */
 struct quark_tls_attachment *
 quark_queue_tls_attach_sym(struct quark_queue *qq, int pid, const char *path)
@@ -2012,7 +1923,9 @@ quark_queue_tls_attach_sym(struct quark_queue *qq, int pid, const char *path)
 	tls_attach_sym_ex(p, ta, pid, path, p->progs.uprobe__ssl_read_ex,
 	    p->progs.uretprobe__ssl_read_ex, "SSL_read_ex", 8, 9);
 
-	return (tls_attach_commit(bqq, p, ta));
+	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
+
+	return (ta);
 
 fail:
 	tls_attachment_destroy(ta);

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1737,17 +1737,30 @@ tls_detach_all(struct bpf_queue *bqq)
  * Detach a single attachment: remove it and destroy its uprobe links. Any
  * connections its process still holds are reclaimed when that process exits
  * (via the tls_conn_tgids-gated exit sweep), so nothing is swept here.
+ *
+ * The handle is validated against this queue's list before it is touched: a
+ * repeated detach, a handle belonging to another queue, or a NULL handle is a
+ * no-op rather than a use-after-free or a foreign-node removal. Only addresses
+ * are compared, ta is never dereferenced, so a stale (freed) handle is safe to
+ * pass. Detach is not a hot path and attachments are few, so the linear walk
+ * is free. Must be called on the thread that drains the queue.
  */
 void
 quark_queue_tls_detach(struct quark_queue *qq, struct quark_tls_attachment *ta)
 {
-	struct bpf_queue	*bqq = qq->queue_be;
+	struct bpf_queue		*bqq = qq->queue_be;
+	struct quark_tls_attachment	*cur;
 
 	if (ta == NULL)
 		return;
 
-	TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
-	tls_attachment_destroy(ta);
+	TAILQ_FOREACH(cur, &bqq->tls_attachments, entry) {
+		if (cur == ta) {
+			TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
+			tls_attachment_destroy(ta);
+			return;
+		}
+	}
 }
 
 /*

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -22,15 +22,17 @@
 #include "elastic-ebpf/GPL/Events/EbpfEventProto.h"
 
 /*
- * One TLS uprobe attachment: the links minted by a single attach call. The
- * skeleton keeps only a single link slot per program, which a second attach
- * would overwrite and leak, so the links are owned here instead. Unused slots stay NULL.
+ * One TLS uprobe attachment: the six links minted by a single attach call
+ * (SSL_new return, SSL_write entry+return, SSL_read entry+return, SSL_free
+ * entry). The skeleton keeps only a single link slot per program, which a
+ * second attach would overwrite and leak, so the links are owned here instead.
+ * Unused slots stay NULL.
  *
  * pid is the process the uprobes are scoped to, or -1 for a system-wide attach.
  */
 struct quark_tls_attachment {
 	TAILQ_ENTRY(quark_tls_attachment)	 entry;
-	struct bpf_link				*links[10];
+	struct bpf_link				*links[6];
 	int					 pid;
 };
 
@@ -110,7 +112,6 @@ ebpf_ctx_to_task(struct quark_queue *qq, struct ebpf_ctx *ebpf_ctx, struct raw_t
 	}
 }
 
-static void	tls_reclaim_conns(struct bpf_probes *, u32);
 static void	tls_attachment_destroy(struct quark_tls_attachment *);
 static void	tls_detach_all(struct bpf_queue *);
 
@@ -192,23 +193,6 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		raw->task.exit_code = exit->exit_code;
 		raw->task.exit_time_event = raw->time;
 		ebpf_ctx_to_task(qq, &ebpf_ctx, &raw->task);
-
-		/*
-		 * This does an O(1) lookup to check if the related tgid has any connections left behind.
-		 * It's better to do this here than in users-space (which would be similar to the existing socket cache).
-		 * The reclaim has some slight overhead, but only runs when necessary and only when enabled.
-		 */
-		if (qq->flags & QQ_TLS) {
-			struct bpf_probes	*p;
-			u8			 v;
-
-			if ((p = quark_get_bpf_probes(qq)) != NULL &&
-			    p->maps.tls_conn_tgids != NULL &&
-			    bpf_map__lookup_elem(p->maps.tls_conn_tgids,
-			    &exit->pids.tgid, sizeof(exit->pids.tgid),
-			    &v, sizeof(v), 0) == 0)
-				tls_reclaim_conns(p, exit->pids.tgid);
-		}
 
 		break;
 	}
@@ -1191,7 +1175,6 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	 * Maps and other state
 	 */
 	p->rodata->consumer_pid = getpid();
-	p->rodata->max_tls_call = qq->max_tls_call;
 
 	/*
 	 * Unload everything since it has way more than we want
@@ -1398,10 +1381,12 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.uprobe__ssl_read, 1);
 		bpf_program__set_autoload(p->progs.uretprobe__ssl_read, 1);
 		bpf_program__set_autoload(p->progs.uprobe__ssl_free, 1);
-		bpf_program__set_autoload(p->progs.uprobe__ssl_write_ex, 1);
-		bpf_program__set_autoload(p->progs.uretprobe__ssl_write_ex, 1);
-		bpf_program__set_autoload(p->progs.uprobe__ssl_read_ex, 1);
-		bpf_program__set_autoload(p->progs.uretprobe__ssl_read_ex, 1);
+		if (use_fentry)
+			bpf_program__set_autoload(
+			    p->progs.fentry__disassociate_ctty_tls, 1);
+		else
+			bpf_program__set_autoload(
+			    p->progs.kprobe__disassociate_ctty_tls, 1);
 	}
 
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
@@ -1598,10 +1583,18 @@ bpf_queue_close(struct quark_queue *qq)
 struct bpf_probes *
 quark_get_bpf_probes(struct quark_queue *qq)
 {
-	struct bpf_queue *bqq = qq->queue_be;
+	struct bpf_queue *bqq;
 
-	if (!(qq->flags & QQ_EBPF))
+	/*
+	 * Gate on the backend that actually opened, not on the requested
+	 * flags: QQ_ALL_BACKENDS can request eBPF but fall back to kprobe, in
+	 * which case qq->queue_be is a struct kprobe_queue. Treating that as a
+	 * struct bpf_queue would dereference the wrong layout.
+	 */
+	if (qq->stats.backend != QQ_EBPF)
 		return (errno = EINVAL, NULL);
+
+	bqq = qq->queue_be;
 
 	return (bqq->probes);
 }
@@ -1643,53 +1636,6 @@ quark_queue_trusted_pid_add(struct quark_queue *qq, u32 pid)
 		return (-1);
 
 	return (0);
-}
-
-/*
- * Reclaim every TLS connection tgid owns and drop it from the tls_conn_tgids
- * GC index. The tls_conns key mirrors struct tls_ssl_key in TLS/Probe.bpf.c;
- * keep the layout in sync. Collect-then-delete because deleting while iterating
- * disturbs get_next_key.
- */
-static void
-tls_reclaim_conns(struct bpf_probes *p, u32 tgid)
-{
-	struct tls_ssl_key {
-		u32	tgid;
-		u64	ssl;
-	} __attribute__((packed)) cur, next, matches[512];
-	struct bpf_map	*m;
-	void		*curp;
-	size_t		 nmatch;
-	int		 i, full;
-
-	if ((m = p->maps.tls_conn_tgids) != NULL)
-		(void)bpf_map__delete_elem(m, &tgid, sizeof(tgid), 0);
-
-	if ((m = p->maps.tls_conns) == NULL)
-		return;
-
-	do {
-		nmatch = 0;
-		full = 0;
-		curp = NULL;
-		while (bpf_map__get_next_key(m, curp, &next,
-		    sizeof(next)) == 0) {
-			if (next.tgid == tgid) {
-				if (nmatch ==
-				    sizeof(matches) / sizeof(matches[0])) {
-					full = 1;
-					break;
-				}
-				matches[nmatch++] = next;
-			}
-			cur = next;
-			curp = &cur;
-		}
-		for (i = 0; i < (int)nmatch; i++)
-			(void)bpf_map__delete_elem(m, &matches[i],
-			    sizeof(matches[i]), 0);
-	} while (full);
 }
 
 /*
@@ -1774,27 +1720,6 @@ tls_attach_uprobe_off(struct bpf_program *prog, int retprobe, int pid,
 }
 
 /*
- * Attach one uprobe by symbol name, resolved in path by libbpf. warn controls
- * whether a miss is logged, so optional symbols (SSL_read_ex/SSL_write_ex) can
- * fail quietly.
- */
-static struct bpf_link *
-tls_attach_uprobe_sym(struct bpf_program *prog, int retprobe, int pid,
-    const char *path, const char *sym, int warn)
-{
-	LIBBPF_OPTS(bpf_uprobe_opts, opts,
-	    .retprobe = retprobe,
-	    .func_name = sym);
-	struct bpf_link	*link;
-
-	link = bpf_program__attach_uprobe_opts(prog, pid, path, 0, &opts);
-	if (link == NULL && warn)
-		qwarn("bpf_program__attach_uprobe_opts %s", sym);
-
-	return (link);
-}
-
-/*
  * Offset attach: path plus SSL_new, SSL_read, SSL_write, SSL_free file offsets,
  * all required. pid == -1 attaches system-wide, so every process hitting these
  * offsets is captured (subject only to the trusted-pid deny-list); pid >= 0
@@ -1845,89 +1770,6 @@ quark_queue_tls_attach(struct quark_queue *qq, int pid, const char *path,
 	    p->progs.uprobe__ssl_free, 0, pid, path, ssl_free_off,
 	    "uprobe__ssl_free")) == NULL)
 		goto fail;
-
-	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
-
-	return (ta);
-
-fail:
-	tls_attachment_destroy(ta);
-	return (NULL);
-}
-
-/*
- * Attach the optional SSL_read_ex/SSL_write_ex entry+return pair by symbol.
- * Missing _ex symbols are expected on older libraries, so a miss is silent and
- * leaves both slots NULL rather than failing the whole attach. A half-resolved
- * pair (only one of the two) is torn down so no return probe runs without its
- * entry.
- */
-static void
-tls_attach_sym_ex(struct bpf_probes *p, struct quark_tls_attachment *ta,
-    int pid, const char *path, struct bpf_program *entry,
-    struct bpf_program *ret, const char *sym, int slot_entry, int slot_ret)
-{
-	ta->links[slot_entry] =
-	    tls_attach_uprobe_sym(entry, 0, pid, path, sym, 0);
-	ta->links[slot_ret] =
-	    tls_attach_uprobe_sym(ret, 1, pid, path, sym, 0);
-
-	if (ta->links[slot_entry] == NULL || ta->links[slot_ret] == NULL) {
-		if (ta->links[slot_entry] != NULL) {
-			bpf_link__destroy(ta->links[slot_entry]);
-			ta->links[slot_entry] = NULL;
-		}
-		if (ta->links[slot_ret] != NULL) {
-			bpf_link__destroy(ta->links[slot_ret]);
-			ta->links[slot_ret] = NULL;
-		}
-	}
-}
-
-/*
- * Symbol attach for a shared library (e.g. libssl). Resolves SSL_new, SSL_free,
- * SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex (optional) by
- * name in path. pid must be >= 0: the uprobes are scoped to that process.
- * Returns an opaque handle, or NULL with errno set on failure.
- */
-struct quark_tls_attachment *
-quark_queue_tls_attach_sym(struct quark_queue *qq, int pid, const char *path)
-{
-	struct bpf_queue		*bqq = qq->queue_be;
-	struct bpf_probes		*p;
-	struct quark_tls_attachment	*ta;
-
-	if (pid < 0)
-		return (errno = EINVAL, NULL);
-	if ((p = quark_get_bpf_probes(qq)) == NULL)
-		return (NULL);
-	if ((ta = calloc(1, sizeof(*ta))) == NULL)
-		return (NULL);
-	ta->pid = pid;
-
-	if ((ta->links[0] = tls_attach_uprobe_sym(
-	    p->progs.uretprobe__ssl_new, 1, pid, path, "SSL_new", 1)) == NULL)
-		goto fail;
-	if ((ta->links[1] = tls_attach_uprobe_sym(
-	    p->progs.uprobe__ssl_free, 0, pid, path, "SSL_free", 1)) == NULL)
-		goto fail;
-	if ((ta->links[2] = tls_attach_uprobe_sym(
-	    p->progs.uprobe__ssl_write, 0, pid, path, "SSL_write", 1)) == NULL)
-		goto fail;
-	if ((ta->links[3] = tls_attach_uprobe_sym(
-	    p->progs.uretprobe__ssl_write, 1, pid, path, "SSL_write", 1)) == NULL)
-		goto fail;
-	if ((ta->links[4] = tls_attach_uprobe_sym(
-	    p->progs.uprobe__ssl_read, 0, pid, path, "SSL_read", 1)) == NULL)
-		goto fail;
-	if ((ta->links[5] = tls_attach_uprobe_sym(
-	    p->progs.uretprobe__ssl_read, 1, pid, path, "SSL_read", 1)) == NULL)
-		goto fail;
-
-	tls_attach_sym_ex(p, ta, pid, path, p->progs.uprobe__ssl_write_ex,
-	    p->progs.uretprobe__ssl_write_ex, "SSL_write_ex", 6, 7);
-	tls_attach_sym_ex(p, ta, pid, path, p->progs.uprobe__ssl_read_ex,
-	    p->progs.uretprobe__ssl_read_ex, "SSL_read_ex", 8, 9);
 
 	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
 

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -96,6 +96,8 @@ ebpf_ctx_to_task(struct quark_queue *qq, struct ebpf_ctx *ebpf_ctx, struct raw_t
 	}
 }
 
+static void	tls_forget_tgid(struct bpf_probes *, u32);
+
 static struct raw_event *
 ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 {
@@ -174,6 +176,25 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		raw->task.exit_code = exit->exit_code;
 		raw->task.exit_time_event = raw->time;
 		ebpf_ctx_to_task(qq, &ebpf_ctx, &raw->task);
+
+		/*
+		 * A tracked process is dying: stop tracking it and reclaim any
+		 * TLS connections it left behind. SSL_free already removes
+		 * entries on a clean close, but a process killed with live SSL
+		 * objects (e.g. SIGKILL) never runs it -- this exit hook, which
+		 * the kernel guarantees even for SIGKILL, is the backstop.
+		 */
+		if (qq->flags & QQ_TLS) {
+			struct bpf_probes	*p;
+			u8			 v;
+
+			if ((p = quark_get_bpf_probes(qq)) != NULL &&
+			    p->maps.tracked_tgids != NULL &&
+			    bpf_map__lookup_elem(p->maps.tracked_tgids,
+			    &exit->pids.tgid, sizeof(exit->pids.tgid),
+			    &v, sizeof(v), 0) == 0)
+				tls_forget_tgid(p, exit->pids.tgid);
+		}
 
 		break;
 	}
@@ -819,6 +840,28 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 			goto bad;
 		qtc->conn_id = tlsnew->conn_id;
 		qtc->tgid = tlsnew->pids.tgid;
+		qtc->flags = tlsnew->flags;
+
+		raw->tls_conn.quark_tls_conn = qtc;
+
+		break;
+	}
+	case EBPF_EVENT_TLS_CONN_CLOSE: {
+		struct ebpf_tls_close_event	*tlsclose;
+		struct quark_tls_conn		*qtc;
+
+		tlsclose = (struct ebpf_tls_close_event *)ev;
+		if ((raw = raw_event_alloc(RAW_TLS_CONN_CLOSE)) == NULL)
+			goto bad;
+
+		raw->pid = tlsclose->pids.tgid;
+		raw->time = ev->ts;
+
+		if ((qtc = malloc(sizeof(*qtc))) == NULL)
+			goto bad;
+		qtc->conn_id = tlsclose->conn_id;
+		qtc->tgid = tlsclose->pids.tgid;
+		qtc->flags = 0;
 
 		raw->tls_conn.quark_tls_conn = qtc;
 
@@ -1338,12 +1381,12 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);
 
 	if (qq->flags & QQ_TLS) {
-		bpf_program__set_autoload(p->progs.uprobe__ssl_new, 1);
 		bpf_program__set_autoload(p->progs.uretprobe__ssl_new, 1);
 		bpf_program__set_autoload(p->progs.uprobe__ssl_write, 1);
 		bpf_program__set_autoload(p->progs.uretprobe__ssl_write, 1);
 		bpf_program__set_autoload(p->progs.uprobe__ssl_read, 1);
 		bpf_program__set_autoload(p->progs.uretprobe__ssl_read, 1);
+		bpf_program__set_autoload(p->progs.uprobe__ssl_free, 1);
 	}
 
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
@@ -1605,18 +1648,63 @@ quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
 	return (0);
 }
 
+/*
+ * Stop tracking tgid and reclaim every TLS connection it owns. The tls_conns
+ * key mirrors struct tls_ssl_key in TLS/Probe.bpf.c; keep the layout in sync.
+ * Collect-then-delete because deleting while iterating disturbs get_next_key.
+ */
+static void
+tls_forget_tgid(struct bpf_probes *p, u32 tgid)
+{
+	struct tls_ssl_key {
+		u32	tgid;
+		u64	ssl;
+	} __attribute__((packed)) cur, next, matches[512];
+	struct bpf_map	*m;
+	void		*curp;
+	size_t		 nmatch;
+	int		 i, full;
+
+	/* Drop the allow-list entry first so no new connection is minted. */
+	if ((m = p->maps.tracked_tgids) != NULL)
+		(void)bpf_map__delete_elem(m, &tgid, sizeof(tgid), 0);
+
+	if ((m = p->maps.tls_conns) == NULL)
+		return;
+
+	do {
+		nmatch = 0;
+		full = 0;
+		curp = NULL;
+		while (bpf_map__get_next_key(m, curp, &next,
+		    sizeof(next)) == 0) {
+			if (next.tgid == tgid) {
+				if (nmatch ==
+				    sizeof(matches) / sizeof(matches[0])) {
+					full = 1;
+					break;
+				}
+				matches[nmatch++] = next;
+			}
+			cur = next;
+			curp = &cur;
+		}
+		for (i = 0; i < (int)nmatch; i++)
+			(void)bpf_map__delete_elem(m, &matches[i],
+			    sizeof(matches[i]), 0);
+	} while (full);
+}
+
 int
 quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
 {
 	struct bpf_probes	*p;
-	struct bpf_map		*m;
 
 	if ((p = quark_get_bpf_probes(qq)) == NULL)
 		return (-1);
-	if ((m = p->maps.tracked_tgids) == NULL)
+	if (p->maps.tracked_tgids == NULL)
 		return (errno = EINVAL, -1);
-	if (bpf_map__delete_elem(m, &tgid, sizeof(tgid), 0) < 0)
-		return (-1);
+	tls_forget_tgid(p, tgid);
 
 	return (0);
 }
@@ -1624,13 +1712,13 @@ quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
 static void
 quark_queue_tls_detach(struct bpf_probes *p)
 {
-	if (p->links.uprobe__ssl_new != NULL) {
-		bpf_link__destroy(p->links.uprobe__ssl_new);
-		p->links.uprobe__ssl_new = NULL;
-	}
 	if (p->links.uretprobe__ssl_new != NULL) {
 		bpf_link__destroy(p->links.uretprobe__ssl_new);
 		p->links.uretprobe__ssl_new = NULL;
+	}
+	if (p->links.uprobe__ssl_free != NULL) {
+		bpf_link__destroy(p->links.uprobe__ssl_free);
+		p->links.uprobe__ssl_free = NULL;
 	}
 	if (p->links.uprobe__ssl_write != NULL) {
 		bpf_link__destroy(p->links.uprobe__ssl_write);
@@ -1651,37 +1739,63 @@ quark_queue_tls_detach(struct bpf_probes *p)
 }
 
 /*
- * path, ssl_new file offset, ssl_read file offset, ssl_write file offset.
- * Attaches system-wide (pid=-1): if multiple tracked processes share the
- * same binary/library, callers should resolve and attach once per distinct
- * path, not once per process.
+ * Thin wrapper over bpf_program__attach_uprobe that warns naming the probe on
+ * failure, so a bad offset or missing permission is logged the same way every
+ * other attach in this file is, instead of bubbling up a bare NULL.
+ */
+static struct bpf_link *
+tls_attach_uprobe(struct bpf_program *prog, int retprobe, const char *path,
+    u64 off, const char *name)
+{
+	struct bpf_link	*link;
+
+	link = bpf_program__attach_uprobe(prog, retprobe, -1, path, off);
+	if (link == NULL)
+		qwarn("bpf_program__attach_uprobe %s", name);
+
+	return (link);
+}
+
+/*
+ * path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. SSL_new is
+ * attached as a uretprobe only (the SSL* it returns is what everything keys
+ * on), SSL_free as a uprobe only, and read/write as entry+return pairs.
+ * Attaches system-wide (pid=-1): if multiple tracked processes share the same
+ * binary/library, callers should resolve and attach once per distinct path,
+ * not once per process.
  */
 int
 quark_queue_tls_attach(struct quark_queue *qq, const char *path,
-    u64 ssl_new_off, u64 ssl_read_off, u64 ssl_write_off)
+    u64 ssl_new_off, u64 ssl_read_off, u64 ssl_write_off, u64 ssl_free_off)
 {
 	struct bpf_probes	*p;
 
 	if ((p = quark_get_bpf_probes(qq)) == NULL)
 		return (-1);
 
-	if ((p->links.uprobe__ssl_new = bpf_program__attach_uprobe(
-	    p->progs.uprobe__ssl_new, 0, -1, path, ssl_new_off)) == NULL)
+	if ((p->links.uretprobe__ssl_new = tls_attach_uprobe(
+	    p->progs.uretprobe__ssl_new, 1, path, ssl_new_off,
+	    "uretprobe__ssl_new")) == NULL)
 		goto fail;
-	if ((p->links.uretprobe__ssl_new = bpf_program__attach_uprobe(
-	    p->progs.uretprobe__ssl_new, 1, -1, path, ssl_new_off)) == NULL)
+	if ((p->links.uprobe__ssl_write = tls_attach_uprobe(
+	    p->progs.uprobe__ssl_write, 0, path, ssl_write_off,
+	    "uprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((p->links.uprobe__ssl_write = bpf_program__attach_uprobe(
-	    p->progs.uprobe__ssl_write, 0, -1, path, ssl_write_off)) == NULL)
+	if ((p->links.uretprobe__ssl_write = tls_attach_uprobe(
+	    p->progs.uretprobe__ssl_write, 1, path, ssl_write_off,
+	    "uretprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((p->links.uretprobe__ssl_write = bpf_program__attach_uprobe(
-	    p->progs.uretprobe__ssl_write, 1, -1, path, ssl_write_off)) == NULL)
+	if ((p->links.uprobe__ssl_read = tls_attach_uprobe(
+	    p->progs.uprobe__ssl_read, 0, path, ssl_read_off,
+	    "uprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((p->links.uprobe__ssl_read = bpf_program__attach_uprobe(
-	    p->progs.uprobe__ssl_read, 0, -1, path, ssl_read_off)) == NULL)
+	if ((p->links.uretprobe__ssl_read = tls_attach_uprobe(
+	    p->progs.uretprobe__ssl_read, 1, path, ssl_read_off,
+	    "uretprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((p->links.uretprobe__ssl_read = bpf_program__attach_uprobe(
-	    p->progs.uretprobe__ssl_read, 1, -1, path, ssl_read_off)) == NULL)
+	if ((p->links.uprobe__ssl_free = tls_attach_uprobe(
+	    p->progs.uprobe__ssl_free, 0, path, ssl_free_off,
+	    "uprobe__ssl_free")) == NULL)
 		goto fail;
 
 	return (0);

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -22,20 +22,27 @@
 #include "elastic-ebpf/GPL/Events/EbpfEventProto.h"
 
 /*
- * One TLS uprobe attachment: the six links minted by a single
- * quark_queue_tls_attach for one binary path. The skeleton keeps only a single
- * link slot per program, which a second path would overwrite and leak, so the
- * links are owned here instead.
+ * One TLS uprobe attachment: the links minted by a single attach call. The
+ * skeleton keeps only a single link slot per program, which a second attach
+ * would overwrite and leak, so the links are owned here instead. Offset attach
+ * uses six (SSL_new/read/write/free); symbol attach can use up to ten (adding
+ * the optional SSL_read_ex/SSL_write_ex pair). Unused slots stay NULL.
+ *
+ * pid is the process the uprobes are scoped to, or -1 for a system-wide attach.
+ * auto_tracked is set when the attach added pid to the tracked_tgids allow-list
+ * itself (every pid-scoped attach does), so detach knows to undo it.
  */
-struct tls_attachment {
-	TAILQ_ENTRY(tls_attachment)	 entry;
-	struct bpf_link			*links[6];
+struct quark_tls_attachment {
+	TAILQ_ENTRY(quark_tls_attachment)	 entry;
+	struct bpf_link				*links[10];
+	int					 pid;
+	int					 auto_tracked;
 };
 
 struct bpf_queue {
-	struct bpf_probes		*probes;
-	struct ring_buffer		*ringbuf;
-	TAILQ_HEAD(, tls_attachment)	 tls_attachments;
+	struct bpf_probes			*probes;
+	struct ring_buffer			*ringbuf;
+	TAILQ_HEAD(, quark_tls_attachment)	 tls_attachments;
 };
 
 static int	bpf_queue_populate(struct quark_queue *);
@@ -108,9 +115,10 @@ ebpf_ctx_to_task(struct quark_queue *qq, struct ebpf_ctx *ebpf_ctx, struct raw_t
 	}
 }
 
+static int	tls_track_tgid(struct bpf_probes *, u32);
 static void	tls_forget_tgid(struct bpf_probes *, u32);
-static void	tls_attachment_destroy(struct tls_attachment *);
-static void	quark_queue_tls_detach(struct bpf_queue *);
+static void	tls_attachment_destroy(struct quark_tls_attachment *);
+static void	tls_detach_all(struct bpf_queue *);
 
 static struct raw_event *
 ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
@@ -1399,6 +1407,10 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.uprobe__ssl_read, 1);
 		bpf_program__set_autoload(p->progs.uretprobe__ssl_read, 1);
 		bpf_program__set_autoload(p->progs.uprobe__ssl_free, 1);
+		bpf_program__set_autoload(p->progs.uprobe__ssl_write_ex, 1);
+		bpf_program__set_autoload(p->progs.uretprobe__ssl_write_ex, 1);
+		bpf_program__set_autoload(p->progs.uprobe__ssl_read_ex, 1);
+		bpf_program__set_autoload(p->progs.uretprobe__ssl_read_ex, 1);
 	}
 
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
@@ -1568,7 +1580,7 @@ bpf_queue_close(struct quark_queue *qq)
 
 	if (bqq == NULL)
 		return;
-	quark_queue_tls_detach(bqq);
+	tls_detach_all(bqq);
 	if (bqq->probes != NULL) {
 		bpf_probes__destroy(bqq->probes);
 		bqq->probes = NULL;
@@ -1642,15 +1654,16 @@ quark_queue_trusted_pid_add(struct quark_queue *qq, u32 pid)
 	return (0);
 }
 
-int
-quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
+/*
+ * Add tgid to the TLS capture allow-list. Shared by the public track call and
+ * by every pid-scoped attach, which tracks its target itself.
+ */
+static int
+tls_track_tgid(struct bpf_probes *p, u32 tgid)
 {
-	struct bpf_probes	*p;
-	struct bpf_map		*m;
-	u8			 v;
+	struct bpf_map	*m;
+	u8		 v;
 
-	if ((p = quark_get_bpf_probes(qq)) == NULL)
-		return (-1);
 	if ((m = p->maps.tracked_tgids) == NULL)
 		return (errno = EINVAL, -1);
 	v = 1;
@@ -1659,6 +1672,17 @@ quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
 		return (-1);
 
 	return (0);
+}
+
+int
+quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
+{
+	struct bpf_probes	*p;
+
+	if ((p = quark_get_bpf_probes(qq)) == NULL)
+		return (-1);
+
+	return (tls_track_tgid(p, tgid));
 }
 
 /*
@@ -1728,7 +1752,7 @@ quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
  * is a no-op, so this doubles as the rollback for a half-finished attach.
  */
 static void
-tls_attachment_destroy(struct tls_attachment *ta)
+tls_attachment_destroy(struct quark_tls_attachment *ta)
 {
 	size_t	i;
 
@@ -1742,12 +1766,14 @@ tls_attachment_destroy(struct tls_attachment *ta)
 }
 
 /*
- * Detach every TLS uprobe attachment. Called from bpf_queue_close.
+ * Detach every TLS uprobe attachment. Called from bpf_queue_close, where the
+ * maps are about to be destroyed anyway, so it only frees the links and skips
+ * the per-attachment untrack/sweep that quark_queue_tls_detach does.
  */
 static void
-quark_queue_tls_detach(struct bpf_queue *bqq)
+tls_detach_all(struct bpf_queue *bqq)
 {
-	struct tls_attachment	*ta;
+	struct quark_tls_attachment	*ta;
 
 	while ((ta = TAILQ_FIRST(&bqq->tls_attachments)) != NULL) {
 		TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
@@ -1756,16 +1782,50 @@ quark_queue_tls_detach(struct bpf_queue *bqq)
 }
 
 /*
- * Thin wrapper over bpf_program__attach_uprobe that warns naming the probe on
- * failure.
+ * Detach a single attachment and reclaim what it owns. A pid-scoped attach
+ * tracked its target itself; drop that tracking (which also sweeps the tgid's
+ * live connections) unless another attachment still covers the same pid.
+ */
+void
+quark_queue_tls_detach(struct quark_queue *qq, struct quark_tls_attachment *ta)
+{
+	struct bpf_queue		*bqq = qq->queue_be;
+	struct quark_tls_attachment	*other;
+	struct bpf_probes		*p;
+	int				 still_tracked;
+
+	if (ta == NULL)
+		return;
+
+	TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
+
+	if (ta->auto_tracked && ta->pid >= 0 &&
+	    (p = quark_get_bpf_probes(qq)) != NULL) {
+		still_tracked = 0;
+		TAILQ_FOREACH(other, &bqq->tls_attachments, entry) {
+			if (other->pid == ta->pid) {
+				still_tracked = 1;
+				break;
+			}
+		}
+		if (!still_tracked)
+			tls_forget_tgid(p, (u32)ta->pid);
+	}
+
+	tls_attachment_destroy(ta);
+}
+
+/*
+ * Attach one uprobe by file offset. pid == -1 is system-wide. Warns naming the
+ * probe on failure.
  */
 static struct bpf_link *
-tls_attach_uprobe(struct bpf_program *prog, int retprobe, const char *path,
-    u64 off, const char *name)
+tls_attach_uprobe_off(struct bpf_program *prog, int retprobe, int pid,
+    const char *path, u64 off, const char *name)
 {
 	struct bpf_link	*link;
 
-	link = bpf_program__attach_uprobe(prog, retprobe, -1, path, off);
+	link = bpf_program__attach_uprobe(prog, retprobe, pid, path, off);
 	if (link == NULL)
 		qwarn("bpf_program__attach_uprobe %s", name);
 
@@ -1773,58 +1833,188 @@ tls_attach_uprobe(struct bpf_program *prog, int retprobe, const char *path,
 }
 
 /*
- * path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. Attaches
- * system-wide (pid=-1): if multiple tracked processes share the same
- * binary/library, callers should resolve and attach once per distinct path,
- * not once per process.
+ * Attach one uprobe by symbol name, resolved in path by libbpf. warn controls
+ * whether a miss is logged, so optional symbols (SSL_read_ex/SSL_write_ex) can
+ * fail quietly.
  */
-int
-quark_queue_tls_attach(struct quark_queue *qq, const char *path,
+static struct bpf_link *
+tls_attach_uprobe_sym(struct bpf_program *prog, int retprobe, int pid,
+    const char *path, const char *sym, int warn)
+{
+	LIBBPF_OPTS(bpf_uprobe_opts, opts,
+	    .retprobe = retprobe,
+	    .func_name = sym);
+	struct bpf_link	*link;
+
+	link = bpf_program__attach_uprobe_opts(prog, pid, path, 0, &opts);
+	if (link == NULL && warn)
+		qwarn("bpf_program__attach_uprobe_opts %s", sym);
+
+	return (link);
+}
+
+/*
+ * Finish an attach: for a pid-scoped attach, track the target so the shared
+ * probes capture it and its connections are swept on exit. Links the record
+ * into the queue on success, rolls it back on failure.
+ */
+static struct quark_tls_attachment *
+tls_attach_commit(struct bpf_queue *bqq, struct bpf_probes *p,
+    struct quark_tls_attachment *ta)
+{
+	if (ta->pid >= 0) {
+		if (tls_track_tgid(p, (u32)ta->pid) != 0)
+			goto fail;
+		ta->auto_tracked = 1;
+	}
+
+	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
+
+	return (ta);
+
+fail:
+	tls_attachment_destroy(ta);
+	return (NULL);
+}
+
+/*
+ * Offset attach: path plus SSL_new, SSL_read, SSL_write, SSL_free file offsets,
+ * all required. pid == -1 attaches system-wide, and capture is then gated by
+ * the tracked_tgids allow-list the caller manages with quark_queue_track_tgid.
+ * pid >= 0 scopes the uprobes to that process and tracks it automatically.
+ * Callers are recommended to track attachments by (dev, inode, offset) and
+ * attach once per such tuple, not once per process; the kernel refcounts
+ * uprobes by (inode, offset) only. Returns an opaque handle, or NULL with
+ * errno set on failure.
+ */
+struct quark_tls_attachment *
+quark_queue_tls_attach(struct quark_queue *qq, int pid, const char *path,
     u64 ssl_new_off, u64 ssl_read_off, u64 ssl_write_off, u64 ssl_free_off)
 {
-	struct bpf_queue	*bqq = qq->queue_be;
-	struct bpf_probes	*p;
-	struct tls_attachment	*ta;
+	struct bpf_queue		*bqq = qq->queue_be;
+	struct bpf_probes		*p;
+	struct quark_tls_attachment	*ta;
 
 	if ((p = quark_get_bpf_probes(qq)) == NULL)
-		return (-1);
+		return (NULL);
 	if ((ta = calloc(1, sizeof(*ta))) == NULL)
-		return (-1);
+		return (NULL);
+	ta->pid = pid;
 
 	/*
 	 * On any failure the partially populated record is rolled back by
 	 * tls_attachment_destroy.
 	 */
-	if ((ta->links[0] = tls_attach_uprobe(
-	    p->progs.uretprobe__ssl_new, 1, path, ssl_new_off,
+	if ((ta->links[0] = tls_attach_uprobe_off(
+	    p->progs.uretprobe__ssl_new, 1, pid, path, ssl_new_off,
 	    "uretprobe__ssl_new")) == NULL)
 		goto fail;
-	if ((ta->links[1] = tls_attach_uprobe(
-	    p->progs.uprobe__ssl_write, 0, path, ssl_write_off,
+	if ((ta->links[1] = tls_attach_uprobe_off(
+	    p->progs.uprobe__ssl_write, 0, pid, path, ssl_write_off,
 	    "uprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((ta->links[2] = tls_attach_uprobe(
-	    p->progs.uretprobe__ssl_write, 1, path, ssl_write_off,
+	if ((ta->links[2] = tls_attach_uprobe_off(
+	    p->progs.uretprobe__ssl_write, 1, pid, path, ssl_write_off,
 	    "uretprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((ta->links[3] = tls_attach_uprobe(
-	    p->progs.uprobe__ssl_read, 0, path, ssl_read_off,
+	if ((ta->links[3] = tls_attach_uprobe_off(
+	    p->progs.uprobe__ssl_read, 0, pid, path, ssl_read_off,
 	    "uprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((ta->links[4] = tls_attach_uprobe(
-	    p->progs.uretprobe__ssl_read, 1, path, ssl_read_off,
+	if ((ta->links[4] = tls_attach_uprobe_off(
+	    p->progs.uretprobe__ssl_read, 1, pid, path, ssl_read_off,
 	    "uretprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((ta->links[5] = tls_attach_uprobe(
-	    p->progs.uprobe__ssl_free, 0, path, ssl_free_off,
+	if ((ta->links[5] = tls_attach_uprobe_off(
+	    p->progs.uprobe__ssl_free, 0, pid, path, ssl_free_off,
 	    "uprobe__ssl_free")) == NULL)
 		goto fail;
 
-	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
-
-	return (0);
+	return (tls_attach_commit(bqq, p, ta));
 
 fail:
 	tls_attachment_destroy(ta);
-	return (-1);
+	return (NULL);
+}
+
+/*
+ * Attach the optional SSL_read_ex/SSL_write_ex entry+return pair by symbol.
+ * Missing _ex symbols are expected on older libraries, so a miss is silent and
+ * leaves both slots NULL rather than failing the whole attach. A half-resolved
+ * pair (only one of the two) is torn down so no return probe runs without its
+ * entry.
+ */
+static void
+tls_attach_sym_ex(struct bpf_probes *p, struct quark_tls_attachment *ta,
+    int pid, const char *path, struct bpf_program *entry,
+    struct bpf_program *ret, const char *sym, int slot_entry, int slot_ret)
+{
+	ta->links[slot_entry] =
+	    tls_attach_uprobe_sym(entry, 0, pid, path, sym, 0);
+	ta->links[slot_ret] =
+	    tls_attach_uprobe_sym(ret, 1, pid, path, sym, 0);
+
+	if (ta->links[slot_entry] == NULL || ta->links[slot_ret] == NULL) {
+		if (ta->links[slot_entry] != NULL) {
+			bpf_link__destroy(ta->links[slot_entry]);
+			ta->links[slot_entry] = NULL;
+		}
+		if (ta->links[slot_ret] != NULL) {
+			bpf_link__destroy(ta->links[slot_ret]);
+			ta->links[slot_ret] = NULL;
+		}
+	}
+}
+
+/*
+ * Symbol attach for a shared library (e.g. libssl). Resolves SSL_new, SSL_free,
+ * SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex (optional) by
+ * name in path. pid must be >= 0: the uprobes are scoped to that process and it
+ * is tracked automatically, so no allow-list management is needed. Returns an
+ * opaque handle, or NULL with errno set on failure.
+ */
+struct quark_tls_attachment *
+quark_queue_tls_attach_sym(struct quark_queue *qq, int pid, const char *path)
+{
+	struct bpf_queue		*bqq = qq->queue_be;
+	struct bpf_probes		*p;
+	struct quark_tls_attachment	*ta;
+
+	if (pid < 0)
+		return (errno = EINVAL, NULL);
+	if ((p = quark_get_bpf_probes(qq)) == NULL)
+		return (NULL);
+	if ((ta = calloc(1, sizeof(*ta))) == NULL)
+		return (NULL);
+	ta->pid = pid;
+
+	if ((ta->links[0] = tls_attach_uprobe_sym(
+	    p->progs.uretprobe__ssl_new, 1, pid, path, "SSL_new", 1)) == NULL)
+		goto fail;
+	if ((ta->links[1] = tls_attach_uprobe_sym(
+	    p->progs.uprobe__ssl_free, 0, pid, path, "SSL_free", 1)) == NULL)
+		goto fail;
+	if ((ta->links[2] = tls_attach_uprobe_sym(
+	    p->progs.uprobe__ssl_write, 0, pid, path, "SSL_write", 1)) == NULL)
+		goto fail;
+	if ((ta->links[3] = tls_attach_uprobe_sym(
+	    p->progs.uretprobe__ssl_write, 1, pid, path, "SSL_write", 1)) == NULL)
+		goto fail;
+	if ((ta->links[4] = tls_attach_uprobe_sym(
+	    p->progs.uprobe__ssl_read, 0, pid, path, "SSL_read", 1)) == NULL)
+		goto fail;
+	if ((ta->links[5] = tls_attach_uprobe_sym(
+	    p->progs.uretprobe__ssl_read, 1, pid, path, "SSL_read", 1)) == NULL)
+		goto fail;
+
+	tls_attach_sym_ex(p, ta, pid, path, p->progs.uprobe__ssl_write_ex,
+	    p->progs.uretprobe__ssl_write_ex, "SSL_write_ex", 6, 7);
+	tls_attach_sym_ex(p, ta, pid, path, p->progs.uprobe__ssl_read_ex,
+	    p->progs.uretprobe__ssl_read_ex, "SSL_read_ex", 8, 9);
+
+	return (tls_attach_commit(bqq, p, ta));
+
+fail:
+	tls_attachment_destroy(ta);
+	return (NULL);
 }

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -804,6 +804,85 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 
 		break;
 	}
+	case EBPF_EVENT_TLS_CONN: {
+		struct ebpf_tls_new_event	*tlsnew;
+		struct quark_tls_conn		*qtc;
+
+		tlsnew = (struct ebpf_tls_new_event *)ev;
+		if ((raw = raw_event_alloc(RAW_TLS_CONN)) == NULL)
+			goto bad;
+
+		raw->pid = tlsnew->pids.tgid;
+		raw->time = ev->ts;
+
+		if ((qtc = malloc(sizeof(*qtc))) == NULL)
+			goto bad;
+		qtc->conn_id = tlsnew->conn_id;
+		qtc->tgid = tlsnew->pids.tgid;
+
+		raw->tls_conn.quark_tls_conn = qtc;
+
+		break;
+	}
+	case EBPF_EVENT_TLS_CHUNK: {
+		struct ebpf_tls_chunk_event	*chunk;
+		struct quark_tls_call		*qtc;
+		size_t				 alloc_len, data_len;
+		void				*data;
+
+		chunk = (struct ebpf_tls_chunk_event *)ev;
+		if ((raw = raw_event_alloc(RAW_TLS_CHUNK)) == NULL)
+			goto bad;
+
+		data = NULL;
+		data_len = 0;
+		if (!chunk->dropped) {
+			FOR_EACH_VARLEN_FIELD(chunk->vl_fields, field) {
+				if (field->type == EBPF_VL_FIELD_TLS_DATA) {
+					data = field->data;
+					data_len = field->size;
+					break;
+				}
+			}
+		}
+
+		raw->pid = chunk->pids.tgid;
+		raw->time = ev->ts;
+
+		alloc_len = sizeof(*qtc) + data_len;
+		if ((qtc = malloc(alloc_len)) == NULL)
+			goto bad;
+
+		qtc->next = NULL;
+		qtc->conn_id = chunk->conn_id;
+		qtc->tgid = chunk->pids.tgid;
+		qtc->direction = chunk->direction == EBPF_TLS_DIR_READ ?
+		    QUARK_TLS_DIR_READ : QUARK_TLS_DIR_WRITE;
+		qtc->call_seq = chunk->call_seq;
+		qtc->chunk_idx = chunk->chunk_idx;
+		qtc->chunk_total = chunk->chunk_total;
+		qtc->call_len = chunk->call_len;
+		qtc->total_len = data_len;
+		qtc->truncated = 0;	/* refined once the chain is aggregated */
+		qtc->dropped = chunk->dropped ? 1 : 0;
+		/*
+		 * A dropped chunk that isn't the last one in the call is a
+		 * hole with more data after it - same hazard as a chunk that
+		 * silently never arrived at all. Only the trailing case is
+		 * safe (equivalent to a clean max_tls_call cap). This covers
+		 * the case where this node ends up being the chain head, or
+		 * a non-head child that was already known-bad before
+		 * quark_can_aggregate_tls() ever runs.
+		 */
+		qtc->gap = (qtc->dropped && chunk->chunk_idx != chunk->chunk_total - 1) ? 1 : 0;
+		qtc->data_len = data_len;
+		if (data != NULL)
+			memcpy(qtc->data, data, data_len);
+
+		raw->tls_chunk.quark_tls_call = qtc;
+
+		break;
+	}
 	default:
 		qwarnx("unhandled type %lu", ev->type);
 		goto bad;
@@ -1058,6 +1137,7 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	 * Maps and other state
 	 */
 	p->rodata->consumer_pid = getpid();
+	p->rodata->max_tls_call = qq->max_tls_call;
 
 	/*
 	 * Unload everything since it has way more than we want
@@ -1256,6 +1336,15 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 
 	if (qq->flags & QQ_GETPID)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);
+
+	if (qq->flags & QQ_TLS) {
+		bpf_program__set_autoload(p->progs.uprobe__ssl_new, 1);
+		bpf_program__set_autoload(p->progs.uretprobe__ssl_new, 1);
+		bpf_program__set_autoload(p->progs.uprobe__ssl_write, 1);
+		bpf_program__set_autoload(p->progs.uretprobe__ssl_write, 1);
+		bpf_program__set_autoload(p->progs.uprobe__ssl_read, 1);
+		bpf_program__set_autoload(p->progs.uretprobe__ssl_read, 1);
+	}
 
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
 	    get_nprocs_conf()) != 0) {
@@ -1495,4 +1584,109 @@ quark_queue_trusted_pid_add(struct quark_queue *qq, u32 pid)
 		return (-1);
 
 	return (0);
+}
+
+int
+quark_queue_track_tgid(struct quark_queue *qq, u32 tgid)
+{
+	struct bpf_probes	*p;
+	struct bpf_map		*m;
+	u8			 v;
+
+	if ((p = quark_get_bpf_probes(qq)) == NULL)
+		return (-1);
+	if ((m = p->maps.tracked_tgids) == NULL)
+		return (errno = EINVAL, -1);
+	v = 1;
+	if (bpf_map__update_elem(m, &tgid, sizeof(tgid),
+	    &v, sizeof(v), BPF_ANY) < 0)
+		return (-1);
+
+	return (0);
+}
+
+int
+quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
+{
+	struct bpf_probes	*p;
+	struct bpf_map		*m;
+
+	if ((p = quark_get_bpf_probes(qq)) == NULL)
+		return (-1);
+	if ((m = p->maps.tracked_tgids) == NULL)
+		return (errno = EINVAL, -1);
+	if (bpf_map__delete_elem(m, &tgid, sizeof(tgid), 0) < 0)
+		return (-1);
+
+	return (0);
+}
+
+static void
+quark_queue_tls_detach(struct bpf_probes *p)
+{
+	if (p->links.uprobe__ssl_new != NULL) {
+		bpf_link__destroy(p->links.uprobe__ssl_new);
+		p->links.uprobe__ssl_new = NULL;
+	}
+	if (p->links.uretprobe__ssl_new != NULL) {
+		bpf_link__destroy(p->links.uretprobe__ssl_new);
+		p->links.uretprobe__ssl_new = NULL;
+	}
+	if (p->links.uprobe__ssl_write != NULL) {
+		bpf_link__destroy(p->links.uprobe__ssl_write);
+		p->links.uprobe__ssl_write = NULL;
+	}
+	if (p->links.uretprobe__ssl_write != NULL) {
+		bpf_link__destroy(p->links.uretprobe__ssl_write);
+		p->links.uretprobe__ssl_write = NULL;
+	}
+	if (p->links.uprobe__ssl_read != NULL) {
+		bpf_link__destroy(p->links.uprobe__ssl_read);
+		p->links.uprobe__ssl_read = NULL;
+	}
+	if (p->links.uretprobe__ssl_read != NULL) {
+		bpf_link__destroy(p->links.uretprobe__ssl_read);
+		p->links.uretprobe__ssl_read = NULL;
+	}
+}
+
+/*
+ * path, ssl_new file offset, ssl_read file offset, ssl_write file offset.
+ * Attaches system-wide (pid=-1): if multiple tracked processes share the
+ * same binary/library, callers should resolve and attach once per distinct
+ * path, not once per process.
+ */
+int
+quark_queue_tls_attach(struct quark_queue *qq, const char *path,
+    u64 ssl_new_off, u64 ssl_read_off, u64 ssl_write_off)
+{
+	struct bpf_probes	*p;
+
+	if ((p = quark_get_bpf_probes(qq)) == NULL)
+		return (-1);
+
+	if ((p->links.uprobe__ssl_new = bpf_program__attach_uprobe(
+	    p->progs.uprobe__ssl_new, 0, -1, path, ssl_new_off)) == NULL)
+		goto fail;
+	if ((p->links.uretprobe__ssl_new = bpf_program__attach_uprobe(
+	    p->progs.uretprobe__ssl_new, 1, -1, path, ssl_new_off)) == NULL)
+		goto fail;
+	if ((p->links.uprobe__ssl_write = bpf_program__attach_uprobe(
+	    p->progs.uprobe__ssl_write, 0, -1, path, ssl_write_off)) == NULL)
+		goto fail;
+	if ((p->links.uretprobe__ssl_write = bpf_program__attach_uprobe(
+	    p->progs.uretprobe__ssl_write, 1, -1, path, ssl_write_off)) == NULL)
+		goto fail;
+	if ((p->links.uprobe__ssl_read = bpf_program__attach_uprobe(
+	    p->progs.uprobe__ssl_read, 0, -1, path, ssl_read_off)) == NULL)
+		goto fail;
+	if ((p->links.uretprobe__ssl_read = bpf_program__attach_uprobe(
+	    p->progs.uretprobe__ssl_read, 1, -1, path, ssl_read_off)) == NULL)
+		goto fail;
+
+	return (0);
+
+fail:
+	quark_queue_tls_detach(p);
+	return (-1);
 }

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -21,9 +21,23 @@
 #include "bpf_probes_skel.h"
 #include "elastic-ebpf/GPL/Events/EbpfEventProto.h"
 
+/*
+ * One TLS uprobe attachment: the six links minted by a single
+ * quark_queue_tls_attach for one binary path. Attach is system-wide per
+ * binary, so a process may be asked to instrument several distinct binaries;
+ * each gets its own record on bqq->tls_attachments. The skeleton keeps only a
+ * single link slot per program, which a second path would overwrite and leak,
+ * so the links are owned here instead.
+ */
+struct tls_attachment {
+	TAILQ_ENTRY(tls_attachment)	 entry;
+	struct bpf_link			*links[6];
+};
+
 struct bpf_queue {
-	struct bpf_probes	*probes;
-	struct ring_buffer	*ringbuf;
+	struct bpf_probes		*probes;
+	struct ring_buffer		*ringbuf;
+	TAILQ_HEAD(, tls_attachment)	 tls_attachments;
 };
 
 static int	bpf_queue_populate(struct quark_queue *);
@@ -97,6 +111,8 @@ ebpf_ctx_to_task(struct quark_queue *qq, struct ebpf_ctx *ebpf_ctx, struct raw_t
 }
 
 static void	tls_forget_tgid(struct bpf_probes *, u32);
+static void	tls_attachment_destroy(struct tls_attachment *);
+static void	quark_queue_tls_detach(struct bpf_queue *);
 
 static struct raw_event *
 ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
@@ -1156,6 +1172,7 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		return (-1);
 
 	qq->queue_be = bqq;
+	TAILQ_INIT(&bqq->tls_attachments);
 	cgroup_fd = -1;
 	cgroup_umount = NULL;
 	btf = NULL;
@@ -1556,6 +1573,7 @@ bpf_queue_close(struct quark_queue *qq)
 
 	if (bqq == NULL)
 		return;
+	quark_queue_tls_detach(bqq);
 	if (bqq->probes != NULL) {
 		bpf_probes__destroy(bqq->probes);
 		bqq->probes = NULL;
@@ -1709,32 +1727,38 @@ quark_queue_untrack_tgid(struct quark_queue *qq, u32 tgid)
 	return (0);
 }
 
+/*
+ * Destroy one attachment's uprobe links and free the record. Safe on a
+ * partially populated record: unset slots are NULL and bpf_link__destroy(NULL)
+ * is a no-op, so this doubles as the rollback for a half-finished attach.
+ */
 static void
-quark_queue_tls_detach(struct bpf_probes *p)
+tls_attachment_destroy(struct tls_attachment *ta)
 {
-	if (p->links.uretprobe__ssl_new != NULL) {
-		bpf_link__destroy(p->links.uretprobe__ssl_new);
-		p->links.uretprobe__ssl_new = NULL;
+	size_t	i;
+
+	for (i = 0; i < nitems(ta->links); i++) {
+		if (ta->links[i] != NULL) {
+			bpf_link__destroy(ta->links[i]);
+			ta->links[i] = NULL;
+		}
 	}
-	if (p->links.uprobe__ssl_free != NULL) {
-		bpf_link__destroy(p->links.uprobe__ssl_free);
-		p->links.uprobe__ssl_free = NULL;
-	}
-	if (p->links.uprobe__ssl_write != NULL) {
-		bpf_link__destroy(p->links.uprobe__ssl_write);
-		p->links.uprobe__ssl_write = NULL;
-	}
-	if (p->links.uretprobe__ssl_write != NULL) {
-		bpf_link__destroy(p->links.uretprobe__ssl_write);
-		p->links.uretprobe__ssl_write = NULL;
-	}
-	if (p->links.uprobe__ssl_read != NULL) {
-		bpf_link__destroy(p->links.uprobe__ssl_read);
-		p->links.uprobe__ssl_read = NULL;
-	}
-	if (p->links.uretprobe__ssl_read != NULL) {
-		bpf_link__destroy(p->links.uretprobe__ssl_read);
-		p->links.uretprobe__ssl_read = NULL;
+	free(ta);
+}
+
+/*
+ * Detach every TLS uprobe attachment. Each quark_queue_tls_attach appended one
+ * record, so tear them all down; the skeleton's single link slot per program
+ * cannot track more than one path. Called from bpf_queue_close.
+ */
+static void
+quark_queue_tls_detach(struct bpf_queue *bqq)
+{
+	struct tls_attachment	*ta;
+
+	while ((ta = TAILQ_FIRST(&bqq->tls_attachments)) != NULL) {
+		TAILQ_REMOVE(&bqq->tls_attachments, ta, entry);
+		tls_attachment_destroy(ta);
 	}
 }
 
@@ -1768,39 +1792,52 @@ int
 quark_queue_tls_attach(struct quark_queue *qq, const char *path,
     u64 ssl_new_off, u64 ssl_read_off, u64 ssl_write_off, u64 ssl_free_off)
 {
+	struct bpf_queue	*bqq = qq->queue_be;
 	struct bpf_probes	*p;
+	struct tls_attachment	*ta;
 
 	if ((p = quark_get_bpf_probes(qq)) == NULL)
 		return (-1);
+	if ((ta = calloc(1, sizeof(*ta))) == NULL)
+		return (-1);
 
-	if ((p->links.uretprobe__ssl_new = tls_attach_uprobe(
+	/*
+	 * The six links go into a per-attach record rather than the skeleton's
+	 * single link slot per program: attach is system-wide per binary, so a
+	 * second path reusing the same program would overwrite the first's link
+	 * and leak it. On any failure the partially populated record is rolled
+	 * back by tls_attachment_destroy.
+	 */
+	if ((ta->links[0] = tls_attach_uprobe(
 	    p->progs.uretprobe__ssl_new, 1, path, ssl_new_off,
 	    "uretprobe__ssl_new")) == NULL)
 		goto fail;
-	if ((p->links.uprobe__ssl_write = tls_attach_uprobe(
+	if ((ta->links[1] = tls_attach_uprobe(
 	    p->progs.uprobe__ssl_write, 0, path, ssl_write_off,
 	    "uprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((p->links.uretprobe__ssl_write = tls_attach_uprobe(
+	if ((ta->links[2] = tls_attach_uprobe(
 	    p->progs.uretprobe__ssl_write, 1, path, ssl_write_off,
 	    "uretprobe__ssl_write")) == NULL)
 		goto fail;
-	if ((p->links.uprobe__ssl_read = tls_attach_uprobe(
+	if ((ta->links[3] = tls_attach_uprobe(
 	    p->progs.uprobe__ssl_read, 0, path, ssl_read_off,
 	    "uprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((p->links.uretprobe__ssl_read = tls_attach_uprobe(
+	if ((ta->links[4] = tls_attach_uprobe(
 	    p->progs.uretprobe__ssl_read, 1, path, ssl_read_off,
 	    "uretprobe__ssl_read")) == NULL)
 		goto fail;
-	if ((p->links.uprobe__ssl_free = tls_attach_uprobe(
+	if ((ta->links[5] = tls_attach_uprobe(
 	    p->progs.uprobe__ssl_free, 0, path, ssl_free_off,
 	    "uprobe__ssl_free")) == NULL)
 		goto fail;
 
+	TAILQ_INSERT_TAIL(&bqq->tls_attachments, ta, entry);
+
 	return (0);
 
 fail:
-	quark_queue_tls_detach(p);
+	tls_attachment_destroy(ta);
 	return (-1);
 }

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -46,6 +46,8 @@ enum ebpf_event_type {
     EBPF_EVENT_PROCESS_LOAD_MODULE          = (1 << 19),
     EBPF_EVENT_NETWORK_DNS_PKT              = (1 << 20),
     EBPF_EVENT_PROCESS_GETPID               = (1 << 21),
+    EBPF_EVENT_TLS_CONN                     = (1 << 22),
+    EBPF_EVENT_TLS_CHUNK                    = (1 << 23),
 };
 
 struct ebpf_event_header {
@@ -74,6 +76,7 @@ enum ebpf_varlen_field_type {
     EBPF_VL_FIELD_MOD_VERSION,
     EBPF_VL_FIELD_MOD_SRCVERSION,
     EBPF_VL_FIELD_DNS_BODY,
+    EBPF_VL_FIELD_TLS_DATA,
 };
 
 // Convenience macro to iterate all the variable length fields in an event
@@ -438,6 +441,36 @@ struct ebpf_dns_event {
     uint32_t orig_len;
     enum ebpf_net_packet_direction direction;
     char packet[]; // must be last
+} __attribute__((packed));
+
+// Fired once at SSL_new entry. Mints conn_id, no payload.
+struct ebpf_tls_new_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    uint64_t conn_id;
+} __attribute__((packed));
+
+enum ebpf_tls_direction {
+    EBPF_TLS_DIR_WRITE = 0, // outgoing request, SSL_write
+    EBPF_TLS_DIR_READ  = 1, // incoming response, SSL_read
+};
+
+// One ring buffer record per chunk of an SSL_read/SSL_write call. Quark
+// aggregates same (conn_id, direction, call_seq) chunks into one
+// quark_tls_call, mirroring EBPF_EVENT_PROCESS_TTY_WRITE's chain.
+struct ebpf_tls_chunk_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    uint64_t conn_id;
+    uint8_t direction;     // enum ebpf_tls_direction, fixed-width on the wire
+    uint64_t call_seq;     // monotonic per (conn_id, direction)
+    uint32_t call_len;     // true SSL_read/SSL_write length, before any capping
+    uint32_t chunk_idx;    // index within this SSL call (0-based)
+    uint32_t chunk_total;  // total chunks actually captured (capped by max_tls_call)
+    uint8_t dropped;       // 1 if this is a drop marker with no data
+
+    // Variable length fields: tls_data
+    struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
 // Basic event statistics

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -446,16 +446,13 @@ struct ebpf_dns_event {
 
 // ebpf_tls_new_event.flags bits.
 //
-// PREFIX_UNKNOWN marks a connection that was not observed from SSL_new but
-// adopted mid-stream by SSL_read/SSL_write because its SSL_new was never seen.
-// Its captured byte stream does not begin at the connection's first byte, so
-// call_seq 0 on it is not the true start.
+// Can always call this something else, it's meant to flag that we have received
+// bytes from Read/Write from a connection that was missed, this can happen if
+// for example we attach in the middle of a connection.
 #define EBPF_TLS_CONN_F_PREFIX_UNKNOWN 0x1
 
-// Fired once when a connection first becomes known: from SSL_new's return probe
-// for connections seen from birth (flags == 0), or from the first
-// SSL_read/SSL_write that adopts a connection whose SSL_new was missed (flags
-// has EBPF_TLS_CONN_F_PREFIX_UNKNOWN).
+// A new connection established, flag is 0 if we attached from the start,
+// If flag is not 0 the connection was adopted mid-stream.
 struct ebpf_tls_new_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
@@ -463,9 +460,8 @@ struct ebpf_tls_new_event {
     uint32_t flags;
 } __attribute__((packed));
 
-// Fired once from SSL_free, the counterpart to ebpf_tls_new_event. Not emitted
-// when a process dies without calling SSL_free (e.g. SIGKILL); consumers must
-// also treat a process exit as closing all of that tgid's connections.
+// Emitted only when a connection is closed properly, if a process is killed
+// with a live connection this will not be emitted.
 struct ebpf_tls_close_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
@@ -484,12 +480,12 @@ struct ebpf_tls_chunk_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     uint64_t conn_id;
-    uint8_t direction;     // enum ebpf_tls_direction, fixed-width on the wire
-    uint64_t call_seq;     // monotonic per (conn_id, direction)
+    uint8_t direction;
+    uint64_t call_seq;
     uint32_t call_len;     // true SSL_read/SSL_write length, before any capping
-    uint32_t chunk_idx;    // index within this SSL call (0-based)
+    uint32_t chunk_idx;
     uint32_t chunk_total;  // total chunks actually captured (capped by max_tls_call)
-    uint8_t dropped;       // 1 if this is a drop marker with no data
+    uint8_t dropped;
 
     // Variable length fields: tls_data
     struct ebpf_varlen_fields_start vl_fields;

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -48,6 +48,7 @@ enum ebpf_event_type {
     EBPF_EVENT_PROCESS_GETPID               = (1 << 21),
     EBPF_EVENT_TLS_CONN                     = (1 << 22),
     EBPF_EVENT_TLS_CHUNK                    = (1 << 23),
+    EBPF_EVENT_TLS_CONN_CLOSE               = (1 << 24),
 };
 
 struct ebpf_event_header {
@@ -443,8 +444,34 @@ struct ebpf_dns_event {
     char packet[]; // must be last
 } __attribute__((packed));
 
-// Fired once at SSL_new entry. Mints conn_id, no payload.
+// ebpf_tls_new_event.flags bits.
+//
+// PREFIX_UNKNOWN marks a connection that was not observed from SSL_new but
+// adopted mid-stream by SSL_read/SSL_write because its SSL_new was never seen
+// (the probes attached, or re-attached, after the connection was already
+// open). Its captured byte stream does not begin at the connection's first
+// byte, so call_seq 0 on it is not the true start -- a consumer that needs the
+// opening bytes (e.g. an HTTP/2 HPACK decoder) must treat such a connection as
+// unreliable rather than trusting it. flags == 0 means the connection was seen
+// from SSL_new and its prefix is intact.
+#define EBPF_TLS_CONN_F_PREFIX_UNKNOWN 0x1
+
+// Fired once when a connection first becomes known: from SSL_new's return probe
+// for connections seen from birth (flags == 0), or from the first
+// SSL_read/SSL_write that adopts a connection whose SSL_new was missed (flags
+// has EBPF_TLS_CONN_F_PREFIX_UNKNOWN). No payload beyond the identity and flags.
 struct ebpf_tls_new_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    uint64_t conn_id;
+    uint32_t flags;
+} __attribute__((packed));
+
+// Fired once from SSL_free, the counterpart to ebpf_tls_new_event. Marks the
+// end of a connection so consumers can release per-conn_id state. Not emitted
+// when a process dies without calling SSL_free (e.g. SIGKILL); consumers must
+// also treat a process exit as closing all of that tgid's connections.
+struct ebpf_tls_close_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
     uint64_t conn_id;

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -482,9 +482,9 @@ struct ebpf_tls_chunk_event {
     uint64_t conn_id;
     uint8_t direction;
     uint64_t call_seq;
-    uint32_t call_len;     // true SSL_read/SSL_write length, before any capping
+    uint32_t call_len;     // true SSL_read/SSL_write length
     uint32_t chunk_idx;
-    uint32_t chunk_total;  // total chunks actually captured (capped by max_tls_call)
+    uint32_t chunk_total;  // total chunks the call was split into
     uint8_t dropped;
 
     // Variable length fields: tls_data

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -447,19 +447,15 @@ struct ebpf_dns_event {
 // ebpf_tls_new_event.flags bits.
 //
 // PREFIX_UNKNOWN marks a connection that was not observed from SSL_new but
-// adopted mid-stream by SSL_read/SSL_write because its SSL_new was never seen
-// (the probes attached, or re-attached, after the connection was already
-// open). Its captured byte stream does not begin at the connection's first
-// byte, so call_seq 0 on it is not the true start -- a consumer that needs the
-// opening bytes (e.g. an HTTP/2 HPACK decoder) must treat such a connection as
-// unreliable rather than trusting it. flags == 0 means the connection was seen
-// from SSL_new and its prefix is intact.
+// adopted mid-stream by SSL_read/SSL_write because its SSL_new was never seen.
+// Its captured byte stream does not begin at the connection's first byte, so
+// call_seq 0 on it is not the true start.
 #define EBPF_TLS_CONN_F_PREFIX_UNKNOWN 0x1
 
 // Fired once when a connection first becomes known: from SSL_new's return probe
 // for connections seen from birth (flags == 0), or from the first
 // SSL_read/SSL_write that adopts a connection whose SSL_new was missed (flags
-// has EBPF_TLS_CONN_F_PREFIX_UNKNOWN). No payload beyond the identity and flags.
+// has EBPF_TLS_CONN_F_PREFIX_UNKNOWN).
 struct ebpf_tls_new_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
@@ -467,8 +463,7 @@ struct ebpf_tls_new_event {
     uint32_t flags;
 } __attribute__((packed));
 
-// Fired once from SSL_free, the counterpart to ebpf_tls_new_event. Marks the
-// end of a connection so consumers can release per-conn_id state. Not emitted
+// Fired once from SSL_free, the counterpart to ebpf_tls_new_event. Not emitted
 // when a process dies without calling SSL_free (e.g. SIGKILL); consumers must
 // also treat a process exit as closing all of that tgid's connections.
 struct ebpf_tls_close_event {

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -25,6 +25,8 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_MEMFD_CREATE   = 11,
     EBPF_EVENTS_STATE_SSL_READ       = 12,
     EBPF_EVENTS_STATE_SSL_WRITE      = 13,
+    EBPF_EVENTS_STATE_SSL_READ_EX    = 14,
+    EBPF_EVENTS_STATE_SSL_WRITE_EX   = 15,
 };
 
 struct ebpf_events_key {
@@ -93,9 +95,14 @@ struct ebpf_events_memfd_create_state {
 // return value gives the bytes actually transferred (min(len, ret)) and drives
 // the per-call sequence bump. Stashing the SSL* lets the return probe re-find
 // the connection, since the return itself only carries the byte count.
+//
+// The SSL_read_ex/SSL_write_ex variants report the transferred count through an
+// out-parameter instead of the return value, so count_ptr holds that pointer
+// for the return probe to read; it is unused (NULL) for plain SSL_read/write.
 struct ebpf_events_ssl_io_state {
     void *ssl;
     void *buf;
+    void *count_ptr;
     u32 len;
 };
 
@@ -114,6 +121,8 @@ struct ebpf_events_state {
         /* struct ebpf_events_fs_create fs_create; nada */
         struct ebpf_events_ssl_io_state ssl_read;
         struct ebpf_events_ssl_io_state ssl_write;
+        struct ebpf_events_ssl_io_state ssl_read_ex;
+        struct ebpf_events_ssl_io_state ssl_write_ex;
     };
 };
 

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -23,6 +23,9 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_CHOWN          = 9,
     EBPF_EVENTS_STATE_FS_CREATE      = 10,
     EBPF_EVENTS_STATE_MEMFD_CREATE   = 11,
+    EBPF_EVENTS_STATE_SSL_READ       = 12,
+    EBPF_EVENTS_STATE_SSL_NEW        = 13,
+    EBPF_EVENTS_STATE_SSL_WRITE      = 14,
 };
 
 struct ebpf_events_key {
@@ -86,6 +89,30 @@ struct ebpf_events_memfd_create_state {
     unsigned int flags;
 };
 
+struct ebpf_events_ssl_read_state {
+    void *buf;
+    u32 len;
+    u64 conn_id;
+};
+
+// SSL_write is captured at uretprobe, not uprobe: entry stashes the caller's
+// buffer and its requested length, and the return value tells us how many
+// bytes were actually consumed (min(len, ret)). This makes capture correct
+// for non-blocking / memory-BIO / partial-write callers, and symmetric with
+// SSL_read, instead of double-counting a buffer that WANT_WRITE retried.
+struct ebpf_events_ssl_write_state {
+    void *buf;
+    u32 len;
+    u64 conn_id;
+};
+
+// SSL_new entry stashes the freshly-minted conn_id here; the return value
+// (the actual SSL* pointer) only exists once the call returns, so the
+// ssl_ptr->conn_id mapping can only be completed at uretprobe time.
+struct ebpf_events_ssl_new_state {
+    u64 conn_id;
+};
+
 struct ebpf_events_state {
     union {
         struct ebpf_events_unlink_state unlink;
@@ -99,6 +126,9 @@ struct ebpf_events_state {
         struct ebpf_events_chown_state chown;
         struct ebpf_events_memfd_create_state memfd;
         /* struct ebpf_events_fs_create fs_create; nada */
+        struct ebpf_events_ssl_read_state ssl_read;
+        struct ebpf_events_ssl_write_state ssl_write;
+        struct ebpf_events_ssl_new_state ssl_new;
     };
 };
 

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -95,10 +95,6 @@ struct ebpf_events_memfd_create_state {
 // return value gives the bytes actually transferred (min(len, ret)) and drives
 // the per-call sequence bump. Stashing the SSL* lets the return probe re-find
 // the connection, since the return itself only carries the byte count.
-//
-// The SSL_read_ex/SSL_write_ex variants report the transferred count through an
-// out-parameter instead of the return value, so count_ptr holds that pointer
-// for the return probe to read; it is unused (NULL) for plain SSL_read/write.
 struct ebpf_events_ssl_io_state {
     void *ssl;
     void *buf;

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -24,8 +24,7 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_FS_CREATE      = 10,
     EBPF_EVENTS_STATE_MEMFD_CREATE   = 11,
     EBPF_EVENTS_STATE_SSL_READ       = 12,
-    EBPF_EVENTS_STATE_SSL_NEW        = 13,
-    EBPF_EVENTS_STATE_SSL_WRITE      = 14,
+    EBPF_EVENTS_STATE_SSL_WRITE      = 13,
 };
 
 struct ebpf_events_key {
@@ -89,28 +88,18 @@ struct ebpf_events_memfd_create_state {
     unsigned int flags;
 };
 
-struct ebpf_events_ssl_read_state {
+// SSL_read and SSL_write are both captured across entry+return. The entry
+// stashes the SSL object and the caller's buffer plus requested length; the
+// return value gives the bytes actually transferred (min(len, ret)) and drives
+// the per-call sequence bump. Stashing the SSL* lets the return probe re-find
+// the connection, since the return itself only carries the byte count. This
+// keeps capture correct for non-blocking / memory-BIO / partial callers (never
+// a WANT_* retry's full buffer, never an unfilled read) and symmetric for both
+// directions.
+struct ebpf_events_ssl_io_state {
+    void *ssl;
     void *buf;
     u32 len;
-    u64 conn_id;
-};
-
-// SSL_write is captured at uretprobe, not uprobe: entry stashes the caller's
-// buffer and its requested length, and the return value tells us how many
-// bytes were actually consumed (min(len, ret)). This makes capture correct
-// for non-blocking / memory-BIO / partial-write callers, and symmetric with
-// SSL_read, instead of double-counting a buffer that WANT_WRITE retried.
-struct ebpf_events_ssl_write_state {
-    void *buf;
-    u32 len;
-    u64 conn_id;
-};
-
-// SSL_new entry stashes the freshly-minted conn_id here; the return value
-// (the actual SSL* pointer) only exists once the call returns, so the
-// ssl_ptr->conn_id mapping can only be completed at uretprobe time.
-struct ebpf_events_ssl_new_state {
-    u64 conn_id;
 };
 
 struct ebpf_events_state {
@@ -126,9 +115,8 @@ struct ebpf_events_state {
         struct ebpf_events_chown_state chown;
         struct ebpf_events_memfd_create_state memfd;
         /* struct ebpf_events_fs_create fs_create; nada */
-        struct ebpf_events_ssl_read_state ssl_read;
-        struct ebpf_events_ssl_write_state ssl_write;
-        struct ebpf_events_ssl_new_state ssl_new;
+        struct ebpf_events_ssl_io_state ssl_read;
+        struct ebpf_events_ssl_io_state ssl_write;
     };
 };
 

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -92,10 +92,7 @@ struct ebpf_events_memfd_create_state {
 // stashes the SSL object and the caller's buffer plus requested length; the
 // return value gives the bytes actually transferred (min(len, ret)) and drives
 // the per-call sequence bump. Stashing the SSL* lets the return probe re-find
-// the connection, since the return itself only carries the byte count. This
-// keeps capture correct for non-blocking / memory-BIO / partial callers (never
-// a WANT_* retry's full buffer, never an unfilled read) and symmetric for both
-// directions.
+// the connection, since the return itself only carries the byte count.
 struct ebpf_events_ssl_io_state {
     void *ssl;
     void *buf;

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -25,8 +25,6 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_MEMFD_CREATE   = 11,
     EBPF_EVENTS_STATE_SSL_READ       = 12,
     EBPF_EVENTS_STATE_SSL_WRITE      = 13,
-    EBPF_EVENTS_STATE_SSL_READ_EX    = 14,
-    EBPF_EVENTS_STATE_SSL_WRITE_EX   = 15,
 };
 
 struct ebpf_events_key {
@@ -98,7 +96,6 @@ struct ebpf_events_memfd_create_state {
 struct ebpf_events_ssl_io_state {
     void *ssl;
     void *buf;
-    void *count_ptr;
     u32 len;
 };
 
@@ -117,8 +114,6 @@ struct ebpf_events_state {
         /* struct ebpf_events_fs_create fs_create; nada */
         struct ebpf_events_ssl_io_state ssl_read;
         struct ebpf_events_ssl_io_state ssl_write;
-        struct ebpf_events_ssl_io_state ssl_read_ex;
-        struct ebpf_events_ssl_io_state ssl_write_ex;
     };
 };
 

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -122,7 +122,6 @@ static long tls_emit_chunk(u32 idx, void *ctx)
     task               = (struct task_struct *)bpf_get_current_task();
     event->hdr.type    = EBPF_EVENT_TLS_CHUNK;
     event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
     ebpf_pid_info__fill(&event->pids, task);
     event->conn_id      = cctx->conn_id;
     event->direction    = (uint8_t)cctx->direction;
@@ -205,7 +204,6 @@ static void tls_emit_conn(u64 conn_id, u32 flags)
     task               = (struct task_struct *)bpf_get_current_task();
     event->hdr.type    = EBPF_EVENT_TLS_CONN;
     event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
     ebpf_pid_info__fill(&event->pids, task);
     event->conn_id = conn_id;
     event->flags   = flags;
@@ -322,7 +320,6 @@ int BPF_UPROBE(uprobe__ssl_free, void *ssl)
     task               = (struct task_struct *)bpf_get_current_task();
     event->hdr.type    = EBPF_EVENT_TLS_CONN_CLOSE;
     event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
     ebpf_pid_info__fill(&event->pids, task);
     event->conn_id = conn_id;
 

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -19,13 +19,7 @@
 
 // Allow-list of TGIDs to capture TLS from. Opposite of trusted_pids (a
 // deny-list): a TGID must be present here for a connection to be minted.
-// Populated by quark_queue_track_tgid()/untrack_tgid(). SSL_new consults it on
-// every call. SSL_read/SSL_write consult it only when they miss tls_conns, to
-// decide whether the miss is a tracked connection whose SSL_new was never seen
-// -- which must be adopted, not dropped -- or an untracked caller to ignore.
-// SSL_free needs no check: it only acts on an existing tls_conns entry, and
-// only gated paths ever create one. A tls_conns hit is therefore always
-// capture-worthy, so the capture hot path stays a single lookup.
+// Populated by quark_queue_track_tgid()/untrack_tgid().
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
@@ -39,11 +33,8 @@ static bool ebpf_events_is_tracked_tgid()
     return bpf_map_lookup_elem(&tracked_tgids, &tgid) != NULL;
 }
 
-// Global monotonic connection-id counter, bumped once per SSL_new. A single
-// array cell (not a per-tgid hash) so conn_id is unique across the whole
-// system -- consumers can key on conn_id alone -- and it is never reused, so a
-// closed-then-reopened SSL object at the same address gets a distinct id.
-// conn_id 0 is never issued, it is reserved as the "unset" sentinel.
+// Global monotonic connection-id counter, bumped once per SSL_new. conn_id 0 is
+// never issued, it is reserved as the "unset" sentinel.
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(key_size, sizeof(u32));
@@ -63,33 +54,20 @@ static u64 tls_mint_conn_id(void)
 }
 
 // (tgid, ssl_ptr) -> per-connection state, established at SSL_new's uretprobe
-// (once the SSL* return value exists) and torn down at SSL_free. Every
-// SSL_read/SSL_write return probe looks the connection up here to resolve its
-// conn_id and bump the matching direction's call_seq in place.
+// and torn down at SSL_free.
 //
 // The key must include tgid: an SSL* is only unique within one address space,
 // so two tracked processes can hold objects at the same virtual address --
-// keying on the pointer alone would cross-attribute them. tgid handles this
-// spatial (concurrent) collision; SSL_free handles temporal reuse within a
-// process by deleting the entry before the address can be recycled.
-//
-// Plain hash + BPF_F_NO_PREALLOC, deleted on SSL_free -- the same shape the
-// network probe's sk_to_tgid uses, freed on tcp_close. Unlike tcp_close,
-// SSL_free is userspace and does not run on SIGKILL, so a killed process's
-// entries are reclaimed instead by the exit-driven sweep in bpf_queue.c
-// (untrack). A reused pointer whose owner was killed is corrected regardless:
-// SSL_new overwrites its entry (BPF_ANY).
+// keying on the pointer alone would cross-attribute them.
 struct tls_ssl_key {
     u32 tgid;
     u64 ssl;
 } __attribute__((packed));
 
 // call_seq is monotonic per (conn_id, direction), incremented once per
-// SSL_read/SSL_write call regardless of how many chunks it is split into. It
-// lives here, next to conn_id, so the read/write return probe resolves the
-// connection and advances its sequence in a single map lookup. flags carries
-// EBPF_TLS_CONN_F_* (currently only PREFIX_UNKNOWN, set when the connection was
-// adopted mid-stream rather than seen from SSL_new).
+// SSL_read/SSL_write call regardless of how many chunks it is split into. flags
+// carries EBPF_TLS_CONN_F_* (currently only PREFIX_UNKNOWN, set when the
+// connection was adopted mid-stream rather than seen from SSL_new).
 struct tls_conn {
     u64 conn_id;
     u64 read_seq;
@@ -106,12 +84,11 @@ struct {
 } tls_conns SEC(".maps");
 
 // Max bytes captured per SSL_read/SSL_write call, set by quark_queue_open()
-// from quark_queue_attr.max_tls_call before the object is loaded, same
-// pattern as consumer_pid in Helpers.h.
+// before the object is loaded, same pattern as consumer_pid in Helpers.h.
 const volatile u32 max_tls_call = 0;
 
-// Per-chunk size. Kept well under half of event_buffer_map's 128 KiB ceiling
-// (see Varlen.h), same headroom rule TTY_OUT_MAX follows in Process/Probe.bpf.c.
+// Per-chunk size. Kept well under half of event_buffer_map's 128 KiB ceiling,
+// same headroom rule TTY_OUT_MAX follows in Process/Probe.bpf.c.
 #define TLS_CHUNK_MAX 32768u
 
 struct tls_chunk_ctx {
@@ -170,8 +147,6 @@ static long tls_emit_chunk(u32 idx, void *ctx)
          * This chunk's bytes are unreadable, but later chunks in the same
          * call read from different offsets into the same buffer and may
          * still succeed - keep going rather than aborting the whole call.
-         * quark's aggregation distinguishes this (a known, marked hole)
-         * from a chunk that never arrives at all.
          */
         event->dropped = 1;
         ebpf_vl_field__set_size(&event->vl_fields, field, 0);
@@ -184,13 +159,7 @@ static long tls_emit_chunk(u32 idx, void *ctx)
         /*
          * The full chunk didn't fit - the ring buffer is under enough
          * pressure that quark's existing "lost" stat will already be
-         * incremented for it. Retry with a minimal drop marker instead:
-         * far smaller, so it has a real chance of fitting even when the
-         * full chunk didn't, and it lets quark's aggregation see this
-         * chunk_idx as a known, marked hole rather than a silent gap
-         * that has to be inferred from a missing index. If this second,
-         * much smaller write also fails, the buffer is genuinely
-         * exhausted and there is nothing further to do here.
+         * incremented for it. Retry with a minimal drop marker instead.
          */
         event->dropped = 1;
         ebpf_vl_fields__init(&event->vl_fields);
@@ -202,10 +171,7 @@ static long tls_emit_chunk(u32 idx, void *ctx)
     return 0;
 }
 
-// Emits one SSL_read/SSL_write call as one or more chunks. conn_id and
-// call_seq are resolved by the caller from tls_conns; len is the byte count
-// actually transferred (the uretprobe's return value), so it is never a
-// WANT_* retry's full buffer nor an unfilled read.
+// Emits one SSL_read/SSL_write call as one or more chunks.
 static void tls_emit_call(u64 conn_id, const void *base, u32 len,
                           enum ebpf_tls_direction direction, u64 call_seq)
 {
@@ -248,15 +214,11 @@ static void tls_emit_conn(u64 conn_id, u32 flags)
 }
 
 // Adopts a connection whose SSL_new was never observed: mints a fresh conn_id,
-// records it flagged PREFIX_UNKNOWN, and announces it. This is the miss path of
-// SSL_read/SSL_write -- the first captured call on a connection that was
-// already open when the probes attached. Surfacing it (rather than dropping the
-// bytes silently) is deliberate: silence would lose traffic with no signal it
-// happened, while the flag lets a consumer decide per protocol whether the
-// missing prefix is recoverable. The announce is withheld until the insert is
-// confirmed so a full map never yields an establish with no state behind it;
-// the caller re-resolves the entry from the map (rather than this returning a
-// map-value pointer, which not every verifier accepts across a call).
+// records it flagged PREFIX_UNKNOWN, and announces it. The announce is withheld
+// until the insert is confirmed so a full map never yields an establish with no
+// state behind it; the caller re-resolves the entry from the map (rather than
+// this returning a map-value pointer, which not every verifier accepts across a
+// call).
 static void tls_adopt_conn(struct tls_ssl_key *key)
 {
     struct tls_conn conn = {};
@@ -274,8 +236,7 @@ static void tls_adopt_conn(struct tls_ssl_key *key)
 }
 
 // SSL_new has no entry probe: the SSL* it returns is the map key, so nothing
-// useful can be done until the return. Mint the conn_id, record the
-// connection, and announce it, all here.
+// useful can be done until the return.
 SEC("uretprobe")
 int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
 {
@@ -308,9 +269,8 @@ out:
     return 0;
 }
 
-// SSL_free is the connection teardown. Announce the close and drop the map
-// entry so its (tgid, ssl_ptr) slot can be reused cleanly. If the SSL was
-// never tracked (no entry) this is a no-op.
+// SSL_free is the connection teardown. If the SSL was never tracked (no entry)
+// this is a no-op.
 SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_free, void *ssl)
 {
@@ -353,15 +313,9 @@ out:
     return 0;
 }
 
-// The read/write entry probes stash the caller's buffer for the matching
-// return probe. They gate on the same trusted deny-list / tracked allow-list as
-// the capture path: a caller that is not tracked can never be captured at
-// return (a tls_conns miss is only adopted for a tracked tgid), so stashing its
-// arguments would only add churn to the per-task state map -- a bounded LRU
-// shared with the other probes -- and risk evicting in-flight state that can be
-// captured. Gating here keeps that map populated only by callers that may
-// actually be captured. Adoption is unaffected: a tracked tgid whose SSL_new
-// was missed still passes the gate, stashes, and is adopted at return.
+// The read/write entry probes stash the caller's buffer for the matching return
+// probe. They gate on the same trusted deny-list / tracked allow-list as the
+// capture path.
 SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
 {
@@ -407,8 +361,7 @@ int BPF_URETPROBE(uretprobe__ssl_write, int ret)
     conn = bpf_map_lookup_elem(&tls_conns, &key);
     if (!conn) {
         // Miss: SSL_new was never seen for this object. Adopt it only for a
-        // tracked, non-trusted tgid (an untracked caller of a shared libssl
-        // stays silent); these checks are paid only here, off the hot path.
+        // tracked, non-trusted tgid; these checks are off the hot path.
         if (ebpf_events_is_trusted_pid())
             goto out;
         if (!ebpf_events_is_tracked_tgid())
@@ -474,9 +427,7 @@ int BPF_URETPROBE(uretprobe__ssl_read, int ret)
     };
     conn = bpf_map_lookup_elem(&tls_conns, &key);
     if (!conn) {
-        // Miss: SSL_new was never seen for this object. Adopt it only for a
-        // tracked, non-trusted tgid (an untracked caller of a shared libssl
-        // stays silent); these checks are paid only here, off the hot path.
+        // Miss path, same as uretprobe__ssl_write above.
         if (ebpf_events_is_trusted_pid())
             goto out;
         if (!ebpf_events_is_tracked_tgid())

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -313,6 +313,40 @@ out:
     return 0;
 }
 
+// Resolves the connection for a completed read/write and emits its payload.
+// Shared by the plain and _ex return probes: a hit is captured directly (the
+// hit is the filter), a miss is adopted mid-stream for a tracked, non-trusted
+// tgid, and the per-direction call_seq is advanced only for a captured call.
+static void tls_capture_io(void *ssl, const void *buf, u32 len,
+                           enum ebpf_tls_direction direction)
+{
+    struct tls_ssl_key key;
+    struct tls_conn *conn;
+    u64 seq;
+
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)ssl,
+    };
+    conn = bpf_map_lookup_elem(&tls_conns, &key);
+    if (!conn) {
+        if (ebpf_events_is_trusted_pid())
+            return;
+        if (!ebpf_events_is_tracked_tgid())
+            return;
+        tls_adopt_conn(&key);
+        conn = bpf_map_lookup_elem(&tls_conns, &key);
+        if (!conn)
+            return;
+    }
+
+    if (direction == EBPF_TLS_DIR_WRITE)
+        seq = __sync_fetch_and_add(&conn->write_seq, 1);
+    else
+        seq = __sync_fetch_and_add(&conn->read_seq, 1);
+    tls_emit_call(conn->conn_id, buf, len, direction, seq);
+}
+
 // The read/write entry probes stash the caller's buffer for the matching return
 // probe. They gate on the same trusted deny-list / tracked allow-list as the
 // capture path.
@@ -342,9 +376,6 @@ SEC("uretprobe")
 int BPF_URETPROBE(uretprobe__ssl_write, int ret)
 {
     struct ebpf_events_state *state;
-    struct tls_ssl_key key;
-    struct tls_conn *conn;
-    u64 seq;
 
     preempt_disable();
 
@@ -354,27 +385,8 @@ int BPF_URETPROBE(uretprobe__ssl_write, int ret)
     if (ret <= 0 || (u32)ret > state->ssl_write.len)
         goto out;
 
-    key = (struct tls_ssl_key){
-        .tgid = bpf_get_current_pid_tgid() >> 32,
-        .ssl  = (u64)state->ssl_write.ssl,
-    };
-    conn = bpf_map_lookup_elem(&tls_conns, &key);
-    if (!conn) {
-        // Miss: SSL_new was never seen for this object. Adopt it only for a
-        // tracked, non-trusted tgid; these checks are off the hot path.
-        if (ebpf_events_is_trusted_pid())
-            goto out;
-        if (!ebpf_events_is_tracked_tgid())
-            goto out;
-        tls_adopt_conn(&key);
-        conn = bpf_map_lookup_elem(&tls_conns, &key);
-        if (!conn)
-            goto out;
-    }
-
-    seq = __sync_fetch_and_add(&conn->write_seq, 1);
-    tls_emit_call(conn->conn_id, state->ssl_write.buf, (u32)ret,
-                  EBPF_TLS_DIR_WRITE, seq);
+    tls_capture_io(state->ssl_write.ssl, state->ssl_write.buf, (u32)ret,
+                   EBPF_TLS_DIR_WRITE);
 
 out:
     ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_WRITE);
@@ -409,9 +421,6 @@ SEC("uretprobe")
 int BPF_URETPROBE(uretprobe__ssl_read, int ret)
 {
     struct ebpf_events_state *state;
-    struct tls_ssl_key key;
-    struct tls_conn *conn;
-    u64 seq;
 
     preempt_disable();
 
@@ -421,29 +430,118 @@ int BPF_URETPROBE(uretprobe__ssl_read, int ret)
     if (ret <= 0 || (u32)ret > state->ssl_read.len)
         goto out;
 
-    key = (struct tls_ssl_key){
-        .tgid = bpf_get_current_pid_tgid() >> 32,
-        .ssl  = (u64)state->ssl_read.ssl,
-    };
-    conn = bpf_map_lookup_elem(&tls_conns, &key);
-    if (!conn) {
-        // Miss path, same as uretprobe__ssl_write above.
-        if (ebpf_events_is_trusted_pid())
-            goto out;
-        if (!ebpf_events_is_tracked_tgid())
-            goto out;
-        tls_adopt_conn(&key);
-        conn = bpf_map_lookup_elem(&tls_conns, &key);
-        if (!conn)
-            goto out;
-    }
-
-    seq = __sync_fetch_and_add(&conn->read_seq, 1);
-    tls_emit_call(conn->conn_id, state->ssl_read.buf, (u32)ret,
-                  EBPF_TLS_DIR_READ, seq);
+    tls_capture_io(state->ssl_read.ssl, state->ssl_read.buf, (u32)ret,
+                   EBPF_TLS_DIR_READ);
 
 out:
     ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_READ);
+    preempt_enable();
+    return 0;
+}
+
+// SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *readbytes) and
+// SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) report
+// the transferred count through the out-parameter and return 1 on success,
+// unlike SSL_read/SSL_write which return the count directly. The entry stashes
+// the count pointer alongside the buffer; the return reads it once ret == 1.
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_write_ex, void *ssl, const void *buf, u64 num,
+               void *written)
+{
+    struct ebpf_events_state state = {};
+
+    preempt_disable();
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
+    state.ssl_write_ex.ssl       = ssl;
+    state.ssl_write_ex.buf       = (void *)buf;
+    state.ssl_write_ex.count_ptr = written;
+    state.ssl_write_ex.len       = (u32)num;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE_EX, &state);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_write_ex, int ret)
+{
+    struct ebpf_events_state *state;
+    u64 count;
+
+    preempt_disable();
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_WRITE_EX);
+    if (!state)
+        goto out;
+    if (ret != 1 || !state->ssl_write_ex.count_ptr)
+        goto out;
+    if (bpf_probe_read_user(&count, sizeof(count), state->ssl_write_ex.count_ptr))
+        goto out;
+    if (count == 0 || count > state->ssl_write_ex.len)
+        goto out;
+
+    tls_capture_io(state->ssl_write_ex.ssl, state->ssl_write_ex.buf,
+                   (u32)count, EBPF_TLS_DIR_WRITE);
+
+out:
+    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_WRITE_EX);
+    preempt_enable();
+    return 0;
+}
+
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_read_ex, void *ssl, void *buf, u64 num,
+               void *readbytes)
+{
+    struct ebpf_events_state state = {};
+
+    preempt_disable();
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
+    state.ssl_read_ex.ssl       = ssl;
+    state.ssl_read_ex.buf       = buf;
+    state.ssl_read_ex.count_ptr = readbytes;
+    state.ssl_read_ex.len       = (u32)num;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_READ_EX, &state);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_read_ex, int ret)
+{
+    struct ebpf_events_state *state;
+    u64 count;
+
+    preempt_disable();
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_READ_EX);
+    if (!state)
+        goto out;
+    if (ret != 1 || !state->ssl_read_ex.count_ptr)
+        goto out;
+    if (bpf_probe_read_user(&count, sizeof(count), state->ssl_read_ex.count_ptr))
+        goto out;
+    if (count == 0 || count > state->ssl_read_ex.len)
+        goto out;
+
+    tls_capture_io(state->ssl_read_ex.ssl, state->ssl_read_ex.buf,
+                   (u32)count, EBPF_TLS_DIR_READ);
+
+out:
+    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_READ_EX);
     preempt_enable();
     return 0;
 }

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+
+/*
+ * Copyright (C) 2026 Elasticsearch BV
+ *
+ * This software is dual-licensed under the BSD 2-Clause and GPL v2 licenses.
+ * You may choose either one of them if you use this software.
+ */
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "Helpers.h"
+#include "State.h"
+#include "Varlen.h"
+
+// Allow-list of TGIDs to capture TLS from. Opposite of trusted_pids (a
+// deny-list): a TGID must be present here for any uprobe below to do
+// anything. Populated by quark_queue_track_tgid()/untrack_tgid().
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u8));
+    __uint(max_entries, 512);
+} tracked_tgids SEC(".maps");
+
+static bool ebpf_events_is_tracked_tgid()
+{
+    u32 tgid = bpf_get_current_pid_tgid() >> 32;
+    return bpf_map_lookup_elem(&tracked_tgids, &tgid) != NULL;
+}
+
+// Global monotonic connection-id counter, bumped once per SSL_new. A single
+// array cell (not a per-tgid hash) so conn_id is unique across the whole
+// system -- consumers can key on conn_id alone -- and nothing accumulates or
+// needs cleanup when a process exits. conn_id 0 is never issued, it is
+// reserved as the "unset" sentinel.
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u64));
+    __uint(max_entries, 1);
+} tls_conn_id_ctr SEC(".maps");
+
+static u64 tls_mint_conn_id(void)
+{
+    u32 zero = 0;
+    u64 *ctr = bpf_map_lookup_elem(&tls_conn_id_ctr, &zero);
+
+    if (!ctr)
+        return 0;
+
+    return __sync_fetch_and_add(ctr, 1) + 1;
+}
+
+// (tgid, ssl_ptr) -> conn_id, completed at SSL_new's uretprobe once the SSL*
+// return value exists. Every SSL_read/SSL_write uprobe looks the conn_id up
+// here. The key must include tgid: an SSL* is only unique within one address
+// space, so two tracked processes can legitimately hold objects at the same
+// virtual address -- keying on the pointer alone would cross-attribute them.
+// LRU (rather than a plain hash) so freed-but-not-reused SSL objects age out
+// on their own -- there is no SSL_free uprobe, so nothing else prunes this --
+// while a reused pointer is corrected by SSL_new overwriting its entry.
+struct tls_ssl_key {
+    u32 tgid;
+    u64 ssl;
+} __attribute__((packed));
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct tls_ssl_key);
+    __type(value, u64);
+    __uint(max_entries, 8192);
+} tls_ssl_to_conn SEC(".maps");
+
+static u64 tls_conn_id_for_ssl(u32 tgid, void *ssl)
+{
+    struct tls_ssl_key key = { .tgid = tgid, .ssl = (u64)ssl };
+    u64 *conn_id = bpf_map_lookup_elem(&tls_ssl_to_conn, &key);
+
+    return conn_id ? *conn_id : 0;
+}
+
+// Monotonic call_seq per (conn_id, direction), incremented once per
+// SSL_read/SSL_write call regardless of how many chunks it is split into.
+struct tls_seq_key {
+    u64 conn_id;
+    u32 direction;
+} __attribute__((packed));
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct tls_seq_key);
+    __type(value, u64);
+    __uint(max_entries, 8192);
+} tls_call_seq SEC(".maps");
+
+static u64 tls_next_call_seq(u64 conn_id, enum ebpf_tls_direction direction)
+{
+    struct tls_seq_key key = { .conn_id = conn_id, .direction = direction };
+    u64 init = 0;
+    u64 *ctr;
+
+    bpf_map_update_elem(&tls_call_seq, &key, &init, BPF_NOEXIST);
+    ctr = bpf_map_lookup_elem(&tls_call_seq, &key);
+    if (!ctr)
+        return 0;
+
+    return __sync_fetch_and_add(ctr, 1);
+}
+
+// Max bytes captured per SSL_read/SSL_write call, set by quark_queue_open()
+// from quark_queue_attr.max_tls_call before the object is loaded, same
+// pattern as consumer_pid in Helpers.h.
+const volatile u32 max_tls_call = 0;
+
+// Per-chunk size. Kept well under half of event_buffer_map's 128 KiB ceiling
+// (see Varlen.h), same headroom rule TTY_OUT_MAX follows in Process/Probe.bpf.c.
+#define TLS_CHUNK_MAX 32768u
+
+struct tls_chunk_ctx {
+    const void *base;
+    u64 conn_id;
+    enum ebpf_tls_direction direction;
+    u64 call_seq;
+    u32 call_len;     // true call length, before max_tls_call capping
+    u32 captured_len; // min(call_len, max_tls_call)
+    u32 chunk_total;
+};
+
+static long tls_emit_chunk(u32 idx, void *ctx)
+{
+    struct tls_chunk_ctx *cctx = ctx;
+    struct ebpf_tls_chunk_event *event;
+    struct ebpf_varlen_field *field;
+    struct task_struct *task;
+    u32 off, len_cap;
+
+    if (idx >= cctx->chunk_total)
+        return 1;
+
+    off = idx * TLS_CHUNK_MAX;
+
+    event = get_event_buffer();
+    if (!event)
+        return 1;
+
+    task               = (struct task_struct *)bpf_get_current_task();
+    event->hdr.type    = EBPF_EVENT_TLS_CHUNK;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    ebpf_pid_info__fill(&event->pids, task);
+    event->conn_id      = cctx->conn_id;
+    event->direction    = (uint8_t)cctx->direction;
+    event->call_seq     = cctx->call_seq;
+    event->call_len     = cctx->call_len;
+    event->chunk_idx    = idx;
+    event->chunk_total  = cctx->chunk_total;
+    event->dropped      = 0;
+
+    ebpf_vl_fields__init(&event->vl_fields);
+    field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_TLS_DATA);
+
+    /*
+     * DO NOT REMOVE THE CASTS, see the identical warning in
+     * Process/Probe.bpf.c's output_tty_event(): narrowing 64->32bit loses
+     * verifier bound tracking on older verifiers, keep this all 32bit.
+     */
+    len_cap = (u32)cctx->captured_len - off;
+    len_cap = (u32)(len_cap > TLS_CHUNK_MAX ? TLS_CHUNK_MAX : len_cap);
+
+    if (bpf_probe_read_user(field->data, len_cap, (const char *)cctx->base + off)) {
+        /*
+         * This chunk's bytes are unreadable, but later chunks in the same
+         * call read from different offsets into the same buffer and may
+         * still succeed - keep going rather than aborting the whole call.
+         * quark's aggregation distinguishes this (a known, marked hole)
+         * from a chunk that never arrives at all.
+         */
+        event->dropped = 1;
+        ebpf_vl_field__set_size(&event->vl_fields, field, 0);
+        ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+        return 0;
+    }
+
+    ebpf_vl_field__set_size(&event->vl_fields, field, len_cap);
+    if (ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0) < 0) {
+        /*
+         * The full chunk didn't fit - the ring buffer is under enough
+         * pressure that quark's existing "lost" stat will already be
+         * incremented for it. Retry with a minimal drop marker instead:
+         * far smaller, so it has a real chance of fitting even when the
+         * full chunk didn't, and it lets quark's aggregation see this
+         * chunk_idx as a known, marked hole rather than a silent gap
+         * that has to be inferred from a missing index. If this second,
+         * much smaller write also fails, the buffer is genuinely
+         * exhausted and there is nothing further to do here.
+         */
+        event->dropped = 1;
+        ebpf_vl_fields__init(&event->vl_fields);
+        field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_TLS_DATA);
+        ebpf_vl_field__set_size(&event->vl_fields, field, 0);
+        ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
+    }
+
+    return 0;
+}
+
+// conn_id is resolved and stashed by the SSL_read/SSL_write uprobe at entry;
+// len is the byte count actually transferred, taken from the uretprobe's
+// return value. Both directions capture at return so len reflects what really
+// moved (never a WANT_WRITE retry's full buffer, never an unfilled read).
+static void tls_emit_call(u64 conn_id, const void *base, u32 len,
+                          enum ebpf_tls_direction direction)
+{
+    struct tls_chunk_ctx cctx = {};
+
+    if (len == 0)
+        return;
+
+    cctx.base         = base;
+    cctx.conn_id      = conn_id;
+    cctx.direction    = direction;
+    cctx.call_seq     = tls_next_call_seq(conn_id, direction);
+    cctx.call_len     = len;
+    cctx.captured_len = max_tls_call != 0 && len > max_tls_call ? max_tls_call : len;
+    cctx.chunk_total  = (cctx.captured_len + TLS_CHUNK_MAX - 1) / TLS_CHUNK_MAX;
+
+    bpf_loop(cctx.chunk_total, tls_emit_chunk, &cctx, 0);
+}
+
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_new)
+{
+    struct ebpf_events_state state = {};
+
+    preempt_disable();
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
+    state.ssl_new.conn_id = tls_mint_conn_id();
+    if (state.ssl_new.conn_id == 0)
+        goto out;
+
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_NEW, &state);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
+{
+    struct ebpf_events_state *state;
+    struct ebpf_tls_new_event *event;
+    struct task_struct *task;
+    struct tls_ssl_key key;
+
+    preempt_disable();
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_NEW);
+    if (!state)
+        goto out;
+    if (!ssl || state->ssl_new.conn_id == 0)
+        goto out;
+
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)ssl,
+    };
+    bpf_map_update_elem(&tls_ssl_to_conn, &key, &state->ssl_new.conn_id, BPF_ANY);
+
+    event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    task               = (struct task_struct *)bpf_get_current_task();
+    event->hdr.type    = EBPF_EVENT_TLS_CONN;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    ebpf_pid_info__fill(&event->pids, task);
+    event->conn_id = state->ssl_new.conn_id;
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_NEW);
+    preempt_enable();
+    return 0;
+}
+
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
+{
+    struct ebpf_events_state state = {};
+    u32 tgid;
+
+    preempt_disable();
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
+    tgid                    = bpf_get_current_pid_tgid() >> 32;
+    state.ssl_write.buf     = (void *)buf;
+    state.ssl_write.len     = (u32)num;
+    state.ssl_write.conn_id = tls_conn_id_for_ssl(tgid, ssl);
+    if (state.ssl_write.conn_id == 0)
+        goto out;
+
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE, &state);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_write, int ret)
+{
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_WRITE);
+    if (!state || state->ssl_write.conn_id == 0)
+        goto out;
+
+    if (ret > 0 && (u32)ret <= state->ssl_write.len)
+        tls_emit_call(state->ssl_write.conn_id, state->ssl_write.buf,
+                      (u32)ret, EBPF_TLS_DIR_WRITE);
+
+out:
+    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_WRITE);
+    preempt_enable();
+    return 0;
+}
+
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_read, void *ssl, void *buf, int num)
+{
+    struct ebpf_events_state state = {};
+    u32 tgid;
+
+    preempt_disable();
+
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
+    tgid                   = bpf_get_current_pid_tgid() >> 32;
+    state.ssl_read.buf     = buf;
+    state.ssl_read.len     = (u32)num;
+    state.ssl_read.conn_id = tls_conn_id_for_ssl(tgid, ssl);
+    if (state.ssl_read.conn_id == 0)
+        goto out;
+
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_READ, &state);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_read, int ret)
+{
+    struct ebpf_events_state *state;
+
+    preempt_disable();
+
+    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_READ);
+    if (!state || state->ssl_read.conn_id == 0)
+        goto out;
+
+    if (ret > 0 && (u32)ret <= state->ssl_read.len)
+        tls_emit_call(state->ssl_read.conn_id, state->ssl_read.buf,
+                      (u32)ret, EBPF_TLS_DIR_READ);
+
+out:
+    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_READ);
+    preempt_enable();
+    return 0;
+}

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -88,12 +88,9 @@ struct {
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } tls_conns SEC(".maps");
 
-// Max bytes captured per SSL_read/SSL_write call, set by quark_queue_open()
-// before the object is loaded, same pattern as consumer_pid in Helpers.h.
-const volatile u32 max_tls_call = 0;
-
-// Per-chunk size. Kept well under half of event_buffer_map's 128 KiB ceiling,
-// same headroom rule TTY_OUT_MAX follows in Process/Probe.bpf.c.
+// Per-chunk size. A single SSL_read/SSL_write call can transfer far more than
+// fits one ring-buffer event (num is an int), and max is 128KB.
+// Similar to Process TTY_OUT_MAX.
 #define TLS_CHUNK_MAX 32768u
 
 struct tls_chunk_ctx {
@@ -101,8 +98,7 @@ struct tls_chunk_ctx {
     u64 conn_id;
     enum ebpf_tls_direction direction;
     u64 call_seq;
-    u32 call_len;     // true call length, before max_tls_call capping
-    u32 captured_len; // min(call_len, max_tls_call)
+    u32 call_len;
     u32 chunk_total;
 };
 
@@ -144,7 +140,7 @@ static long tls_emit_chunk(u32 idx, void *ctx)
      * Process/Probe.bpf.c's output_tty_event(): narrowing 64->32bit loses
      * verifier bound tracking on older verifiers, keep this all 32bit.
      */
-    len_cap = (u32)cctx->captured_len - off;
+    len_cap = (u32)cctx->call_len - off;
     len_cap = (u32)(len_cap > TLS_CHUNK_MAX ? TLS_CHUNK_MAX : len_cap);
 
     if (bpf_probe_read_user(field->data, len_cap, (const char *)cctx->base + off)) {
@@ -190,8 +186,7 @@ static void tls_emit_call(u64 conn_id, const void *base, u32 len,
     cctx.direction    = direction;
     cctx.call_seq     = call_seq;
     cctx.call_len     = len;
-    cctx.captured_len = max_tls_call != 0 && len > max_tls_call ? max_tls_call : len;
-    cctx.chunk_total  = (cctx.captured_len + TLS_CHUNK_MAX - 1) / TLS_CHUNK_MAX;
+    cctx.chunk_total  = (len + TLS_CHUNK_MAX - 1) / TLS_CHUNK_MAX;
 
     bpf_loop(cctx.chunk_total, tls_emit_chunk, &cctx, 0);
 }
@@ -278,6 +273,14 @@ int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
     if (!tls_mark_conn_tgid(key.tgid))
         goto out;
     bpf_map_update_elem(&tls_conns, &key, &conn, BPF_ANY);
+    /*
+     * Withhold the announce until the insert is confirmed: a full map must
+     * never yield an ESTABLISHED with no state behind it, since the later
+     * read/write/free probes would never find the connection and no close
+     * would follow. Same guard as tls_adopt_conn.
+     */
+    if (!bpf_map_lookup_elem(&tls_conns, &key))
+        goto out;
 
     tls_emit_conn(conn.conn_id, 0);
 
@@ -331,7 +334,7 @@ out:
 }
 
 // Resolves the connection for a completed read/write and emits its payload.
-// Shared by the plain and _ex return probes: a hit is captured directly (the
+// Shared by the read and write return probes: a hit is captured directly (the
 // hit is the filter), a miss is adopted mid-stream for a non-trusted tgid, and
 // the per-direction call_seq is advanced only for a captured call.
 static void tls_capture_io(void *ssl, const void *buf, u32 len,
@@ -449,105 +452,70 @@ out:
     return 0;
 }
 
-// SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *readbytes) and
-// SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) report
-// the transferred count through the out-parameter and return 1 on success,
-// unlike SSL_read/SSL_write which return the count directly. The entry stashes
-// the count pointer alongside the buffer; the return reads it once ret == 1.
-SEC("uprobe")
-int BPF_UPROBE(uprobe__ssl_write_ex, void *ssl, const void *buf, u64 num,
-               void *written)
+// bpf_for_each_map_elem callback: deletes every tls_conns entry owned by the
+// tgid carried in ctx. Deleting the current element mid-iteration is RCU-safe
+// for a HASH map.
+static long
+tls_reclaim_conn(struct bpf_map *map, const void *key, void *value, void *ctx)
 {
-    struct ebpf_events_state state = {};
+    const struct tls_ssl_key *k = key;
+    u32 tgid = *(u32 *)ctx;
 
-    preempt_disable();
+    if (k->tgid == tgid)
+        bpf_map_delete_elem(&tls_conns, key);
 
-    if (ebpf_events_is_trusted_pid())
-        goto out;
-
-    state.ssl_write_ex.ssl       = ssl;
-    state.ssl_write_ex.buf       = (void *)buf;
-    state.ssl_write_ex.count_ptr = written;
-    state.ssl_write_ex.len       = (u32)num;
-    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE_EX, &state);
-
-out:
-    preempt_enable();
     return 0;
 }
 
-SEC("uretprobe")
-int BPF_URETPROBE(uretprobe__ssl_write_ex, int ret)
+// Reclaims the connections of a process that exited without SSL_free (e.g.
+// SIGKILL). Runs entirely in-kernel from the process-exit hook so the userspace
+// drain path never issues a syscall for it. tls_conn_tgids is the O(1) gate:
+// an unrecorded tgid (the common case) costs a single lookup and stops, so only
+// a process that actually opened a TLS connection ever triggers the sweep.
+static void
+tls_reclaim_tgid(u32 tgid)
 {
-    struct ebpf_events_state *state;
-    u64 count;
+    if (bpf_map_lookup_elem(&tls_conn_tgids, &tgid) == NULL)
+        return;
 
-    preempt_disable();
+    bpf_for_each_map_elem(&tls_conns, tls_reclaim_conn, &tgid, 0);
+    bpf_map_delete_elem(&tls_conn_tgids, &tgid);
+}
 
-    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_WRITE_EX);
-    if (!state)
-        goto out;
-    if (ret != 1 || !state->ssl_write_ex.count_ptr)
-        goto out;
-    if (bpf_probe_read_user(&count, sizeof(count), state->ssl_write_ex.count_ptr))
-        goto out;
-    if (count == 0 || count > state->ssl_write_ex.len)
-        goto out;
+// Mirrors the Process probe's disassociate_ctty hook: on_exit is true only on
+// the last thread of a thread group exiting, which is exactly when the tgid's
+// SSL objects are gone for good.
+static int
+tls_disassociate_ctty(int on_exit)
+{
+    if (!on_exit)
+        return 0;
 
-    tls_capture_io(state->ssl_write_ex.ssl, state->ssl_write_ex.buf,
-                   (u32)count, EBPF_TLS_DIR_WRITE);
+    tls_reclaim_tgid(bpf_get_current_pid_tgid() >> 32);
 
-out:
-    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_WRITE_EX);
-    preempt_enable();
     return 0;
 }
 
-SEC("uprobe")
-int BPF_UPROBE(uprobe__ssl_read_ex, void *ssl, void *buf, u64 num,
-               void *readbytes)
+SEC("fentry/disassociate_ctty")
+int BPF_PROG(fentry__disassociate_ctty_tls, int on_exit)
 {
-    struct ebpf_events_state state = {};
+    int r;
 
     preempt_disable();
-
-    if (ebpf_events_is_trusted_pid())
-        goto out;
-
-    state.ssl_read_ex.ssl       = ssl;
-    state.ssl_read_ex.buf       = buf;
-    state.ssl_read_ex.count_ptr = readbytes;
-    state.ssl_read_ex.len       = (u32)num;
-    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_READ_EX, &state);
-
-out:
+    r = tls_disassociate_ctty(on_exit);
     preempt_enable();
-    return 0;
+
+    return r;
 }
 
-SEC("uretprobe")
-int BPF_URETPROBE(uretprobe__ssl_read_ex, int ret)
+SEC("kprobe/disassociate_ctty")
+int BPF_KPROBE(kprobe__disassociate_ctty_tls, int on_exit)
 {
-    struct ebpf_events_state *state;
-    u64 count;
+    int r;
 
     preempt_disable();
-
-    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_READ_EX);
-    if (!state)
-        goto out;
-    if (ret != 1 || !state->ssl_read_ex.count_ptr)
-        goto out;
-    if (bpf_probe_read_user(&count, sizeof(count), state->ssl_read_ex.count_ptr))
-        goto out;
-    if (count == 0 || count > state->ssl_read_ex.len)
-        goto out;
-
-    tls_capture_io(state->ssl_read_ex.ssl, state->ssl_read_ex.buf,
-                   (u32)count, EBPF_TLS_DIR_READ);
-
-out:
-    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_READ_EX);
+    r = tls_disassociate_ctty(on_exit);
     preempt_enable();
-    return 0;
+
+    return r;
 }

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -18,8 +18,14 @@
 #include "Varlen.h"
 
 // Allow-list of TGIDs to capture TLS from. Opposite of trusted_pids (a
-// deny-list): a TGID must be present here for any uprobe below to do
-// anything. Populated by quark_queue_track_tgid()/untrack_tgid().
+// deny-list): a TGID must be present here for a connection to be minted.
+// Populated by quark_queue_track_tgid()/untrack_tgid(). SSL_new consults it on
+// every call. SSL_read/SSL_write consult it only when they miss tls_conns, to
+// decide whether the miss is a tracked connection whose SSL_new was never seen
+// -- which must be adopted, not dropped -- or an untracked caller to ignore.
+// SSL_free needs no check: it only acts on an existing tls_conns entry, and
+// only gated paths ever create one. A tls_conns hit is therefore always
+// capture-worthy, so the capture hot path stays a single lookup.
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
@@ -35,9 +41,9 @@ static bool ebpf_events_is_tracked_tgid()
 
 // Global monotonic connection-id counter, bumped once per SSL_new. A single
 // array cell (not a per-tgid hash) so conn_id is unique across the whole
-// system -- consumers can key on conn_id alone -- and nothing accumulates or
-// needs cleanup when a process exits. conn_id 0 is never issued, it is
-// reserved as the "unset" sentinel.
+// system -- consumers can key on conn_id alone -- and it is never reused, so a
+// closed-then-reopened SSL object at the same address gets a distinct id.
+// conn_id 0 is never issued, it is reserved as the "unset" sentinel.
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(key_size, sizeof(u32));
@@ -56,61 +62,48 @@ static u64 tls_mint_conn_id(void)
     return __sync_fetch_and_add(ctr, 1) + 1;
 }
 
-// (tgid, ssl_ptr) -> conn_id, completed at SSL_new's uretprobe once the SSL*
-// return value exists. Every SSL_read/SSL_write uprobe looks the conn_id up
-// here. The key must include tgid: an SSL* is only unique within one address
-// space, so two tracked processes can legitimately hold objects at the same
-// virtual address -- keying on the pointer alone would cross-attribute them.
-// LRU (rather than a plain hash) so freed-but-not-reused SSL objects age out
-// on their own -- there is no SSL_free uprobe, so nothing else prunes this --
-// while a reused pointer is corrected by SSL_new overwriting its entry.
+// (tgid, ssl_ptr) -> per-connection state, established at SSL_new's uretprobe
+// (once the SSL* return value exists) and torn down at SSL_free. Every
+// SSL_read/SSL_write return probe looks the connection up here to resolve its
+// conn_id and bump the matching direction's call_seq in place.
+//
+// The key must include tgid: an SSL* is only unique within one address space,
+// so two tracked processes can hold objects at the same virtual address --
+// keying on the pointer alone would cross-attribute them. tgid handles this
+// spatial (concurrent) collision; SSL_free handles temporal reuse within a
+// process by deleting the entry before the address can be recycled.
+//
+// Plain hash + BPF_F_NO_PREALLOC, deleted on SSL_free -- the same shape the
+// network probe's sk_to_tgid uses, freed on tcp_close. Unlike tcp_close,
+// SSL_free is userspace and does not run on SIGKILL, so a killed process's
+// entries are reclaimed instead by the exit-driven sweep in bpf_queue.c
+// (untrack). A reused pointer whose owner was killed is corrected regardless:
+// SSL_new overwrites its entry (BPF_ANY).
 struct tls_ssl_key {
     u32 tgid;
     u64 ssl;
 } __attribute__((packed));
 
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, struct tls_ssl_key);
-    __type(value, u64);
-    __uint(max_entries, 8192);
-} tls_ssl_to_conn SEC(".maps");
-
-static u64 tls_conn_id_for_ssl(u32 tgid, void *ssl)
-{
-    struct tls_ssl_key key = { .tgid = tgid, .ssl = (u64)ssl };
-    u64 *conn_id = bpf_map_lookup_elem(&tls_ssl_to_conn, &key);
-
-    return conn_id ? *conn_id : 0;
-}
-
-// Monotonic call_seq per (conn_id, direction), incremented once per
-// SSL_read/SSL_write call regardless of how many chunks it is split into.
-struct tls_seq_key {
+// call_seq is monotonic per (conn_id, direction), incremented once per
+// SSL_read/SSL_write call regardless of how many chunks it is split into. It
+// lives here, next to conn_id, so the read/write return probe resolves the
+// connection and advances its sequence in a single map lookup. flags carries
+// EBPF_TLS_CONN_F_* (currently only PREFIX_UNKNOWN, set when the connection was
+// adopted mid-stream rather than seen from SSL_new).
+struct tls_conn {
     u64 conn_id;
-    u32 direction;
-} __attribute__((packed));
+    u64 read_seq;
+    u64 write_seq;
+    u32 flags;
+};
 
 struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, struct tls_seq_key);
-    __type(value, u64);
-    __uint(max_entries, 8192);
-} tls_call_seq SEC(".maps");
-
-static u64 tls_next_call_seq(u64 conn_id, enum ebpf_tls_direction direction)
-{
-    struct tls_seq_key key = { .conn_id = conn_id, .direction = direction };
-    u64 init = 0;
-    u64 *ctr;
-
-    bpf_map_update_elem(&tls_call_seq, &key, &init, BPF_NOEXIST);
-    ctr = bpf_map_lookup_elem(&tls_call_seq, &key);
-    if (!ctr)
-        return 0;
-
-    return __sync_fetch_and_add(ctr, 1);
-}
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, struct tls_ssl_key);
+    __type(value, struct tls_conn);
+    __uint(max_entries, 16384);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} tls_conns SEC(".maps");
 
 // Max bytes captured per SSL_read/SSL_write call, set by quark_queue_open()
 // from quark_queue_attr.max_tls_call before the object is loaded, same
@@ -209,12 +202,12 @@ static long tls_emit_chunk(u32 idx, void *ctx)
     return 0;
 }
 
-// conn_id is resolved and stashed by the SSL_read/SSL_write uprobe at entry;
-// len is the byte count actually transferred, taken from the uretprobe's
-// return value. Both directions capture at return so len reflects what really
-// moved (never a WANT_WRITE retry's full buffer, never an unfilled read).
+// Emits one SSL_read/SSL_write call as one or more chunks. conn_id and
+// call_seq are resolved by the caller from tls_conns; len is the byte count
+// actually transferred (the uretprobe's return value), so it is never a
+// WANT_* retry's full buffer nor an unfilled read.
 static void tls_emit_call(u64 conn_id, const void *base, u32 len,
-                          enum ebpf_tls_direction direction)
+                          enum ebpf_tls_direction direction, u64 call_seq)
 {
     struct tls_chunk_ctx cctx = {};
 
@@ -224,7 +217,7 @@ static void tls_emit_call(u64 conn_id, const void *base, u32 len,
     cctx.base         = base;
     cctx.conn_id      = conn_id;
     cctx.direction    = direction;
-    cctx.call_seq     = tls_next_call_seq(conn_id, direction);
+    cctx.call_seq     = call_seq;
     cctx.call_len     = len;
     cctx.captured_len = max_tls_call != 0 && len > max_tls_call ? max_tls_call : len;
     cctx.chunk_total  = (cctx.captured_len + TLS_CHUNK_MAX - 1) / TLS_CHUNK_MAX;
@@ -232,75 +225,62 @@ static void tls_emit_call(u64 conn_id, const void *base, u32 len,
     bpf_loop(cctx.chunk_total, tls_emit_chunk, &cctx, 0);
 }
 
-SEC("uprobe")
-int BPF_UPROBE(uprobe__ssl_new)
+// Announces a connection becoming known (EBPF_EVENT_TLS_CONN), from either
+// SSL_new (flags 0) or a mid-stream adoption (flags PREFIX_UNKNOWN).
+static void tls_emit_conn(u64 conn_id, u32 flags)
 {
-    struct ebpf_events_state state = {};
-
-    preempt_disable();
-
-    if (ebpf_events_is_trusted_pid())
-        goto out;
-    if (!ebpf_events_is_tracked_tgid())
-        goto out;
-
-    state.ssl_new.conn_id = tls_mint_conn_id();
-    if (state.ssl_new.conn_id == 0)
-        goto out;
-
-    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_NEW, &state);
-
-out:
-    preempt_enable();
-    return 0;
-}
-
-SEC("uretprobe")
-int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
-{
-    struct ebpf_events_state *state;
     struct ebpf_tls_new_event *event;
     struct task_struct *task;
-    struct tls_ssl_key key;
-
-    preempt_disable();
-
-    state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_NEW);
-    if (!state)
-        goto out;
-    if (!ssl || state->ssl_new.conn_id == 0)
-        goto out;
-
-    key = (struct tls_ssl_key){
-        .tgid = bpf_get_current_pid_tgid() >> 32,
-        .ssl  = (u64)ssl,
-    };
-    bpf_map_update_elem(&tls_ssl_to_conn, &key, &state->ssl_new.conn_id, BPF_ANY);
 
     event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
     if (!event)
-        goto out;
+        return;
 
     task               = (struct task_struct *)bpf_get_current_task();
     event->hdr.type    = EBPF_EVENT_TLS_CONN;
     event->hdr.ts      = bpf_ktime_get_ns();
     event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
     ebpf_pid_info__fill(&event->pids, task);
-    event->conn_id = state->ssl_new.conn_id;
+    event->conn_id = conn_id;
+    event->flags   = flags;
 
     bpf_ringbuf_submit(event, 0);
-
-out:
-    ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_NEW);
-    preempt_enable();
-    return 0;
 }
 
-SEC("uprobe")
-int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
+// Adopts a connection whose SSL_new was never observed: mints a fresh conn_id,
+// records it flagged PREFIX_UNKNOWN, and announces it. This is the miss path of
+// SSL_read/SSL_write -- the first captured call on a connection that was
+// already open when the probes attached. Surfacing it (rather than dropping the
+// bytes silently) is deliberate: silence would lose traffic with no signal it
+// happened, while the flag lets a consumer decide per protocol whether the
+// missing prefix is recoverable. The announce is withheld until the insert is
+// confirmed so a full map never yields an establish with no state behind it;
+// the caller re-resolves the entry from the map (rather than this returning a
+// map-value pointer, which not every verifier accepts across a call).
+static void tls_adopt_conn(struct tls_ssl_key *key)
 {
-    struct ebpf_events_state state = {};
-    u32 tgid;
+    struct tls_conn conn = {};
+
+    conn.conn_id = tls_mint_conn_id();
+    if (conn.conn_id == 0)
+        return;
+    conn.flags = EBPF_TLS_CONN_F_PREFIX_UNKNOWN;
+
+    bpf_map_update_elem(&tls_conns, key, &conn, BPF_ANY);
+    if (!bpf_map_lookup_elem(&tls_conns, key))
+        return;
+
+    tls_emit_conn(conn.conn_id, EBPF_TLS_CONN_F_PREFIX_UNKNOWN);
+}
+
+// SSL_new has no entry probe: the SSL* it returns is the map key, so nothing
+// useful can be done until the return. Mint the conn_id, record the
+// connection, and announce it, all here.
+SEC("uretprobe")
+int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
+{
+    struct tls_ssl_key key;
+    struct tls_conn conn = {};
 
     preempt_disable();
 
@@ -308,17 +288,89 @@ int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
         goto out;
     if (!ebpf_events_is_tracked_tgid())
         goto out;
-
-    tgid                    = bpf_get_current_pid_tgid() >> 32;
-    state.ssl_write.buf     = (void *)buf;
-    state.ssl_write.len     = (u32)num;
-    state.ssl_write.conn_id = tls_conn_id_for_ssl(tgid, ssl);
-    if (state.ssl_write.conn_id == 0)
+    if (!ssl)
         goto out;
 
-    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE, &state);
+    conn.conn_id = tls_mint_conn_id();
+    if (conn.conn_id == 0)
+        goto out;
+
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)ssl,
+    };
+    bpf_map_update_elem(&tls_conns, &key, &conn, BPF_ANY);
+
+    tls_emit_conn(conn.conn_id, 0);
 
 out:
+    preempt_enable();
+    return 0;
+}
+
+// SSL_free is the connection teardown. Announce the close and drop the map
+// entry so its (tgid, ssl_ptr) slot can be reused cleanly. If the SSL was
+// never tracked (no entry) this is a no-op.
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_free, void *ssl)
+{
+    struct ebpf_tls_close_event *event;
+    struct task_struct *task;
+    struct tls_ssl_key key;
+    struct tls_conn *conn;
+    u64 conn_id;
+
+    preempt_disable();
+
+    if (!ssl)
+        goto out;
+
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)ssl,
+    };
+    conn = bpf_map_lookup_elem(&tls_conns, &key);
+    if (!conn)
+        goto out;
+    conn_id = conn->conn_id;
+    bpf_map_delete_elem(&tls_conns, &key);
+
+    event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    task               = (struct task_struct *)bpf_get_current_task();
+    event->hdr.type    = EBPF_EVENT_TLS_CONN_CLOSE;
+    event->hdr.ts      = bpf_ktime_get_ns();
+    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    ebpf_pid_info__fill(&event->pids, task);
+    event->conn_id = conn_id;
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    preempt_enable();
+    return 0;
+}
+
+// The read/write entry probes only stash the arguments; no tracked/trusted
+// gate here on purpose. The matching return probe resolves the connection from
+// tls_conns: a hit is captured, a miss is either adopted (a tracked tgid whose
+// SSL_new was missed) or ignored (any other caller). Keeping the entry
+// gate-free -- it fires for every caller of the probed symbol, tracked or not
+// -- keeps it cheap; the tracked/trusted checks are paid only on the rare miss.
+SEC("uprobe")
+int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
+{
+    struct ebpf_events_state state = {};
+
+    preempt_disable();
+
+    state.ssl_write.ssl = ssl;
+    state.ssl_write.buf = (void *)buf;
+    state.ssl_write.len = (u32)num;
+    ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE, &state);
+
     preempt_enable();
     return 0;
 }
@@ -327,16 +379,40 @@ SEC("uretprobe")
 int BPF_URETPROBE(uretprobe__ssl_write, int ret)
 {
     struct ebpf_events_state *state;
+    struct tls_ssl_key key;
+    struct tls_conn *conn;
+    u64 seq;
 
     preempt_disable();
 
     state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_WRITE);
-    if (!state || state->ssl_write.conn_id == 0)
+    if (!state)
+        goto out;
+    if (ret <= 0 || (u32)ret > state->ssl_write.len)
         goto out;
 
-    if (ret > 0 && (u32)ret <= state->ssl_write.len)
-        tls_emit_call(state->ssl_write.conn_id, state->ssl_write.buf,
-                      (u32)ret, EBPF_TLS_DIR_WRITE);
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)state->ssl_write.ssl,
+    };
+    conn = bpf_map_lookup_elem(&tls_conns, &key);
+    if (!conn) {
+        // Miss: SSL_new was never seen for this object. Adopt it only for a
+        // tracked, non-trusted tgid (an untracked caller of a shared libssl
+        // stays silent); these checks are paid only here, off the hot path.
+        if (ebpf_events_is_trusted_pid())
+            goto out;
+        if (!ebpf_events_is_tracked_tgid())
+            goto out;
+        tls_adopt_conn(&key);
+        conn = bpf_map_lookup_elem(&tls_conns, &key);
+        if (!conn)
+            goto out;
+    }
+
+    seq = __sync_fetch_and_add(&conn->write_seq, 1);
+    tls_emit_call(conn->conn_id, state->ssl_write.buf, (u32)ret,
+                  EBPF_TLS_DIR_WRITE, seq);
 
 out:
     ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_WRITE);
@@ -348,25 +424,14 @@ SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_read, void *ssl, void *buf, int num)
 {
     struct ebpf_events_state state = {};
-    u32 tgid;
 
     preempt_disable();
 
-    if (ebpf_events_is_trusted_pid())
-        goto out;
-    if (!ebpf_events_is_tracked_tgid())
-        goto out;
-
-    tgid                   = bpf_get_current_pid_tgid() >> 32;
-    state.ssl_read.buf     = buf;
-    state.ssl_read.len     = (u32)num;
-    state.ssl_read.conn_id = tls_conn_id_for_ssl(tgid, ssl);
-    if (state.ssl_read.conn_id == 0)
-        goto out;
-
+    state.ssl_read.ssl = ssl;
+    state.ssl_read.buf = buf;
+    state.ssl_read.len = (u32)num;
     ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_READ, &state);
 
-out:
     preempt_enable();
     return 0;
 }
@@ -375,16 +440,40 @@ SEC("uretprobe")
 int BPF_URETPROBE(uretprobe__ssl_read, int ret)
 {
     struct ebpf_events_state *state;
+    struct tls_ssl_key key;
+    struct tls_conn *conn;
+    u64 seq;
 
     preempt_disable();
 
     state = ebpf_events_state__get(EBPF_EVENTS_STATE_SSL_READ);
-    if (!state || state->ssl_read.conn_id == 0)
+    if (!state)
+        goto out;
+    if (ret <= 0 || (u32)ret > state->ssl_read.len)
         goto out;
 
-    if (ret > 0 && (u32)ret <= state->ssl_read.len)
-        tls_emit_call(state->ssl_read.conn_id, state->ssl_read.buf,
-                      (u32)ret, EBPF_TLS_DIR_READ);
+    key = (struct tls_ssl_key){
+        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .ssl  = (u64)state->ssl_read.ssl,
+    };
+    conn = bpf_map_lookup_elem(&tls_conns, &key);
+    if (!conn) {
+        // Miss: SSL_new was never seen for this object. Adopt it only for a
+        // tracked, non-trusted tgid (an untracked caller of a shared libssl
+        // stays silent); these checks are paid only here, off the hot path.
+        if (ebpf_events_is_trusted_pid())
+            goto out;
+        if (!ebpf_events_is_tracked_tgid())
+            goto out;
+        tls_adopt_conn(&key);
+        conn = bpf_map_lookup_elem(&tls_conns, &key);
+        if (!conn)
+            goto out;
+    }
+
+    seq = __sync_fetch_and_add(&conn->read_seq, 1);
+    tls_emit_call(conn->conn_id, state->ssl_read.buf, (u32)ret,
+                  EBPF_TLS_DIR_READ, seq);
 
 out:
     ebpf_events_state__del(EBPF_EVENTS_STATE_SSL_READ);

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -353,12 +353,15 @@ out:
     return 0;
 }
 
-// The read/write entry probes only stash the arguments; no tracked/trusted
-// gate here on purpose. The matching return probe resolves the connection from
-// tls_conns: a hit is captured, a miss is either adopted (a tracked tgid whose
-// SSL_new was missed) or ignored (any other caller). Keeping the entry
-// gate-free -- it fires for every caller of the probed symbol, tracked or not
-// -- keeps it cheap; the tracked/trusted checks are paid only on the rare miss.
+// The read/write entry probes stash the caller's buffer for the matching
+// return probe. They gate on the same trusted deny-list / tracked allow-list as
+// the capture path: a caller that is not tracked can never be captured at
+// return (a tls_conns miss is only adopted for a tracked tgid), so stashing its
+// arguments would only add churn to the per-task state map -- a bounded LRU
+// shared with the other probes -- and risk evicting in-flight state that can be
+// captured. Gating here keeps that map populated only by callers that may
+// actually be captured. Adoption is unaffected: a tracked tgid whose SSL_new
+// was missed still passes the gate, stashes, and is adopted at return.
 SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
 {
@@ -366,11 +369,17 @@ int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
 
     preempt_disable();
 
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
     state.ssl_write.ssl = ssl;
     state.ssl_write.buf = (void *)buf;
     state.ssl_write.len = (u32)num;
     ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_WRITE, &state);
 
+out:
     preempt_enable();
     return 0;
 }
@@ -420,6 +429,7 @@ out:
     return 0;
 }
 
+// Same gate rationale as uprobe__ssl_write above.
 SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_read, void *ssl, void *buf, int num)
 {
@@ -427,11 +437,17 @@ int BPF_UPROBE(uprobe__ssl_read, void *ssl, void *buf, int num)
 
     preempt_disable();
 
+    if (ebpf_events_is_trusted_pid())
+        goto out;
+    if (!ebpf_events_is_tracked_tgid())
+        goto out;
+
     state.ssl_read.ssl = ssl;
     state.ssl_read.buf = buf;
     state.ssl_read.len = (u32)num;
     ebpf_events_state__set(EBPF_EVENTS_STATE_SSL_READ, &state);
 
+out:
     preempt_enable();
     return 0;
 }

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -31,11 +31,15 @@ struct {
     __uint(max_entries, 16384);
 } tls_conn_tgids SEC(".maps");
 
-static void tls_mark_conn_tgid(u32 tgid)
+// Returns 1 if the tgid is recorded in the index, 0 if the insert failed (map
+// full). Callers must not create a tls_conns entry for a tgid this fails on:
+// the process-exit sweep skips unrecorded tgids, so such an entry could never
+// be reclaimed.
+static int tls_mark_conn_tgid(u32 tgid)
 {
     u8 one = 1;
 
-    bpf_map_update_elem(&tls_conn_tgids, &tgid, &one, BPF_ANY);
+    return bpf_map_update_elem(&tls_conn_tgids, &tgid, &one, BPF_ANY) == 0;
 }
 
 // Global monotonic connection-id counter, bumped once per SSL_new. conn_id 0 is
@@ -219,10 +223,13 @@ static void tls_emit_conn(u64 conn_id, u32 flags)
 }
 
 // Adopts a connection whose SSL_new was never observed: mints a fresh conn_id,
-// records it flagged PREFIX_UNKNOWN, and announces it. The announce is withheld
-// until the insert is confirmed so a full map never yields an establish with no
-// state behind it; the caller re-resolves the entry from the map (rather than
-// this returning a map-value pointer, which not every verifier accepts across a
+// records it flagged PREFIX_UNKNOWN, and announces it. The tgid is recorded in
+// the GC index before the connection is inserted: an unrecorded tgid is skipped
+// by the process-exit sweep, so a connection tracked under a failed mark could
+// never be reclaimed -- drop it instead. The announce is withheld until the
+// insert is confirmed so a full map never yields an establish with no state
+// behind it; the caller re-resolves the entry from the map (rather than this
+// returning a map-value pointer, which not every verifier accepts across a
 // call).
 static void tls_adopt_conn(struct tls_ssl_key *key)
 {
@@ -233,11 +240,13 @@ static void tls_adopt_conn(struct tls_ssl_key *key)
         return;
     conn.flags = EBPF_TLS_CONN_F_PREFIX_UNKNOWN;
 
+    if (!tls_mark_conn_tgid(key->tgid))
+        return;
+
     bpf_map_update_elem(&tls_conns, key, &conn, BPF_ANY);
     if (!bpf_map_lookup_elem(&tls_conns, key))
         return;
 
-    tls_mark_conn_tgid(key->tgid);
     tls_emit_conn(conn.conn_id, EBPF_TLS_CONN_F_PREFIX_UNKNOWN);
 }
 
@@ -264,9 +273,16 @@ int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .ssl  = (u64)ssl,
     };
+
+    /*
+     * Record the tgid before inserting: the process-exit sweep skips
+     * unrecorded tgids, so a tls_conns entry created under a failed mark
+     * could never be reclaimed. Drop the connection instead of stranding it.
+     */
+    if (!tls_mark_conn_tgid(key.tgid))
+        goto out;
     bpf_map_update_elem(&tls_conns, &key, &conn, BPF_ANY);
 
-    tls_mark_conn_tgid(key.tgid);
     tls_emit_conn(conn.conn_id, 0);
 
 out:

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -18,12 +18,10 @@
 #include "Varlen.h"
 
 // GC index of TGIDs that have opened at least one TLS connection. The probe
-// maintains it (insert on SSL_new and on mid-stream adopt); it does NOT gate
-// capture. Userspace consults it once per process exit to decide whether to
+// maintains it (insert on SSL_new and on mid-stream adopt); 
+// Userspace consults it once per process exit to decide whether to
 // sweep leftover tls_conns entries for a process that died without SSL_free
-// (e.g. SIGKILL), so unrelated exits don't scan the map. Membership-only: an
-// entry may outlive the tgid's connections (it is cleared on process exit), so
-// a stale hit costs at most one wasted sweep, never a leak.
+// (e.g. SIGKILL), so unrelated exits don't scan the map. 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
@@ -32,9 +30,7 @@ struct {
 } tls_conn_tgids SEC(".maps");
 
 // Returns 1 if the tgid is recorded in the index, 0 if the insert failed (map
-// full). Callers must not create a tls_conns entry for a tgid this fails on:
-// the process-exit sweep skips unrecorded tgids, so such an entry could never
-// be reclaimed.
+// full).
 static int tls_mark_conn_tgid(u32 tgid)
 {
     u8 one = 1;

--- a/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/TLS/Probe.bpf.c
@@ -17,20 +17,25 @@
 #include "State.h"
 #include "Varlen.h"
 
-// Allow-list of TGIDs to capture TLS from. Opposite of trusted_pids (a
-// deny-list): a TGID must be present here for a connection to be minted.
-// Populated by quark_queue_track_tgid()/untrack_tgid().
+// GC index of TGIDs that have opened at least one TLS connection. The probe
+// maintains it (insert on SSL_new and on mid-stream adopt); it does NOT gate
+// capture. Userspace consults it once per process exit to decide whether to
+// sweep leftover tls_conns entries for a process that died without SSL_free
+// (e.g. SIGKILL), so unrelated exits don't scan the map. Membership-only: an
+// entry may outlive the tgid's connections (it is cleared on process exit), so
+// a stale hit costs at most one wasted sweep, never a leak.
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(u32));
     __uint(value_size, sizeof(u8));
-    __uint(max_entries, 512);
-} tracked_tgids SEC(".maps");
+    __uint(max_entries, 16384);
+} tls_conn_tgids SEC(".maps");
 
-static bool ebpf_events_is_tracked_tgid()
+static void tls_mark_conn_tgid(u32 tgid)
 {
-    u32 tgid = bpf_get_current_pid_tgid() >> 32;
-    return bpf_map_lookup_elem(&tracked_tgids, &tgid) != NULL;
+    u8 one = 1;
+
+    bpf_map_update_elem(&tls_conn_tgids, &tgid, &one, BPF_ANY);
 }
 
 // Global monotonic connection-id counter, bumped once per SSL_new. conn_id 0 is
@@ -232,6 +237,7 @@ static void tls_adopt_conn(struct tls_ssl_key *key)
     if (!bpf_map_lookup_elem(&tls_conns, key))
         return;
 
+    tls_mark_conn_tgid(key->tgid);
     tls_emit_conn(conn.conn_id, EBPF_TLS_CONN_F_PREFIX_UNKNOWN);
 }
 
@@ -247,8 +253,6 @@ int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
 
     if (ebpf_events_is_trusted_pid())
         goto out;
-    if (!ebpf_events_is_tracked_tgid())
-        goto out;
     if (!ssl)
         goto out;
 
@@ -262,6 +266,7 @@ int BPF_URETPROBE(uretprobe__ssl_new, void *ssl)
     };
     bpf_map_update_elem(&tls_conns, &key, &conn, BPF_ANY);
 
+    tls_mark_conn_tgid(key.tgid);
     tls_emit_conn(conn.conn_id, 0);
 
 out:
@@ -315,8 +320,8 @@ out:
 
 // Resolves the connection for a completed read/write and emits its payload.
 // Shared by the plain and _ex return probes: a hit is captured directly (the
-// hit is the filter), a miss is adopted mid-stream for a tracked, non-trusted
-// tgid, and the per-direction call_seq is advanced only for a captured call.
+// hit is the filter), a miss is adopted mid-stream for a non-trusted tgid, and
+// the per-direction call_seq is advanced only for a captured call.
 static void tls_capture_io(void *ssl, const void *buf, u32 len,
                            enum ebpf_tls_direction direction)
 {
@@ -332,8 +337,6 @@ static void tls_capture_io(void *ssl, const void *buf, u32 len,
     if (!conn) {
         if (ebpf_events_is_trusted_pid())
             return;
-        if (!ebpf_events_is_tracked_tgid())
-            return;
         tls_adopt_conn(&key);
         conn = bpf_map_lookup_elem(&tls_conns, &key);
         if (!conn)
@@ -348,8 +351,7 @@ static void tls_capture_io(void *ssl, const void *buf, u32 len,
 }
 
 // The read/write entry probes stash the caller's buffer for the matching return
-// probe. They gate on the same trusted deny-list / tracked allow-list as the
-// capture path.
+// probe. They gate on the trusted deny-list, same as the capture path.
 SEC("uprobe")
 int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
 {
@@ -358,8 +360,6 @@ int BPF_UPROBE(uprobe__ssl_write, void *ssl, const void *buf, int num)
     preempt_disable();
 
     if (ebpf_events_is_trusted_pid())
-        goto out;
-    if (!ebpf_events_is_tracked_tgid())
         goto out;
 
     state.ssl_write.ssl = ssl;
@@ -403,8 +403,6 @@ int BPF_UPROBE(uprobe__ssl_read, void *ssl, void *buf, int num)
     preempt_disable();
 
     if (ebpf_events_is_trusted_pid())
-        goto out;
-    if (!ebpf_events_is_tracked_tgid())
         goto out;
 
     state.ssl_read.ssl = ssl;
@@ -454,8 +452,6 @@ int BPF_UPROBE(uprobe__ssl_write_ex, void *ssl, const void *buf, u64 num,
 
     if (ebpf_events_is_trusted_pid())
         goto out;
-    if (!ebpf_events_is_tracked_tgid())
-        goto out;
 
     state.ssl_write_ex.ssl       = ssl;
     state.ssl_write_ex.buf       = (void *)buf;
@@ -504,8 +500,6 @@ int BPF_UPROBE(uprobe__ssl_read_ex, void *ssl, void *buf, u64 num,
     preempt_disable();
 
     if (ebpf_events_is_trusted_pid())
-        goto out;
-    if (!ebpf_events_is_tracked_tgid())
         goto out;
 
     state.ssl_read_ex.ssl       = ssl;

--- a/elftoolchain/libelf/gelf_shdr.c
+++ b/elftoolchain/libelf/gelf_shdr.c
@@ -157,55 +157,10 @@ gelf_getverdaux(UD Elf_Data *_data, UD int _offset, UD GElf_Verdaux *_dst)
 	return (NULL);
 }
 
-/*
- * Real implementation (not a stub): libbpf's uprobe symbol resolution walks a
- * versioned .dynsym and skips every entry whose gelf_getversym() fails, so a
- * NULL stub makes attach-by-symbol miss all libc/libssl symbols.
- */
 GElf_Versym *
-gelf_getversym(Elf_Data *ed, int ndx, GElf_Versym *dst)
+gelf_getversym(UD Elf_Data *_data, UD int _ndx, UD GElf_Versym *_dst)
 {
-	int ec;
-	Elf *e;
-	size_t msz;
-	Elf_Scn *scn;
-	uint32_t sh_type;
-	struct _Libelf_Data *d;
-
-	d = (struct _Libelf_Data *) ed;
-
-	if (d == NULL || ndx < 0 || dst == NULL ||
-	    (scn = d->d_scn) == NULL ||
-	    (e = scn->s_elf) == NULL) {
-		LIBELF_SET_ERROR(ARGUMENT, 0);
-		return (NULL);
-	}
-
-	ec = e->e_class;
-	assert(ec == ELFCLASS32 || ec == ELFCLASS64);
-
-	if (ec == ELFCLASS32)
-		sh_type = scn->s_shdr.s_shdr32.sh_type;
-	else
-		sh_type = scn->s_shdr.s_shdr64.sh_type;
-
-	if (_libelf_xlate_shtype(sh_type) != ELF_T_HALF) {
-		LIBELF_SET_ERROR(ARGUMENT, 0);
-		return (NULL);
-	}
-
-	if ((msz = _libelf_msize(ELF_T_HALF, ec, e->e_version)) == 0)
-		return (NULL);
-
-	if (msz * (size_t) ndx >= d->d_data.d_size) {
-		LIBELF_SET_ERROR(ARGUMENT, 0);
-		return (NULL);
-	}
-
-	/* Elf32_Versym and Elf64_Versym are both 16-bit halves. */
-	*dst = ((Elf64_Versym *) d->d_data.d_buf)[ndx];
-
-	return (dst);
+	return (NULL);
 }
 
 #undef UD

--- a/elftoolchain/libelf/gelf_shdr.c
+++ b/elftoolchain/libelf/gelf_shdr.c
@@ -157,10 +157,55 @@ gelf_getverdaux(UD Elf_Data *_data, UD int _offset, UD GElf_Verdaux *_dst)
 	return (NULL);
 }
 
+/*
+ * Real implementation (not a stub): libbpf's uprobe symbol resolution walks a
+ * versioned .dynsym and skips every entry whose gelf_getversym() fails, so a
+ * NULL stub makes attach-by-symbol miss all libc/libssl symbols.
+ */
 GElf_Versym *
-gelf_getversym(UD Elf_Data *_data, UD int _ndx, UD GElf_Versym *_dst)
+gelf_getversym(Elf_Data *ed, int ndx, GElf_Versym *dst)
 {
-	return (NULL);
+	int ec;
+	Elf *e;
+	size_t msz;
+	Elf_Scn *scn;
+	uint32_t sh_type;
+	struct _Libelf_Data *d;
+
+	d = (struct _Libelf_Data *) ed;
+
+	if (d == NULL || ndx < 0 || dst == NULL ||
+	    (scn = d->d_scn) == NULL ||
+	    (e = scn->s_elf) == NULL) {
+		LIBELF_SET_ERROR(ARGUMENT, 0);
+		return (NULL);
+	}
+
+	ec = e->e_class;
+	assert(ec == ELFCLASS32 || ec == ELFCLASS64);
+
+	if (ec == ELFCLASS32)
+		sh_type = scn->s_shdr.s_shdr32.sh_type;
+	else
+		sh_type = scn->s_shdr.s_shdr64.sh_type;
+
+	if (_libelf_xlate_shtype(sh_type) != ELF_T_HALF) {
+		LIBELF_SET_ERROR(ARGUMENT, 0);
+		return (NULL);
+	}
+
+	if ((msz = _libelf_msize(ELF_T_HALF, ec, e->e_version)) == 0)
+		return (NULL);
+
+	if (msz * (size_t) ndx >= d->d_data.d_size) {
+		LIBELF_SET_ERROR(ARGUMENT, 0);
+		return (NULL);
+	}
+
+	/* Elf32_Versym and Elf64_Versym are both 16-bit halves. */
+	*dst = ((Elf64_Versym *) d->d_data.d_buf)[ndx];
+
+	return (dst);
 }
 
 #undef UD

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -183,11 +183,7 @@ type Tty struct {
 
 // TlsConn carries a connection lifecycle event. It is delivered with
 // QUARK_EV_TLS_CONN_ESTABLISHED when the connection first becomes known and
-// again with QUARK_EV_TLS_CONN_CLOSED when SSL_free runs; check Event.Events to
-// tell them apart. ConnId is globally unique across all connections and
-// processes and never reused, so it may be used as a map key on its own. A
-// close is not delivered when a process dies without calling SSL_free (e.g.
-// SIGKILL); treat a process exit as closing all its connections.
+// again with QUARK_EV_TLS_CONN_CLOSED when SSL_free runs;
 //
 // PrefixUnknown is set on an ESTABLISHED event when the connection was adopted
 // mid-stream (its SSL_new was never seen) rather than observed from birth.
@@ -197,17 +193,10 @@ type TlsConn struct {
 	PrefixUnknown bool
 }
 
-// TlsCall is a fully reassembled SSL_read or SSL_write call. Data holds the
-// plaintext as a slice of chunks in the order they were chained by quark's
-// aggregator; concatenate for the full buffer. Truncated is non-zero if
-// CallLen is bigger than the sum of Data's lengths (capped by
-// QueueAttr.MaxTlsCall, or a chunk that failed to read).
+// TlsCall is a fully reassembled SSL_read or SSL_write call.
 //
-// Gap distinguishes the two ways Truncated can be non-zero: false means a
-// clean trailing cut (Data is a valid, if incomplete, prefix of the
-// original call - safe to parse up to TotalLen). true means some
-// non-trailing chunk never arrived or was unreadable - Data has a hole
-// before its end and is NOT a safe contiguous buffer to parse.
+// Gap distinguishes the two ways Truncated can be non-zero.
+// false means truncate was clean at the end, while true means there was a gap in the data.
 type TlsCall struct {
 	ConnId    uint64
 	Tgid      uint32
@@ -224,7 +213,7 @@ type TlsCall struct {
 // event, Process is the context of the Event.
 type Event struct {
 	Events     uint64
-	Time       uint64 // wall-clock nanoseconds since the Unix epoch (boot wall time + kernel monotonic ts)
+	Time       uint64
 	Process    Process
 	Socket     *Socket
 	Packet     *Packet
@@ -455,12 +444,9 @@ type TlsAttachment struct {
 	handle *C.struct_quark_tls_attachment
 }
 
-// TlsAttach attaches the SSL_new/SSL_read/SSL_write/SSL_free uprobes at the
-// given file offsets in path; all four are required. Callers are recommended
-// to track attachments by (dev, inode, offset) and attach once per such tuple;
-// the kernel refcounts uprobes by (inode, offset) only. pid == -1 attaches
-// system-wide, capturing every process hitting these offsets (subject only to
-// the trusted-pid deny-list); pid >= 0 scopes the uprobes to that process.
+// TlsAttach attaches the uprobes at the given file offsets in path; all four are required.
+// Callers are recommended to track attachments by (dev, inode, offset) and attach once per such tuple;
+// Use -1 pid to attach system-wide, recommended but do not use against shared system libraries (libssl.so etc)
 func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWriteOff, sslFreeOff uint64) (*TlsAttachment, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
@@ -476,9 +462,8 @@ func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWr
 }
 
 // TlsAttachSym attaches the TLS uprobes to a shared library (e.g. libssl) by
-// symbol name. SSL_new/SSL_free/SSL_read/SSL_write are required and
-// SSL_read_ex/SSL_write_ex are attached if present. pid must be >= 0: the
-// uprobes are scoped to that process.
+// symbol name. All four are required. pid must be >= 0: the uprobes are scoped to that process.
+// It is safe to call this multiple times with different PIDs as uprobes are refcounted by (inode, offset).
 func (queue *Queue) TlsAttachSym(pid int, path string) (*TlsAttachment, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -181,13 +181,25 @@ type Tty struct {
 	Data      [][]byte
 }
 
-// TlsConn is delivered once per connection, when SSL_new returns. ConnId is
-// the identifier every subsequent TlsCall for this connection carries; it is
-// globally unique across all connections and processes and never reused, so
-// it may be used as a map key on its own. Tgid is the owning process.
+// TlsConn carries a connection lifecycle event. It is delivered with
+// QUARK_EV_TLS_CONN_ESTABLISHED when the connection first becomes known and
+// again with QUARK_EV_TLS_CONN_CLOSED when SSL_free runs; check Event.Events to
+// tell them apart. ConnId is the identifier every subsequent TlsCall for this
+// connection carries; it is globally unique across all connections and
+// processes and never reused, so it may be used as a map key on its own. Tgid
+// is the owning process. A close is not delivered when a process dies without
+// calling SSL_free (e.g. SIGKILL); treat a process exit as closing all its
+// connections.
+//
+// PrefixUnknown is set on an ESTABLISHED event when the connection was adopted
+// mid-stream (its SSL_new was never seen because the probes attached after it
+// was already open) rather than observed from birth. Its captured bytes do not
+// start at the connection's first byte, so CallSeq 0 is not the true start; a
+// consumer that needs the opening bytes should treat it as unreliable.
 type TlsConn struct {
-	ConnId uint64
-	Tgid   uint32
+	ConnId        uint64
+	Tgid          uint32
+	PrefixUnknown bool
 }
 
 // TlsCall is a fully reassembled SSL_read or SSL_write call. Data holds the
@@ -269,6 +281,7 @@ const (
 	QUARK_EV_TTY                  = uint64(C.QUARK_EV_TTY)
 	QUARK_EV_TLS_CONN_ESTABLISHED = uint64(C.QUARK_EV_TLS_CONN_ESTABLISHED)
 	QUARK_EV_TLS_CALL             = uint64(C.QUARK_EV_TLS_CALL)
+	QUARK_EV_TLS_CONN_CLOSED      = uint64(C.QUARK_EV_TLS_CONN_CLOSED)
 
 	// TlsCall.Direction
 	QUARK_TLS_DIR_WRITE = int(C.QUARK_TLS_DIR_WRITE)
@@ -454,7 +467,10 @@ func (queue *Queue) TrackTgid(tgid uint32) error {
 	return nil
 }
 
-// UntrackTgid removes tgid from the TLS capture allow-list.
+// UntrackTgid removes tgid from the TLS capture allow-list and reclaims any
+// connections it still owns. This also happens automatically when quark sees
+// the process exit, so an explicit call is only needed to stop capturing a
+// live process early.
 func (queue *Queue) UntrackTgid(tgid uint32) error {
 	ok, err := C.quark_queue_untrack_tgid(queue.quarkQueue, C.u32(tgid))
 	if ok == -1 {
@@ -464,16 +480,18 @@ func (queue *Queue) UntrackTgid(tgid uint32) error {
 	return nil
 }
 
-// TlsAttach attaches the SSL_new/SSL_read/SSL_write uprobes at the given
-// file offsets in path. Attachment is system-wide, not scoped to a single
-// process: call this once per distinct binary/library path even if several
-// tracked tgids share it, not once per tgid.
-func (queue *Queue) TlsAttach(path string, sslNewOff, sslReadOff, sslWriteOff uint64) error {
+// TlsAttach attaches the SSL_new/SSL_read/SSL_write/SSL_free uprobes at the
+// given file offsets in path. All four offsets are required. Attachment is
+// system-wide, not scoped to a single process: call this once per distinct
+// binary/library path even if several tracked tgids share it, not once per
+// tgid.
+func (queue *Queue) TlsAttach(path string, sslNewOff, sslReadOff, sslWriteOff, sslFreeOff uint64) error {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
 	ok, err := C.quark_queue_tls_attach(queue.quarkQueue, cpath,
-		C.u64(sslNewOff), C.u64(sslReadOff), C.u64(sslWriteOff))
+		C.u64(sslNewOff), C.u64(sslReadOff), C.u64(sslWriteOff),
+		C.u64(sslFreeOff))
 	if ok == -1 {
 		return wrapErrno(err)
 	}
@@ -765,6 +783,7 @@ func tlsConnFromC(cTlsConn *C.struct_quark_tls_conn) TlsConn {
 
 	tlsConn.ConnId = uint64(cTlsConn.conn_id)
 	tlsConn.Tgid = uint32(cTlsConn.tgid)
+	tlsConn.PrefixUnknown = cTlsConn.flags&C.QUARK_TLS_CONN_F_PREFIX_UNKNOWN != 0
 
 	return tlsConn
 }

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -449,31 +449,6 @@ func (queue *Queue) GetEvent() (Event, bool) {
 	return event, true
 }
 
-// TrackTgid adds tgid to the TLS capture allow-list. All SSL_new/SSL_read/
-// SSL_write activity from tgid (and only tgid, no descendant propagation) is
-// captured once TlsAttach has been called for the binary/library tgid uses.
-func (queue *Queue) TrackTgid(tgid uint32) error {
-	ok, err := C.quark_queue_track_tgid(queue.quarkQueue, C.u32(tgid))
-	if ok == -1 {
-		return wrapErrno(err)
-	}
-
-	return nil
-}
-
-// UntrackTgid removes tgid from the TLS capture allow-list and reclaims any
-// connections it still owns. This also happens automatically when quark sees
-// the process exit, so an explicit call is only needed to stop capturing a
-// live process early.
-func (queue *Queue) UntrackTgid(tgid uint32) error {
-	ok, err := C.quark_queue_untrack_tgid(queue.quarkQueue, C.u32(tgid))
-	if ok == -1 {
-		return wrapErrno(err)
-	}
-
-	return nil
-}
-
 // TlsAttachment is an opaque handle to a set of TLS uprobes, returned by
 // TlsAttach/TlsAttachSym and passed to TlsDetach.
 type TlsAttachment struct {
@@ -484,9 +459,8 @@ type TlsAttachment struct {
 // given file offsets in path; all four are required. Callers are recommended
 // to track attachments by (dev, inode, offset) and attach once per such tuple;
 // the kernel refcounts uprobes by (inode, offset) only. pid == -1 attaches
-// system-wide, and capture is then gated by the allow-list managed with
-// TrackTgid; pid >= 0 scopes the uprobes to that process and tracks it
-// automatically.
+// system-wide, capturing every process hitting these offsets (subject only to
+// the trusted-pid deny-list); pid >= 0 scopes the uprobes to that process.
 func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWriteOff, sslFreeOff uint64) (*TlsAttachment, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
@@ -504,7 +478,7 @@ func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWr
 // TlsAttachSym attaches the TLS uprobes to a shared library (e.g. libssl) by
 // symbol name. SSL_new/SSL_free/SSL_read/SSL_write are required and
 // SSL_read_ex/SSL_write_ex are attached if present. pid must be >= 0: the
-// uprobes are scoped to that process and it is tracked automatically.
+// uprobes are scoped to that process.
 func (queue *Queue) TlsAttachSym(pid int, path string) (*TlsAttachment, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -307,7 +307,6 @@ type QueueAttr struct {
 	MaxLength      int
 	CacheGraceTime int
 	HoldTime       int
-	MaxTlsCall     int // max bytes captured per TLS call, only used if QQ_TLS is set; 0 == unlimited
 }
 
 // Documented in https://elastic.github.io/quark/quark_queue_get_stats.3.html.
@@ -348,7 +347,6 @@ func DefaultQueueAttr() QueueAttr {
 		MaxLength:      int(attr.max_length),
 		CacheGraceTime: int(attr.cache_grace_time),
 		HoldTime:       int(attr.hold_time),
-		MaxTlsCall:     int(attr.max_tls_call),
 	}
 }
 
@@ -369,7 +367,6 @@ func OpenQueue(attr QueueAttr) (*Queue, error) {
 	cattr.max_length = C.int(attr.MaxLength)
 	cattr.cache_grace_time = C.int(attr.CacheGraceTime)
 	cattr.hold_time = C.int(attr.HoldTime)
-	cattr.max_tls_call = C.size_t(attr.MaxTlsCall)
 	ok, err := C.quark_queue_open(queue.quarkQueue, &cattr)
 	if ok == -1 {
 		C.free(unsafe.Pointer(queue.quarkQueue))
@@ -439,7 +436,7 @@ func (queue *Queue) GetEvent() (Event, bool) {
 }
 
 // TlsAttachment is an opaque handle to a set of TLS uprobes, returned by
-// TlsAttach/TlsAttachSym and passed to TlsDetach.
+// TlsAttach and passed to TlsDetach.
 type TlsAttachment struct {
 	handle *C.struct_quark_tls_attachment
 }
@@ -461,22 +458,7 @@ func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWr
 	return &TlsAttachment{handle: h}, nil
 }
 
-// TlsAttachSym attaches the TLS uprobes to a shared library (e.g. libssl) by
-// symbol name. All four are required. pid must be >= 0: the uprobes are scoped to that process.
-// It is safe to call this multiple times with different PIDs as uprobes are refcounted by (inode, offset).
-func (queue *Queue) TlsAttachSym(pid int, path string) (*TlsAttachment, error) {
-	cpath := C.CString(path)
-	defer C.free(unsafe.Pointer(cpath))
-
-	h, err := C.quark_queue_tls_attach_sym(queue.quarkQueue, C.int(pid), cpath)
-	if h == nil {
-		return nil, wrapErrno(err)
-	}
-
-	return &TlsAttachment{handle: h}, nil
-}
-
-// TlsDetach detaches a single attachment obtained from TlsAttach/TlsAttachSym
+// TlsDetach detaches a single attachment obtained from TlsAttach
 // and reclaims what it owns. Calling it twice, or with a nil handle, is a no-op.
 func (queue *Queue) TlsDetach(a *TlsAttachment) {
 	if a == nil || a.handle == nil {

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -474,23 +474,57 @@ func (queue *Queue) UntrackTgid(tgid uint32) error {
 	return nil
 }
 
+// TlsAttachment is an opaque handle to a set of TLS uprobes, returned by
+// TlsAttach/TlsAttachSym and passed to TlsDetach.
+type TlsAttachment struct {
+	handle *C.struct_quark_tls_attachment
+}
+
 // TlsAttach attaches the SSL_new/SSL_read/SSL_write/SSL_free uprobes at the
-// given file offsets in path. All four offsets are required. Attachment is
-// system-wide, not scoped to a single process: call this once per distinct
-// binary/library path even if several tracked tgids share it, not once per
-// tgid.
-func (queue *Queue) TlsAttach(path string, sslNewOff, sslReadOff, sslWriteOff, sslFreeOff uint64) error {
+// given file offsets in path; all four are required. Callers are recommended
+// to track attachments by (dev, inode, offset) and attach once per such tuple;
+// the kernel refcounts uprobes by (inode, offset) only. pid == -1 attaches
+// system-wide, and capture is then gated by the allow-list managed with
+// TrackTgid; pid >= 0 scopes the uprobes to that process and tracks it
+// automatically.
+func (queue *Queue) TlsAttach(pid int, path string, sslNewOff, sslReadOff, sslWriteOff, sslFreeOff uint64) (*TlsAttachment, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
-	ok, err := C.quark_queue_tls_attach(queue.quarkQueue, cpath,
+	h, err := C.quark_queue_tls_attach(queue.quarkQueue, C.int(pid), cpath,
 		C.u64(sslNewOff), C.u64(sslReadOff), C.u64(sslWriteOff),
 		C.u64(sslFreeOff))
-	if ok == -1 {
-		return wrapErrno(err)
+	if h == nil {
+		return nil, wrapErrno(err)
 	}
 
-	return nil
+	return &TlsAttachment{handle: h}, nil
+}
+
+// TlsAttachSym attaches the TLS uprobes to a shared library (e.g. libssl) by
+// symbol name. SSL_new/SSL_free/SSL_read/SSL_write are required and
+// SSL_read_ex/SSL_write_ex are attached if present. pid must be >= 0: the
+// uprobes are scoped to that process and it is tracked automatically.
+func (queue *Queue) TlsAttachSym(pid int, path string) (*TlsAttachment, error) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+
+	h, err := C.quark_queue_tls_attach_sym(queue.quarkQueue, C.int(pid), cpath)
+	if h == nil {
+		return nil, wrapErrno(err)
+	}
+
+	return &TlsAttachment{handle: h}, nil
+}
+
+// TlsDetach detaches a single attachment obtained from TlsAttach/TlsAttachSym
+// and reclaims what it owns. Calling it twice, or with a nil handle, is a no-op.
+func (queue *Queue) TlsDetach(a *TlsAttachment) {
+	if a == nil || a.handle == nil {
+		return
+	}
+	C.quark_queue_tls_detach(queue.quarkQueue, a.handle)
+	a.handle = nil
 }
 
 func (queue *Queue) GetEventAsECS() ([]byte, bool, error) {

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -184,18 +184,13 @@ type Tty struct {
 // TlsConn carries a connection lifecycle event. It is delivered with
 // QUARK_EV_TLS_CONN_ESTABLISHED when the connection first becomes known and
 // again with QUARK_EV_TLS_CONN_CLOSED when SSL_free runs; check Event.Events to
-// tell them apart. ConnId is the identifier every subsequent TlsCall for this
-// connection carries; it is globally unique across all connections and
-// processes and never reused, so it may be used as a map key on its own. Tgid
-// is the owning process. A close is not delivered when a process dies without
-// calling SSL_free (e.g. SIGKILL); treat a process exit as closing all its
-// connections.
+// tell them apart. ConnId is globally unique across all connections and
+// processes and never reused, so it may be used as a map key on its own. A
+// close is not delivered when a process dies without calling SSL_free (e.g.
+// SIGKILL); treat a process exit as closing all its connections.
 //
 // PrefixUnknown is set on an ESTABLISHED event when the connection was adopted
-// mid-stream (its SSL_new was never seen because the probes attached after it
-// was already open) rather than observed from birth. Its captured bytes do not
-// start at the connection's first byte, so CallSeq 0 is not the true start; a
-// consumer that needs the opening bytes should treat it as unreliable.
+// mid-stream (its SSL_new was never seen) rather than observed from birth.
 type TlsConn struct {
 	ConnId        uint64
 	Tgid          uint32
@@ -455,9 +450,8 @@ func (queue *Queue) GetEvent() (Event, bool) {
 }
 
 // TrackTgid adds tgid to the TLS capture allow-list. All SSL_new/SSL_read/
-// SSL_write activity from tgid (and only tgid, no descendant propagation -
-// callers add children explicitly on fork) is captured once TlsAttach has
-// been called for the binary/library tgid uses.
+// SSL_write activity from tgid (and only tgid, no descendant propagation) is
+// captured once TlsAttach has been called for the binary/library tgid uses.
 func (queue *Queue) TrackTgid(tgid uint32) error {
 	ok, err := C.quark_queue_track_tgid(queue.quarkQueue, C.u32(tgid))
 	if ok == -1 {

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -181,10 +181,43 @@ type Tty struct {
 	Data      [][]byte
 }
 
+// TlsConn is delivered once per connection, when SSL_new returns. ConnId is
+// the identifier every subsequent TlsCall for this connection carries; it is
+// globally unique across all connections and processes and never reused, so
+// it may be used as a map key on its own. Tgid is the owning process.
+type TlsConn struct {
+	ConnId uint64
+	Tgid   uint32
+}
+
+// TlsCall is a fully reassembled SSL_read or SSL_write call. Data holds the
+// plaintext as a slice of chunks in the order they were chained by quark's
+// aggregator; concatenate for the full buffer. Truncated is non-zero if
+// CallLen is bigger than the sum of Data's lengths (capped by
+// QueueAttr.MaxTlsCall, or a chunk that failed to read).
+//
+// Gap distinguishes the two ways Truncated can be non-zero: false means a
+// clean trailing cut (Data is a valid, if incomplete, prefix of the
+// original call - safe to parse up to TotalLen). true means some
+// non-trailing chunk never arrived or was unreadable - Data has a hole
+// before its end and is NOT a safe contiguous buffer to parse.
+type TlsCall struct {
+	ConnId    uint64
+	Tgid      uint32
+	Direction int
+	CallSeq   uint64
+	CallLen   uint64
+	TotalLen  uint64
+	Truncated uint64
+	Gap       bool
+	Data      [][]byte
+}
+
 // Events is a bitmask of QUARK_EV_* and expresses what triggered this
 // event, Process is the context of the Event.
 type Event struct {
 	Events     uint64
+	Time       uint64 // wall-clock nanoseconds since the Unix epoch (boot wall time + kernel monotonic ts)
 	Process    Process
 	Socket     *Socket
 	Packet     *Packet
@@ -193,6 +226,8 @@ type Event struct {
 	ModuleLoad *ModuleLoad
 	Shm        *any // ShmGet, MemFd or ShmOpen
 	Tty        *Tty
+	TlsConn    *TlsConn
+	TlsCall    *TlsCall
 }
 
 // Queue holds the state of a quark instance.
@@ -216,21 +251,28 @@ const (
 	QQ_TTY           = int(C.QQ_TTY)
 	QQ_PTRACE        = int(C.QQ_PTRACE)
 	QQ_MODULE_LOAD   = int(C.QQ_MODULE_LOAD)
+	QQ_TLS           = int(C.QQ_TLS)
 	QQ_ALL_BACKENDS  = int(C.QQ_ALL_BACKENDS)
 
 	// Event.events
-	QUARK_EV_FORK             = uint64(C.QUARK_EV_FORK)
-	QUARK_EV_EXEC             = uint64(C.QUARK_EV_EXEC)
-	QUARK_EV_EXIT             = uint64(C.QUARK_EV_EXIT)
-	QUARK_EV_SETPROCTITLE     = uint64(C.QUARK_EV_SETPROCTITLE)
-	QUARK_EV_SOCK_CONN_CLOSED = uint64(C.QUARK_EV_SOCK_CONN_CLOSED)
-	QUARK_EV_PACKET           = uint64(C.QUARK_EV_PACKET)
-	QUARK_EV_BYPASS           = uint64(C.QUARK_EV_BYPASS)
-	QUARK_EV_FILE             = uint64(C.QUARK_EV_FILE)
-	QUARK_EV_PTRACE           = uint64(C.QUARK_EV_PTRACE)
-	QUARK_EV_MODULE_LOAD      = uint64(C.QUARK_EV_MODULE_LOAD)
-	QUARK_EV_SHM              = uint64(C.QUARK_EV_SHM)
-	QUARK_EV_TTY              = uint64(C.QUARK_EV_TTY)
+	QUARK_EV_FORK                 = uint64(C.QUARK_EV_FORK)
+	QUARK_EV_EXEC                 = uint64(C.QUARK_EV_EXEC)
+	QUARK_EV_EXIT                 = uint64(C.QUARK_EV_EXIT)
+	QUARK_EV_SETPROCTITLE         = uint64(C.QUARK_EV_SETPROCTITLE)
+	QUARK_EV_SOCK_CONN_CLOSED     = uint64(C.QUARK_EV_SOCK_CONN_CLOSED)
+	QUARK_EV_PACKET               = uint64(C.QUARK_EV_PACKET)
+	QUARK_EV_BYPASS               = uint64(C.QUARK_EV_BYPASS)
+	QUARK_EV_FILE                 = uint64(C.QUARK_EV_FILE)
+	QUARK_EV_PTRACE               = uint64(C.QUARK_EV_PTRACE)
+	QUARK_EV_MODULE_LOAD          = uint64(C.QUARK_EV_MODULE_LOAD)
+	QUARK_EV_SHM                  = uint64(C.QUARK_EV_SHM)
+	QUARK_EV_TTY                  = uint64(C.QUARK_EV_TTY)
+	QUARK_EV_TLS_CONN_ESTABLISHED = uint64(C.QUARK_EV_TLS_CONN_ESTABLISHED)
+	QUARK_EV_TLS_CALL             = uint64(C.QUARK_EV_TLS_CALL)
+
+	// TlsCall.Direction
+	QUARK_TLS_DIR_WRITE = int(C.QUARK_TLS_DIR_WRITE)
+	QUARK_TLS_DIR_READ  = int(C.QUARK_TLS_DIR_READ)
 
 	// EntryLeaderType
 	QUARK_ELT_UNKNOWN   = int(C.QUARK_ELT_UNKNOWN)
@@ -268,6 +310,7 @@ type QueueAttr struct {
 	MaxLength      int
 	CacheGraceTime int
 	HoldTime       int
+	MaxTlsCall     int // max bytes captured per TLS call, only used if QQ_TLS is set; 0 == unlimited
 }
 
 // Documented in https://elastic.github.io/quark/quark_queue_get_stats.3.html.
@@ -308,6 +351,7 @@ func DefaultQueueAttr() QueueAttr {
 		MaxLength:      int(attr.max_length),
 		CacheGraceTime: int(attr.cache_grace_time),
 		HoldTime:       int(attr.hold_time),
+		MaxTlsCall:     int(attr.max_tls_call),
 	}
 }
 
@@ -328,6 +372,7 @@ func OpenQueue(attr QueueAttr) (*Queue, error) {
 	cattr.max_length = C.int(attr.MaxLength)
 	cattr.cache_grace_time = C.int(attr.CacheGraceTime)
 	cattr.hold_time = C.int(attr.HoldTime)
+	cattr.max_tls_call = C.size_t(attr.MaxTlsCall)
 	ok, err := C.quark_queue_open(queue.quarkQueue, &cattr)
 	if ok == -1 {
 		C.free(unsafe.Pointer(queue.quarkQueue))
@@ -355,6 +400,7 @@ func (queue *Queue) GetEvent() (Event, bool) {
 	}
 
 	event.Events = uint64(cev.events)
+	event.Time = uint64(cev.time)
 	event.Process = processFromC(cev.process)
 	if cev.socket != nil {
 		socket := socketFromC(cev.socket)
@@ -383,8 +429,56 @@ func (queue *Queue) GetEvent() (Event, bool) {
 		tty := ttyFromC(cev.tty)
 		event.Tty = &tty
 	}
+	if cev.tls_conn != nil {
+		tlsConn := tlsConnFromC(cev.tls_conn)
+		event.TlsConn = &tlsConn
+	}
+	if cev.tls_call != nil {
+		tlsCall := tlsCallFromC(cev.tls_call)
+		event.TlsCall = &tlsCall
+	}
 
 	return event, true
+}
+
+// TrackTgid adds tgid to the TLS capture allow-list. All SSL_new/SSL_read/
+// SSL_write activity from tgid (and only tgid, no descendant propagation -
+// callers add children explicitly on fork) is captured once TlsAttach has
+// been called for the binary/library tgid uses.
+func (queue *Queue) TrackTgid(tgid uint32) error {
+	ok, err := C.quark_queue_track_tgid(queue.quarkQueue, C.u32(tgid))
+	if ok == -1 {
+		return wrapErrno(err)
+	}
+
+	return nil
+}
+
+// UntrackTgid removes tgid from the TLS capture allow-list.
+func (queue *Queue) UntrackTgid(tgid uint32) error {
+	ok, err := C.quark_queue_untrack_tgid(queue.quarkQueue, C.u32(tgid))
+	if ok == -1 {
+		return wrapErrno(err)
+	}
+
+	return nil
+}
+
+// TlsAttach attaches the SSL_new/SSL_read/SSL_write uprobes at the given
+// file offsets in path. Attachment is system-wide, not scoped to a single
+// process: call this once per distinct binary/library path even if several
+// tracked tgids share it, not once per tgid.
+func (queue *Queue) TlsAttach(path string, sslNewOff, sslReadOff, sslWriteOff uint64) error {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+
+	ok, err := C.quark_queue_tls_attach(queue.quarkQueue, cpath,
+		C.u64(sslNewOff), C.u64(sslReadOff), C.u64(sslWriteOff))
+	if ok == -1 {
+		return wrapErrno(err)
+	}
+
+	return nil
 }
 
 func (queue *Queue) GetEventAsECS() ([]byte, bool, error) {
@@ -664,4 +758,35 @@ func ttyFromC(cTty *C.struct_quark_tty) Tty {
 	}
 
 	return tty
+}
+
+func tlsConnFromC(cTlsConn *C.struct_quark_tls_conn) TlsConn {
+	var tlsConn TlsConn
+
+	tlsConn.ConnId = uint64(cTlsConn.conn_id)
+	tlsConn.Tgid = uint32(cTlsConn.tgid)
+
+	return tlsConn
+}
+
+func tlsCallFromC(cTlsCall *C.struct_quark_tls_call) TlsCall {
+	var call TlsCall
+	var t *C.struct_quark_tls_call
+
+	call.ConnId = uint64(cTlsCall.conn_id)
+	call.Tgid = uint32(cTlsCall.tgid)
+	call.Direction = int(cTlsCall.direction)
+	call.CallSeq = uint64(cTlsCall.call_seq)
+	call.CallLen = uint64(cTlsCall.call_len)
+	call.TotalLen = uint64(cTlsCall.total_len)
+	call.Truncated = uint64(cTlsCall.truncated)
+	call.Gap = cTlsCall.gap != 0
+
+	for t = cTlsCall; t != nil; t = t.next {
+		data := unsafe.Pointer(uintptr(unsafe.Pointer(t)) + unsafe.Sizeof(*t))
+		chunk := C.GoBytes(data, C.int(t.data_len))
+		call.Data = append(call.Data, chunk)
+	}
+
+	return call
 }

--- a/quark-test.c
+++ b/quark-test.c
@@ -1916,9 +1916,9 @@ tls_test_server_ctx(void)
 }
 
 /*
- * Untracked TLS server: never added to tracked_tgids, so none of its own
- * activity is ever captured by quark. It exists purely to give the tracked
- * client something real to handshake with.
+ * TLS server: exists purely to give the client something real to handshake
+ * with. Its own SSL activity is captured too under a system-wide attach, but
+ * the tests drain by the client's pid, so the server's events are ignored.
  */
 static void
 tls_test_server(int fd, size_t req_len, const char *resp, size_t resp_len)
@@ -1978,7 +1978,12 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
 	/* See the matching comment in tls_test_server() */
 	signal(SIGPIPE, SIG_IGN);
 
-	/* Wait until the parent has called quark_queue_track_tgid() on us */
+	/*
+	 * Wait until the parent has released us. For the offset tests the
+	 * probes are already attached system-wide; for the symbol test the
+	 * parent attaches to our pid first, so we must not SSL_new until it
+	 * signals, or the connection would be missed and adopted mid-stream.
+	 */
 	if (read(syncfd, &c, 1) != 1)
 		err(1, "client sync read");
 	close(syncfd);
@@ -2023,10 +2028,10 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
 
 /*
  * Late-adoption variant of tls_test_client(): the SSL_new + SSL_connect
- * handshake runs *before* the client signals the parent, so the parent tracks
- * it only afterwards and quark never sees this connection's SSL_new. The first
- * SSL_write below therefore misses tls_conns and is adopted in place, minting a
- * conn_id flagged PREFIX_UNKNOWN.
+ * handshake runs *before* the client signals the parent, so the parent attaches
+ * the probes only afterwards and quark never sees this connection's SSL_new. The
+ * first SSL_write below therefore misses tls_conns and is adopted in place,
+ * minting a conn_id flagged PREFIX_UNKNOWN.
  */
 static void
 tls_test_client_late(int fd, int rsyncfd, int wsyncfd, const char *req,
@@ -2053,12 +2058,12 @@ tls_test_client_late(int fd, int rsyncfd, int wsyncfd, const char *req,
 	if (SSL_connect(ssl) != 1)
 		errx(1, "SSL_connect");
 
-	/* Handshake done while still untracked: ask the parent to track us. */
+	/* Handshake done before any probe is attached: tell the parent. */
 	if (write(wsyncfd, "", 1) != 1)
 		err(1, "client sync write");
 	close(wsyncfd);
 
-	/* Proceed only once the parent has called quark_queue_track_tgid(). */
+	/* Proceed only once the parent has attached the probes. */
 	if (read(rsyncfd, &c, 1) != 1)
 		err(1, "client sync read");
 	close(rsyncfd);
@@ -2108,16 +2113,16 @@ tls_attach(struct quark_queue *qq)
 	if (tls_resolve((void *)SSL_free, &path, &free_off) != 0)
 		errx(1, "can't resolve SSL_free");
 
-	/* pid -1: system-wide, gated by the tracked_tgids allow-list. */
+	/* pid -1: system-wide, every process hitting these offsets is captured. */
 	if (quark_queue_tls_attach(qq, -1, path, new_off, read_off, write_off,
 	    free_off) == NULL)
 		err(1, "quark_queue_tls_attach");
 }
 
 /*
- * Forks an untracked TLS server and a tracked TLS client connected over a
- * socketpair, and tracks only the client's tgid. The uprobes must already be
- * attached via tls_attach().
+ * Forks a TLS server and a TLS client connected over a socketpair. The uprobes
+ * must already be attached via tls_attach(); the client blocks until we release
+ * it, purely to keep the harness in step with the symbol-attach variant.
  */
 static void
 tls_session_start(struct tls_session *ts, struct quark_queue *qq,
@@ -2152,19 +2157,19 @@ tls_session_start(struct tls_session *ts, struct quark_queue *qq,
 	close(sv[1]);
 	close(syncfds[0]);
 
-	if (quark_queue_track_tgid(qq, ts->client) != 0)
-		err(1, "quark_queue_track_tgid");
-
-	/* Tracking is in place now, let the client proceed */
+	/* Probes are already attached, let the client proceed */
 	if (write(syncfds[1], "", 1) != 1)
 		err(1, "client sync write");
 	close(syncfds[1]);
 }
 
 /*
- * Like tls_session_start(), but the client handshakes before it is tracked (see
- * tls_test_client_late): the parent waits for the client's "handshake done"
- * signal, tracks it, then releases it into the data phase.
+ * Like tls_session_start(), but the client handshakes before the probes are
+ * attached (see tls_test_client_late): the parent waits for the client's
+ * "handshake done" signal, attaches system-wide only then, and releases it into
+ * the data phase. The connection's SSL_new is thus missed and its first
+ * SSL_write is adopted mid-stream. Attaches itself, so callers must not
+ * pre-attach via tls_attach().
  */
 static void
 tls_session_start_late(struct tls_session *ts, struct quark_queue *qq,
@@ -2206,15 +2211,15 @@ tls_session_start_late(struct tls_session *ts, struct quark_queue *qq,
 	close(up[0]);
 	close(down[1]);
 
-	/* Wait for the client to finish its handshake before tracking it. */
+	/* Wait for the client to finish its handshake before attaching. */
 	if (read(down[0], &c, 1) != 1)
 		err(1, "parent sync read");
 	close(down[0]);
 
-	if (quark_queue_track_tgid(qq, ts->client) != 0)
-		err(1, "quark_queue_track_tgid");
+	/* Attach only now, so the already-open connection's SSL_new is missed. */
+	tls_attach(qq);
 
-	/* Tracking is in place now, let the client proceed to write/read. */
+	/* Probes are in place now, let the client proceed to write/read. */
 	if (write(up[1], "", 1) != 1)
 		err(1, "client sync write");
 	close(up[1]);
@@ -2234,8 +2239,6 @@ tls_session_finish(struct quark_queue *qq, struct tls_session *ts)
 		err(1, "waitpid server");
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
 		errx(1, "tls server didn't exit cleanly");
-
-	(void)quark_queue_untrack_tgid(qq, ts->client);
 }
 
 /*
@@ -2386,8 +2389,8 @@ t_tls_call(const struct test *t, struct quark_queue_attr *qa)
 }
 
 /*
- * A connection whose SSL_new the probes never saw (here the client is tracked
- * only after it has handshaked) must not be dropped silently. Its first
+ * A connection whose SSL_new the probes never saw (here the probes attach only
+ * after the client has handshaked) must not be dropped silently. Its first
  * SSL_write adopts the connection on the spot: a conn_id is minted, flagged
  * PREFIX_UNKNOWN so the missing prefix is visible, and the payload is still
  * delivered under it.
@@ -2405,8 +2408,7 @@ t_tls_late_adopt(const struct test *t, struct quark_queue_attr *qa)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	tls_attach(&qq);
-
+	/* tls_session_start_late() attaches late itself; don't pre-attach. */
 	tls_session_start_late(&ts, &qq, tls_req_small, strlen(tls_req_small),
 	    tls_resp_small, strlen(tls_resp_small));
 
@@ -2546,10 +2548,10 @@ t_tls_truncated(const struct test *t, struct quark_queue_attr *qa)
 }
 
 /*
- * Two tracked clients talking through the same system-wide uprobes at the
- * same time must never bleed into each other: each SSL_new mints its own
- * globally-unique conn_id, and each client's captured request bytes must come
- * back tagged with that client's conn_id and tgid.
+ * Two clients talking through the same system-wide uprobes at the same time
+ * must never bleed into each other: each SSL_new mints its own globally-unique
+ * conn_id, and each client's captured request bytes must come back tagged with
+ * that client's conn_id and tgid.
  */
 static int
 t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
@@ -2627,9 +2629,8 @@ t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
 
 /*
  * Like tls_session_start(), but attaches by symbol name to the client's own
- * libssl scoped to its pid (which quark_queue_tls_attach_sym tracks itself),
- * instead of the system-wide offset attach + explicit track the offset tests
- * use. Returns the attachment handle so the caller can detach it.
+ * libssl scoped to its pid, instead of the system-wide offset attach the other
+ * offset tests use. Returns the attachment handle so the caller can detach it.
  */
 static struct quark_tls_attachment *
 tls_session_start_sym(struct tls_session *ts, struct quark_queue *qq,

--- a/quark-test.c
+++ b/quark-test.c
@@ -1979,10 +1979,9 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
 	signal(SIGPIPE, SIG_IGN);
 
 	/*
-	 * Wait until the parent has released us. For the offset tests the
-	 * probes are already attached system-wide; for the symbol test the
-	 * parent attaches to our pid first, so we must not SSL_new until it
-	 * signals, or the connection would be missed and adopted mid-stream.
+	 * Wait until the parent has released us. The probes are already
+	 * attached system-wide by the time we are signalled, so SSL_new is
+	 * observed from birth rather than adopted mid-stream.
 	 */
 	if (read(syncfd, &c, 1) != 1)
 		err(1, "client sync read");
@@ -2243,8 +2242,9 @@ tls_session_finish(struct quark_queue *qq, struct tls_session *ts)
 
 /*
  * Asserts a fully reassembled quark_tls_call chain against the buffer the
- * application actually passed to SSL_read/SSL_write (call_len), tolerating
- * a deliberate per-call cap (want_truncated bytes off the tail).
+ * application actually passed to SSL_read/SSL_write (call_len). want_truncated
+ * is how many bytes are expected to be missing from the tail (0 when the whole
+ * call was captured).
  */
 static void
 assert_tls_call(struct quark_tls_call *qtc, enum quark_tls_direction direction,
@@ -2282,6 +2282,12 @@ t_tls_load(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct quark_queue	qq;
 
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
+
 	qa->flags |= QQ_TLS;
 
 	if (quark_queue_open(&qq, qa) != 0)
@@ -2299,6 +2305,12 @@ t_tls_conn(const struct test *t, struct quark_queue_attr *qa)
 	struct tls_session		 ts;
 	const struct quark_event	*qev;
 	u64				 conn_id;
+
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
 
 	qa->flags |= QQ_TLS;
 
@@ -2347,6 +2359,12 @@ t_tls_call(const struct test *t, struct quark_queue_attr *qa)
 	struct tls_session		 ts;
 	const struct quark_event	*qev;
 	u64				 conn_id;
+
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
 
 	qa->flags |= QQ_TLS;
 
@@ -2402,6 +2420,12 @@ t_tls_late_adopt(const struct test *t, struct quark_queue_attr *qa)
 	struct tls_session		 ts;
 	const struct quark_event	*qev;
 	u64				 conn_id;
+
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
 
 	qa->flags |= QQ_TLS;
 
@@ -2460,6 +2484,12 @@ t_tls_multichunk(const struct test *t, struct quark_queue_attr *qa)
 	size_t				 req_len;
 	u64				 conn_id;
 
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
+
 	req_len = 70000;	/* > TLS_CHUNK_MAX (32768): forces 3 chunks */
 	if ((req = malloc(req_len)) == NULL)
 		err(1, "malloc");
@@ -2498,55 +2528,6 @@ t_tls_multichunk(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
-static int
-t_tls_truncated(const struct test *t, struct quark_queue_attr *qa)
-{
-	struct quark_queue		 qq;
-	struct tls_session		 ts;
-	const struct quark_event	*qev;
-	char				*req;
-	size_t				 req_len, cap;
-	u64				 conn_id;
-
-	req_len = 200000;
-	cap = 65536;		/* 2 * TLS_CHUNK_MAX, well under req_len */
-	if ((req = malloc(req_len)) == NULL)
-		err(1, "malloc");
-	fill_pattern(req, req_len);
-
-	qa->flags |= QQ_TLS;
-	qa->max_tls_call = cap;
-
-	if (quark_queue_open(&qq, qa) != 0)
-		err(1, "quark_queue_open");
-
-	tls_attach(&qq);
-
-	tls_session_start(&ts, &qq, req, req_len, tls_resp_small,
-	    strlen(tls_resp_small));
-
-	qev = drain_for_pid(&qq, ts.client);	/* FORK */
-	assert(qev->events & QUARK_EV_FORK);
-
-	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
-	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
-	conn_id = qev->tls_conn->conn_id;
-
-	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
-	assert(qev->events == QUARK_EV_TLS_CALL);
-	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
-	    req, req_len, req_len - cap);
-
-	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: read (response) */
-	assert(qev->events == QUARK_EV_TLS_CALL);
-
-	tls_session_finish(&qq, &ts);
-	quark_queue_close(&qq);
-	free(req);
-
-	return (0);
-}
-
 /*
  * Two clients talking through the same system-wide uprobes at the same time
  * must never bleed into each other: each SSL_new mints its own globally-unique
@@ -2563,6 +2544,12 @@ t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
 	const char			*req1 = "POST /bbbbbbbbbbbb HTTP/1.1\r\n\r\n";
 	u64				 conn0, conn1;
 	int				 got0, got1;
+
+	if (in_valgrind) {
+		warnx("%s: skipping under valgrind: valgrind's ptrace use "
+		    "delivers a SIGTRAP that breaks uprobes", __func__);
+		return (0);
+	}
 
 	conn0 = conn1 = 0;
 	got0 = got1 = 0;
@@ -2622,136 +2609,6 @@ t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
 
 	tls_session_finish(&qq, &ts0);
 	tls_session_finish(&qq, &ts1);
-	quark_queue_close(&qq);
-
-	return (0);
-}
-
-/*
- * Like tls_session_start(), but attaches by symbol name to the client's own
- * libssl scoped to its pid, instead of the system-wide offset attach the other
- * offset tests use. Returns the attachment handle so the caller can detach it.
- */
-static struct quark_tls_attachment *
-tls_session_start_sym(struct tls_session *ts, struct quark_queue *qq,
-    const char *path, const char *req, size_t req_len,
-    const char *resp, size_t resp_len)
-{
-	struct quark_tls_attachment	*att;
-	int				 sv[2];
-	int				 syncfds[2];
-
-	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
-		err(1, "socketpair");
-	if (pipe(syncfds) == -1)
-		err(1, "pipe");
-
-	if ((ts->server = fork()) == -1)
-		err(1, "fork");
-	if (ts->server == 0) {
-		close(sv[1]);
-		close(syncfds[0]);
-		close(syncfds[1]);
-		tls_test_server(sv[0], req_len, resp, resp_len);
-		/* NOTREACHED */
-	}
-	close(sv[0]);
-
-	if ((ts->client = fork()) == -1)
-		err(1, "fork");
-	if (ts->client == 0) {
-		close(syncfds[1]);
-		tls_test_client(sv[1], syncfds[0], req, req_len, resp_len);
-		/* NOTREACHED */
-	}
-	close(sv[1]);
-	close(syncfds[0]);
-
-	/* The client blocks on syncfds until we've attached to its pid. */
-	if ((att = quark_queue_tls_attach_sym(qq, ts->client, path)) == NULL)
-		err(1, "quark_queue_tls_attach_sym");
-
-	if (write(syncfds[1], "", 1) != 1)
-		err(1, "client sync write");
-	close(syncfds[1]);
-
-	return (att);
-}
-
-/*
- * Symbol-based attach against the client's real libssl: resolves SSL_* by name
- * (not by pre-computed offset) and captures the same establish + write.
- */
-static int
-t_tls_attach_sym(const struct test *t, struct quark_queue_attr *qa)
-{
-	struct quark_queue		 qq;
-	struct tls_session		 ts;
-	struct quark_tls_attachment	*att;
-	const struct quark_event	*qev;
-	const char			*path;
-	u64				 conn_id, new_off;
-
-	qa->flags |= QQ_TLS;
-
-	if (quark_queue_open(&qq, qa) != 0)
-		err(1, "quark_queue_open");
-
-	/* Only need libssl's path here; the symbols are resolved by name. */
-	if (tls_resolve((void *)SSL_new, &path, &new_off) != 0)
-		errx(1, "can't resolve SSL_new");
-	if (path[0] != '/')
-		errx(1, "resolved non-absolute path: %s", path);
-
-	att = tls_session_start_sym(&ts, &qq, path, tls_req_small,
-	    strlen(tls_req_small), tls_resp_small, strlen(tls_resp_small));
-
-	qev = drain_for_pid(&qq, ts.client);	/* FORK */
-	assert(qev->events & QUARK_EV_FORK);
-
-	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
-	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
-	assert(qev->tls_conn->flags == 0);
-	conn_id = qev->tls_conn->conn_id;
-
-	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
-	assert(qev->events == QUARK_EV_TLS_CALL);
-	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
-	    tls_req_small, strlen(tls_req_small), 0);
-
-	/* Detach via the handle mid-session; the rest just drains out. */
-	quark_queue_tls_detach(&qq, att);
-
-	tls_session_finish(&qq, &ts);
-	quark_queue_close(&qq);
-
-	return (0);
-}
-
-/*
- * A symbol attach against a target with no SSL_* symbols (and against a path
- * that doesn't exist) must fail cleanly rather than crash or half-attach.
- */
-static int
-t_tls_attach_sym_missing(const struct test *t, struct quark_queue_attr *qa)
-{
-	struct quark_queue		 qq;
-	struct quark_tls_attachment	*att;
-
-	qa->flags |= QQ_TLS;
-
-	if (quark_queue_open(&qq, qa) != 0)
-		err(1, "quark_queue_open");
-
-	/* A real ELF that only imports SSL_* (undefined here), so none resolve. */
-	att = quark_queue_tls_attach_sym(&qq, getpid(), "/proc/self/exe");
-	assert(att == NULL);
-
-	/* A path that doesn't exist at all. */
-	att = quark_queue_tls_attach_sym(&qq, getpid(),
-	    "/nonexistent/definitely/not/a/library.so");
-	assert(att == NULL);
-
 	quark_queue_close(&qq);
 
 	return (0);
@@ -3375,10 +3232,7 @@ struct test all_tests[] = {
 	T_EBPF(t_tls_call),
 	T_EBPF(t_tls_late_adopt),
 	T_EBPF(t_tls_multichunk),
-	T_EBPF(t_tls_truncated),
 	T_EBPF(t_tls_multiproc),
-	T_EBPF(t_tls_attach_sym),
-	T_EBPF(t_tls_attach_sym_missing),
 #endif /* WITH_TLS_TESTS */
 	T_EBPF(t_cgroup_parse),
 	T_EBPF(t_namespace),

--- a/quark-test.c
+++ b/quark-test.c
@@ -2028,8 +2028,75 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
 }
 
 /*
- * Resolves SSL_new/SSL_read/SSL_write to a path + file offset in the loaded
- * libssl and attaches quark's TLS uprobes system-wide. The attach is
+ * Late-adoption variant of tls_test_client(): the SSL_new + SSL_connect
+ * handshake runs *before* the client signals the parent, so the parent tracks
+ * it only afterwards and quark never sees this connection's SSL_new. The first
+ * SSL_write below therefore misses tls_conns and is adopted in place, minting a
+ * conn_id flagged PREFIX_UNKNOWN. rsyncfd carries "you are tracked, proceed"
+ * from the parent; wsyncfd carries "handshake done, track me now" back to it.
+ */
+static void
+tls_test_client_late(int fd, int rsyncfd, int wsyncfd, const char *req,
+    size_t req_len, size_t resp_len)
+{
+	SSL_CTX	*ctx;
+	SSL	*ssl;
+	char	*resp;
+	char	*wbuf;
+	char	 c;
+	size_t	 got;
+	int	 n;
+
+	/* See the matching comment in tls_test_server() */
+	signal(SIGPIPE, SIG_IGN);
+
+	if ((ctx = SSL_CTX_new(TLS_client_method())) == NULL)
+		errx(1, "SSL_CTX_new(client)");
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+
+	ssl = SSL_new(ctx);
+	SSL_set_fd(ssl, fd);
+
+	if (SSL_connect(ssl) != 1)
+		errx(1, "SSL_connect");
+
+	/* Handshake done while still untracked: ask the parent to track us. */
+	if (write(wsyncfd, "", 1) != 1)
+		err(1, "client sync write");
+	close(wsyncfd);
+
+	/* Proceed only once the parent has called quark_queue_track_tgid(). */
+	if (read(rsyncfd, &c, 1) != 1)
+		err(1, "client sync read");
+	close(rsyncfd);
+
+	if ((wbuf = malloc(req_len)) == NULL)
+		err(1, "malloc");
+	memcpy(wbuf, req, req_len);
+	if (SSL_write(ssl, wbuf, (int)req_len) <= 0)
+		errx(1, "client SSL_write");
+	free(wbuf);
+
+	if ((resp = malloc(resp_len)) == NULL)
+		err(1, "malloc");
+	for (got = 0; got < resp_len; got += (size_t)n) {
+		n = SSL_read(ssl, resp + got, (int)(resp_len - got));
+		if (n <= 0)
+			errx(1, "client SSL_read");
+	}
+	free(resp);
+
+	SSL_shutdown(ssl);
+	SSL_free(ssl);
+	SSL_CTX_free(ctx);
+	close(fd);
+
+	exit(0);
+}
+
+/*
+ * Resolves SSL_new/SSL_read/SSL_write/SSL_free to a path + file offset in the
+ * loaded libssl and attaches quark's TLS uprobes system-wide. The attach is
  * per-binary, not per-process (see quark_queue_tls_attach), so this is called
  * exactly once per queue no matter how many tracked clients follow -- a
  * multi-client test attaches once and starts several sessions.
@@ -2038,7 +2105,7 @@ static void
 tls_attach(struct quark_queue *qq)
 {
 	const char	*path;
-	u64		 new_off, read_off, write_off;
+	u64		 new_off, read_off, write_off, free_off;
 
 	if (tls_resolve((void *)SSL_new, &path, &new_off) != 0)
 		errx(1, "can't resolve SSL_new");
@@ -2048,8 +2115,11 @@ tls_attach(struct quark_queue *qq)
 		errx(1, "can't resolve SSL_read");
 	if (tls_resolve((void *)SSL_write, &path, &write_off) != 0)
 		errx(1, "can't resolve SSL_write");
+	if (tls_resolve((void *)SSL_free, &path, &free_off) != 0)
+		errx(1, "can't resolve SSL_free");
 
-	if (quark_queue_tls_attach(qq, path, new_off, read_off, write_off) != 0)
+	if (quark_queue_tls_attach(qq, path, new_off, read_off, write_off,
+	    free_off) != 0)
 		err(1, "quark_queue_tls_attach");
 }
 
@@ -2100,6 +2170,66 @@ tls_session_start(struct tls_session *ts, struct quark_queue *qq,
 	if (write(syncfds[1], "", 1) != 1)
 		err(1, "client sync write");
 	close(syncfds[1]);
+}
+
+/*
+ * Like tls_session_start(), but the client handshakes before it is tracked (see
+ * tls_test_client_late): the parent waits for the client's "handshake done"
+ * signal, tracks it, then releases it into the data phase. The connection is
+ * thus adopted mid-stream rather than seen from SSL_new.
+ */
+static void
+tls_session_start_late(struct tls_session *ts, struct quark_queue *qq,
+    const char *req, size_t req_len, const char *resp, size_t resp_len)
+{
+	int	sv[2];
+	int	up[2];		/* parent -> client: proceed */
+	int	down[2];	/* client -> parent: handshake done */
+	char	c;
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
+		err(1, "socketpair");
+	if (pipe(up) == -1 || pipe(down) == -1)
+		err(1, "pipe");
+
+	if ((ts->server = fork()) == -1)
+		err(1, "fork");
+	if (ts->server == 0) {
+		close(sv[1]);
+		close(up[0]);
+		close(up[1]);
+		close(down[0]);
+		close(down[1]);
+		tls_test_server(sv[0], req_len, resp, resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[0]);
+
+	if ((ts->client = fork()) == -1)
+		err(1, "fork");
+	if (ts->client == 0) {
+		close(up[1]);
+		close(down[0]);
+		tls_test_client_late(sv[1], up[0], down[1], req, req_len,
+		    resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[1]);
+	close(up[0]);
+	close(down[1]);
+
+	/* Wait for the client to finish its handshake before tracking it. */
+	if (read(down[0], &c, 1) != 1)
+		err(1, "parent sync read");
+	close(down[0]);
+
+	if (quark_queue_track_tgid(qq, ts->client) != 0)
+		err(1, "quark_queue_track_tgid");
+
+	/* Tracking is in place now, let the client proceed to write/read. */
+	if (write(up[1], "", 1) != 1)
+		err(1, "client sync write");
+	close(up[1]);
 }
 
 static void
@@ -2179,6 +2309,7 @@ t_tls_conn(const struct test *t, struct quark_queue_attr *qa)
 	struct quark_queue		 qq;
 	struct tls_session		 ts;
 	const struct quark_event	*qev;
+	u64				 conn_id;
 
 	qa->flags |= QQ_TLS;
 
@@ -2197,6 +2328,21 @@ t_tls_conn(const struct test *t, struct quark_queue_attr *qa)
 	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
 	assert(qev->tls_conn != NULL);
 	assert(qev->tls_conn->conn_id != 0);
+	assert(qev->tls_conn->tgid == (u32)ts.client);
+	/* Seen from SSL_new, so its prefix is intact -- not adopted mid-stream. */
+	assert(qev->tls_conn->flags == 0);
+	conn_id = qev->tls_conn->conn_id;
+
+	/*
+	 * The close is the counterpart to the establish above: SSL_free emits
+	 * it with the same conn_id. Drain past the intervening read/write
+	 * calls to reach it.
+	 */
+	do {
+		qev = drain_for_pid(&qq, ts.client);
+	} while (!(qev->events & QUARK_EV_TLS_CONN_CLOSED));
+	assert(qev->tls_conn != NULL);
+	assert(qev->tls_conn->conn_id == conn_id);
 	assert(qev->tls_conn->tgid == (u32)ts.client);
 
 	tls_session_finish(&qq, &ts);
@@ -2228,6 +2374,7 @@ t_tls_call(const struct test *t, struct quark_queue_attr *qa)
 
 	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
 	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	assert(qev->tls_conn->flags == 0);
 	conn_id = qev->tls_conn->conn_id;
 
 	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
@@ -2239,6 +2386,71 @@ t_tls_call(const struct test *t, struct quark_queue_attr *qa)
 	assert(qev->events == QUARK_EV_TLS_CALL);
 	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_READ, conn_id,
 	    tls_resp_small, strlen(tls_resp_small), 0);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_CLOSED (SSL_free) */
+	assert(qev->events == QUARK_EV_TLS_CONN_CLOSED);
+	assert(qev->tls_conn != NULL);
+	assert(qev->tls_conn->conn_id == conn_id);
+	assert(qev->tls_conn->tgid == (u32)ts.client);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * A connection whose SSL_new the probes never saw (here the client is tracked
+ * only after it has handshaked) must not be dropped silently. Its first
+ * SSL_write adopts the connection on the spot: a conn_id is minted, flagged
+ * PREFIX_UNKNOWN so the missing prefix is visible, and the payload is still
+ * delivered under it. This is the late-attach / re-hook path -- the connection
+ * and its traffic surface instead of being lost. The establish is emitted from
+ * the same probe call as the first chunk, but always ahead of it (submitted
+ * first, so it sorts first even on a timestamp tie), so drain order holds.
+ */
+static int
+t_tls_late_adopt(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	const struct quark_event	*qev;
+	u64				 conn_id;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start_late(&ts, &qq, tls_req_small, strlen(tls_req_small),
+	    tls_resp_small, strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED (adopted) */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	assert(qev->tls_conn != NULL);
+	assert(qev->tls_conn->conn_id != 0);
+	assert(qev->tls_conn->tgid == (u32)ts.client);
+	/* Adopted mid-stream, so its prefix was missed. */
+	assert(qev->tls_conn->flags & QUARK_TLS_CONN_F_PREFIX_UNKNOWN);
+	conn_id = qev->tls_conn->conn_id;
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
+	    tls_req_small, strlen(tls_req_small), 0);
+
+	/* SSL_free still closes the adopted connection under the same conn_id. */
+	do {
+		qev = drain_for_pid(&qq, ts.client);
+	} while (!(qev->events & QUARK_EV_TLS_CONN_CLOSED));
+	assert(qev->tls_conn != NULL);
+	assert(qev->tls_conn->conn_id == conn_id);
+	assert(qev->tls_conn->tgid == (u32)ts.client);
 
 	tls_session_finish(&qq, &ts);
 	quark_queue_close(&qq);
@@ -3049,6 +3261,7 @@ struct test all_tests[] = {
 	T_EBPF(t_tls_load),
 	T_EBPF(t_tls_conn),
 	T_EBPF(t_tls_call),
+	T_EBPF(t_tls_late_adopt),
 	T_EBPF(t_tls_multichunk),
 	T_EBPF(t_tls_truncated),
 	T_EBPF(t_tls_multiproc),

--- a/quark-test.c
+++ b/quark-test.c
@@ -27,6 +27,7 @@
 #include <ifaddrs.h>
 #include <limits.h>
 #include <sched.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,6 +35,15 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
+
+#if !defined(STATIC) && defined(HAVE_OPENSSL)
+#define WITH_TLS_TESTS
+#include <dlfcn.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#endif /* !STATIC && HAVE_OPENSSL */
 
 #include "quark.h"
 
@@ -1807,6 +1817,624 @@ t_dns(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
+#ifdef WITH_TLS_TESTS
+
+/*
+ * Self-signed EC P-256 cert+key, valid 100 years from generation, used only
+ * to give the in-process TLS handshake below something to present. CN is
+ * irrelevant since the client never verifies it (SSL_VERIFY_NONE).
+ */
+static const char tls_test_cert_pem[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBlzCCAT2gAwIBAgIUIsxJCdwn9Bk3ytpQh78igIk2EdUwCgYIKoZIzj0EAwIw\n"
+"FTETMBEGA1UEAwwKcXVhcmstdGVzdDAgFw0yNjA2MzAyMTU0MzlaGA8yMTI2MDYw\n"
+"NjIxNTQzOVowFTETMBEGA1UEAwwKcXVhcmstdGVzdDBZMBMGByqGSM49AgEGCCqG\n"
+"SM49AwEHA0IABAoKixIVb5LuFwx88POgva0Ef6nEsjg2bieR7CwGHxxQnF9QfPqa\n"
+"ths6HegBeCQsvNfG5npgBWSL4erK0mtvP82jaTBnMB0GA1UdDgQWBBQMJKDCZCv8\n"
+"KZ/edHBQjhB7LJrlZjAfBgNVHSMEGDAWgBQMJKDCZCv8KZ/edHBQjhB7LJrlZjAP\n"
+"BgNVHRMBAf8EBTADAQH/MBQGA1UdEQQNMAuCCWxvY2FsaG9zdDAKBggqhkjOPQQD\n"
+"AgNIADBFAiAtklGw3Y4+Gt0pkQzlQW499VPnnEKUh5pzbQKJhf74eQIhAMBWxjjW\n"
+"b9mjQ5YMeCEJVw+q7Bon1UhWn/qT59X/PJI6\n"
+"-----END CERTIFICATE-----\n";
+
+static const char tls_test_key_pem[] =
+"-----BEGIN EC PRIVATE KEY-----\n"
+"MHcCAQEEIGjD4WqMPVIM/yaVJ4LR51eTW9MQYeFwDH/vwvJ1PEjzoAoGCCqGSM49\n"
+"AwEHoUQDQgAECgqLEhVvku4XDHzw86C9rQR/qcSyODZuJ5HsLAYfHFCcX1B8+pq2\n"
+"Gzod6AF4JCy818bmemAFZIvh6srSa28/zQ==\n"
+"-----END EC PRIVATE KEY-----\n";
+
+static const char tls_req_small[] = "GET /v1/messages HTTP/1.1\r\n";
+static const char tls_resp_small[] = "HTTP/1.1 200 OK\r\n";
+
+struct tls_session {
+	pid_t	client;
+	pid_t	server;
+};
+
+/*
+ * SSL_new/SSL_read/SSL_write are already resolved addresses in our own
+ * address space (we link libssl directly). dladdr() tells us which shared
+ * object backs a given address and that object's load bias. For an ET_DYN
+ * ELF (any .so), vaddr and file offset are numerically identical, so
+ * subtracting the load bias from the runtime address gives exactly the
+ * file offset quark_queue_tls_attach() wants -- the same quantity an
+ * external resolver (build-id registry, ELF symbol table) would have to
+ * produce for a stripped binary it can't run code in.
+ */
+static int
+tls_resolve(void *sym, const char **path, u64 *off)
+{
+	Dl_info	info;
+
+	if (dladdr(sym, &info) == 0 || info.dli_fname == NULL ||
+	    info.dli_fbase == NULL)
+		return (-1);
+
+	*path = info.dli_fname;
+	*off = (u64)((uintptr_t)sym - (uintptr_t)info.dli_fbase);
+
+	return (0);
+}
+
+static void
+fill_pattern(char *buf, size_t len)
+{
+	size_t	i, plen;
+
+	plen = strlen(PATTERN);
+	for (i = 0; i < len; i++)
+		buf[i] = PATTERN[i % plen];
+}
+
+static SSL_CTX *
+tls_test_server_ctx(void)
+{
+	SSL_CTX		*ctx;
+	BIO		*bio;
+	X509		*cert;
+	EVP_PKEY	*key;
+
+	if ((ctx = SSL_CTX_new(TLS_server_method())) == NULL)
+		errx(1, "SSL_CTX_new(server)");
+
+	if ((bio = BIO_new_mem_buf(tls_test_cert_pem, -1)) == NULL)
+		errx(1, "BIO_new_mem_buf(cert)");
+	cert = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+	BIO_free(bio);
+	if (cert == NULL || SSL_CTX_use_certificate(ctx, cert) != 1)
+		errx(1, "SSL_CTX_use_certificate");
+	X509_free(cert);
+
+	if ((bio = BIO_new_mem_buf(tls_test_key_pem, -1)) == NULL)
+		errx(1, "BIO_new_mem_buf(key)");
+	key = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+	BIO_free(bio);
+	if (key == NULL || SSL_CTX_use_PrivateKey(ctx, key) != 1)
+		errx(1, "SSL_CTX_use_PrivateKey");
+	EVP_PKEY_free(key);
+
+	return (ctx);
+}
+
+/*
+ * Untracked TLS server: never added to tracked_tgids, so none of its own
+ * SSL_new/SSL_read/SSL_write activity is ever captured by quark. It exists
+ * purely to give the tracked client something real to handshake with.
+ */
+static void
+tls_test_server(int fd, size_t req_len, const char *resp, size_t resp_len)
+{
+	SSL_CTX	*ctx;
+	SSL	*ssl;
+	char	*req;
+	size_t	 got;
+	int	 n;
+
+	/*
+	 * SSL_shutdown() can still try to write a close_notify after the peer
+	 * has already gone away; without this the default SIGPIPE disposition
+	 * kills this child right after it has otherwise succeeded.
+	 */
+	signal(SIGPIPE, SIG_IGN);
+
+	ctx = tls_test_server_ctx();
+	ssl = SSL_new(ctx);
+	SSL_set_fd(ssl, fd);
+
+	if (SSL_accept(ssl) != 1)
+		errx(1, "SSL_accept");
+
+	if ((req = malloc(req_len)) == NULL)
+		err(1, "malloc");
+	for (got = 0; got < req_len; got += (size_t)n) {
+		n = SSL_read(ssl, req + got, (int)(req_len - got));
+		if (n <= 0)
+			errx(1, "server SSL_read");
+	}
+	free(req);
+
+	if (SSL_write(ssl, resp, (int)resp_len) <= 0)
+		errx(1, "server SSL_write");
+
+	SSL_shutdown(ssl);
+	SSL_free(ssl);
+	SSL_CTX_free(ctx);
+	close(fd);
+
+	exit(0);
+}
+
+static void
+tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
+    size_t resp_len)
+{
+	SSL_CTX	*ctx;
+	SSL	*ssl;
+	char	*resp;
+	char	*wbuf;
+	char	 c;
+	size_t	 got;
+	int	 n;
+
+	/* See the matching comment in tls_test_server() */
+	signal(SIGPIPE, SIG_IGN);
+
+	/* Wait until the parent has called quark_queue_track_tgid() on us */
+	if (read(syncfd, &c, 1) != 1)
+		err(1, "client sync read");
+	close(syncfd);
+
+	if ((ctx = SSL_CTX_new(TLS_client_method())) == NULL)
+		errx(1, "SSL_CTX_new(client)");
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+
+	ssl = SSL_new(ctx);
+	SSL_set_fd(ssl, fd);
+
+	if (SSL_connect(ssl) != 1)
+		errx(1, "SSL_connect");
+
+	/*
+	 * Callers pass static string literals for the small fixed-content
+	 * tests; copy into a heap buffer this process just wrote before
+	 * SSL_write(), since req's page may otherwise have never been
+	 * touched by us at all. A real request body is always built into
+	 * memory the app just wrote, so this matches that -- it isn't
+	 * working around anything on quark's side.
+	 */
+	if ((wbuf = malloc(req_len)) == NULL)
+		err(1, "malloc");
+	memcpy(wbuf, req, req_len);
+	if (SSL_write(ssl, wbuf, (int)req_len) <= 0)
+		errx(1, "client SSL_write");
+	free(wbuf);
+
+	if ((resp = malloc(resp_len)) == NULL)
+		err(1, "malloc");
+	for (got = 0; got < resp_len; got += (size_t)n) {
+		n = SSL_read(ssl, resp + got, (int)(resp_len - got));
+		if (n <= 0)
+			errx(1, "client SSL_read");
+	}
+	free(resp);
+
+	SSL_shutdown(ssl);
+	SSL_free(ssl);
+	SSL_CTX_free(ctx);
+	close(fd);
+
+	exit(0);
+}
+
+/*
+ * Resolves SSL_new/SSL_read/SSL_write to a path + file offset in the loaded
+ * libssl and attaches quark's TLS uprobes system-wide. The attach is
+ * per-binary, not per-process (see quark_queue_tls_attach), so this is called
+ * exactly once per queue no matter how many tracked clients follow -- a
+ * multi-client test attaches once and starts several sessions.
+ */
+static void
+tls_attach(struct quark_queue *qq)
+{
+	const char	*path;
+	u64		 new_off, read_off, write_off;
+
+	if (tls_resolve((void *)SSL_new, &path, &new_off) != 0)
+		errx(1, "can't resolve SSL_new");
+	if (path[0] != '/')
+		errx(1, "resolved non-absolute path: %s", path);
+	if (tls_resolve((void *)SSL_read, &path, &read_off) != 0)
+		errx(1, "can't resolve SSL_read");
+	if (tls_resolve((void *)SSL_write, &path, &write_off) != 0)
+		errx(1, "can't resolve SSL_write");
+
+	if (quark_queue_tls_attach(qq, path, new_off, read_off, write_off) != 0)
+		err(1, "quark_queue_tls_attach");
+}
+
+/*
+ * Forks an untracked TLS server and a tracked TLS client connected over a
+ * socketpair, and tracks only the client's tgid: the client is added to the
+ * allow-list while the peer it talks to is deliberately left off it, so the
+ * capture path is exercised end to end alongside the tgid gating. The
+ * uprobes must already be attached via tls_attach().
+ */
+static void
+tls_session_start(struct tls_session *ts, struct quark_queue *qq,
+    const char *req, size_t req_len, const char *resp, size_t resp_len)
+{
+	int		 sv[2];
+	int		 syncfds[2];
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
+		err(1, "socketpair");
+	if (pipe(syncfds) == -1)
+		err(1, "pipe");
+
+	if ((ts->server = fork()) == -1)
+		err(1, "fork");
+	if (ts->server == 0) {
+		close(sv[1]);
+		close(syncfds[0]);
+		close(syncfds[1]);
+		tls_test_server(sv[0], req_len, resp, resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[0]);
+
+	if ((ts->client = fork()) == -1)
+		err(1, "fork");
+	if (ts->client == 0) {
+		close(syncfds[1]);
+		tls_test_client(sv[1], syncfds[0], req, req_len, resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[1]);
+	close(syncfds[0]);
+
+	if (quark_queue_track_tgid(qq, ts->client) != 0)
+		err(1, "quark_queue_track_tgid");
+
+	/* Tracking is in place now, let the client proceed */
+	if (write(syncfds[1], "", 1) != 1)
+		err(1, "client sync write");
+	close(syncfds[1]);
+}
+
+static void
+tls_session_finish(struct quark_queue *qq, struct tls_session *ts)
+{
+	int	status;
+
+	if (waitpid(ts->client, &status, 0) == -1)
+		err(1, "waitpid client");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		errx(1, "tls client didn't exit cleanly");
+
+	if (waitpid(ts->server, &status, 0) == -1)
+		err(1, "waitpid server");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		errx(1, "tls server didn't exit cleanly");
+
+	(void)quark_queue_untrack_tgid(qq, ts->client);
+}
+
+/*
+ * Asserts a fully reassembled quark_tls_call chain against the buffer the
+ * application actually passed to SSL_read/SSL_write (call_len), tolerating
+ * a deliberate per-call cap (want_truncated bytes off the tail).
+ */
+static void
+assert_tls_call(struct quark_tls_call *qtc, enum quark_tls_direction direction,
+    u64 conn_id, const char *expect, size_t call_len, size_t want_truncated)
+{
+	size_t	off, want_total;
+	u32	chunk_total;
+
+	want_total = call_len - want_truncated;
+
+	assert(qtc->conn_id == conn_id);
+	assert(qtc->direction == direction);
+	assert(qtc->call_len == call_len);
+	assert(qtc->truncated == want_truncated);
+	assert(qtc->total_len == want_total);
+	/*
+	 * None of these tests engineer a mid-chain drop (that needs either a
+	 * real bpf_probe_read_user failure or a saturated ring buffer,
+	 * neither of which is reproducible deterministically here) -- gap
+	 * must be clean, and so must every individual chunk in the chain.
+	 */
+	assert(qtc->gap == 0);
+
+	chunk_total = qtc->chunk_total;
+	for (off = 0; qtc != NULL; qtc = qtc->next) {
+		assert(qtc->chunk_total == chunk_total);
+		assert(qtc->dropped == 0);
+		assert(off + qtc->data_len <= want_total);
+		assert(!memcmp(qtc->data, expect + off, qtc->data_len));
+		off += qtc->data_len;
+	}
+	assert(off == want_total);
+}
+
+static int
+t_tls_load(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue	qq;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+static int
+t_tls_conn(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	const struct quark_event	*qev;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start(&ts, &qq, tls_req_small, strlen(tls_req_small),
+	    tls_resp_small, strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	assert(qev->tls_conn != NULL);
+	assert(qev->tls_conn->conn_id != 0);
+	assert(qev->tls_conn->tgid == (u32)ts.client);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+static int
+t_tls_call(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	const struct quark_event	*qev;
+	u64				 conn_id;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start(&ts, &qq, tls_req_small, strlen(tls_req_small),
+	    tls_resp_small, strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	conn_id = qev->tls_conn->conn_id;
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
+	    tls_req_small, strlen(tls_req_small), 0);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: read (response) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_READ, conn_id,
+	    tls_resp_small, strlen(tls_resp_small), 0);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * A single SSL_write() call sees the whole application buffer atomically
+ * (the uprobe reads it straight from the call's argument before the
+ * library fragments it into TLS records), so the write direction is where
+ * multi-chunk reassembly is deterministic to test. SSL_read() returns
+ * whatever happens to be decrypted at call time, bounded by TLS's own
+ * 16KiB per-record plaintext ceiling, so it isn't used here.
+ */
+static int
+t_tls_multichunk(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	const struct quark_event	*qev;
+	char				*req;
+	size_t				 req_len;
+	u64				 conn_id;
+
+	req_len = 70000;	/* > TLS_CHUNK_MAX (32768): forces 3 chunks */
+	if ((req = malloc(req_len)) == NULL)
+		err(1, "malloc");
+	fill_pattern(req, req_len);
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start(&ts, &qq, req, req_len, tls_resp_small,
+	    strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	conn_id = qev->tls_conn->conn_id;
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert(qev->tls_call->next != NULL);	/* must actually be chunked */
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
+	    req, req_len, 0);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: read (response) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+	free(req);
+
+	return (0);
+}
+
+static int
+t_tls_truncated(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	const struct quark_event	*qev;
+	char				*req;
+	size_t				 req_len, cap;
+	u64				 conn_id;
+
+	req_len = 200000;
+	cap = 65536;		/* 2 * TLS_CHUNK_MAX, well under req_len */
+	if ((req = malloc(req_len)) == NULL)
+		err(1, "malloc");
+	fill_pattern(req, req_len);
+
+	qa->flags |= QQ_TLS;
+	qa->max_tls_call = cap;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start(&ts, &qq, req, req_len, tls_resp_small,
+	    strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	conn_id = qev->tls_conn->conn_id;
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
+	    req, req_len, req_len - cap);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: read (response) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+	free(req);
+
+	return (0);
+}
+
+/*
+ * Two tracked clients talking through the same system-wide uprobes at the
+ * same time must never bleed into each other: each SSL_new mints its own
+ * globally-unique conn_id, and each client's captured request bytes must come
+ * back tagged with that client's conn_id and tgid. A regression to a per-tgid
+ * conn_id counter, or an ssl->conn_id key that dropped tgid, would surface
+ * here as a shared conn_id or a swapped payload.
+ */
+static int
+t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts0, ts1;
+	const struct quark_event	*qev;
+	const char			*req0 = "GET /aaaaaa HTTP/1.1\r\n\r\n";
+	const char			*req1 = "POST /bbbbbbbbbbbb HTTP/1.1\r\n\r\n";
+	u64				 conn0, conn1;
+	int				 got0, got1;
+
+	conn0 = conn1 = 0;
+	got0 = got1 = 0;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	tls_attach(&qq);
+
+	tls_session_start(&ts0, &qq, req0, strlen(req0),
+	    tls_resp_small, strlen(tls_resp_small));
+	tls_session_start(&ts1, &qq, req1, strlen(req1),
+	    tls_resp_small, strlen(tls_resp_small));
+
+	/*
+	 * The two clients' events interleave, so drain in arrival order and
+	 * dispatch by pid -- draining one client to completion would make
+	 * drain_for_pid() discard the other's events.
+	 */
+	while (!got0 || !got1) {
+		qev = drain_any(&qq);
+		if (qev->process == NULL)
+			continue;
+
+		if (qev->events == QUARK_EV_TLS_CONN_ESTABLISHED) {
+			if (qev->process->pid == (u32)ts0.client)
+				conn0 = qev->tls_conn->conn_id;
+			else if (qev->process->pid == (u32)ts1.client)
+				conn1 = qev->tls_conn->conn_id;
+			continue;
+		}
+
+		if (qev->events != QUARK_EV_TLS_CALL)
+			continue;
+		if (qev->tls_call->direction != QUARK_TLS_DIR_WRITE)
+			continue;
+
+		if (qev->process->pid == (u32)ts0.client) {
+			assert(conn0 != 0);
+			assert(qev->tls_call->tgid == (u32)ts0.client);
+			assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE,
+			    conn0, req0, strlen(req0), 0);
+			got0 = 1;
+		} else if (qev->process->pid == (u32)ts1.client) {
+			assert(conn1 != 0);
+			assert(qev->tls_call->tgid == (u32)ts1.client);
+			assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE,
+			    conn1, req1, strlen(req1), 0);
+			got1 = 1;
+		}
+	}
+
+	assert(conn0 != 0 && conn1 != 0);
+	assert(conn0 != conn1);
+
+	tls_session_finish(&qq, &ts0);
+	tls_session_finish(&qq, &ts1);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+#endif /* WITH_TLS_TESTS */
+
 static int
 t_cgroup_parse(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -2417,6 +3045,14 @@ struct test all_tests[] = {
 	T_EBPF(t_tty),
 	T_EBPF(t_sock_conn),
 	T_EBPF(t_dns),
+#ifdef WITH_TLS_TESTS
+	T_EBPF(t_tls_load),
+	T_EBPF(t_tls_conn),
+	T_EBPF(t_tls_call),
+	T_EBPF(t_tls_multichunk),
+	T_EBPF(t_tls_truncated),
+	T_EBPF(t_tls_multiproc),
+#endif /* WITH_TLS_TESTS */
 	T_EBPF(t_cgroup_parse),
 	T_EBPF(t_namespace),
 	T_KPROBE(t_namespace),

--- a/quark-test.c
+++ b/quark-test.c
@@ -1820,9 +1820,9 @@ t_dns(const struct test *t, struct quark_queue_attr *qa)
 #ifdef WITH_TLS_TESTS
 
 /*
- * Self-signed EC P-256 cert+key, valid 100 years from generation, used only
- * to give the in-process TLS handshake below something to present. CN is
- * irrelevant since the client never verifies it (SSL_VERIFY_NONE).
+ * Self-signed EC P-256 cert+key, used only to give the in-process TLS
+ * handshake below something to present. CN is irrelevant since the client
+ * never verifies it (SSL_VERIFY_NONE).
  */
 static const char tls_test_cert_pem[] =
 "-----BEGIN CERTIFICATE-----\n"
@@ -1858,9 +1858,7 @@ struct tls_session {
  * object backs a given address and that object's load bias. For an ET_DYN
  * ELF (any .so), vaddr and file offset are numerically identical, so
  * subtracting the load bias from the runtime address gives exactly the
- * file offset quark_queue_tls_attach() wants -- the same quantity an
- * external resolver (build-id registry, ELF symbol table) would have to
- * produce for a stripped binary it can't run code in.
+ * file offset quark_queue_tls_attach() wants.
  */
 static int
 tls_resolve(void *sym, const char **path, u64 *off)
@@ -1919,8 +1917,8 @@ tls_test_server_ctx(void)
 
 /*
  * Untracked TLS server: never added to tracked_tgids, so none of its own
- * SSL_new/SSL_read/SSL_write activity is ever captured by quark. It exists
- * purely to give the tracked client something real to handshake with.
+ * activity is ever captured by quark. It exists purely to give the tracked
+ * client something real to handshake with.
  */
 static void
 tls_test_server(int fd, size_t req_len, const char *resp, size_t resp_len)
@@ -1996,12 +1994,8 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
 		errx(1, "SSL_connect");
 
 	/*
-	 * Callers pass static string literals for the small fixed-content
-	 * tests; copy into a heap buffer this process just wrote before
-	 * SSL_write(), since req's page may otherwise have never been
-	 * touched by us at all. A real request body is always built into
-	 * memory the app just wrote, so this matches that -- it isn't
-	 * working around anything on quark's side.
+	 * Copy into a heap buffer this process just wrote before SSL_write(),
+	 * since req's page may otherwise have never been touched by us at all.
 	 */
 	if ((wbuf = malloc(req_len)) == NULL)
 		err(1, "malloc");
@@ -2032,8 +2026,7 @@ tls_test_client(int fd, int syncfd, const char *req, size_t req_len,
  * handshake runs *before* the client signals the parent, so the parent tracks
  * it only afterwards and quark never sees this connection's SSL_new. The first
  * SSL_write below therefore misses tls_conns and is adopted in place, minting a
- * conn_id flagged PREFIX_UNKNOWN. rsyncfd carries "you are tracked, proceed"
- * from the parent; wsyncfd carries "handshake done, track me now" back to it.
+ * conn_id flagged PREFIX_UNKNOWN.
  */
 static void
 tls_test_client_late(int fd, int rsyncfd, int wsyncfd, const char *req,
@@ -2096,10 +2089,7 @@ tls_test_client_late(int fd, int rsyncfd, int wsyncfd, const char *req,
 
 /*
  * Resolves SSL_new/SSL_read/SSL_write/SSL_free to a path + file offset in the
- * loaded libssl and attaches quark's TLS uprobes system-wide. The attach is
- * per-binary, not per-process (see quark_queue_tls_attach), so this is called
- * exactly once per queue no matter how many tracked clients follow -- a
- * multi-client test attaches once and starts several sessions.
+ * loaded libssl and attaches quark's TLS uprobes system-wide.
  */
 static void
 tls_attach(struct quark_queue *qq)
@@ -2125,10 +2115,8 @@ tls_attach(struct quark_queue *qq)
 
 /*
  * Forks an untracked TLS server and a tracked TLS client connected over a
- * socketpair, and tracks only the client's tgid: the client is added to the
- * allow-list while the peer it talks to is deliberately left off it, so the
- * capture path is exercised end to end alongside the tgid gating. The
- * uprobes must already be attached via tls_attach().
+ * socketpair, and tracks only the client's tgid. The uprobes must already be
+ * attached via tls_attach().
  */
 static void
 tls_session_start(struct tls_session *ts, struct quark_queue *qq,
@@ -2175,8 +2163,7 @@ tls_session_start(struct tls_session *ts, struct quark_queue *qq,
 /*
  * Like tls_session_start(), but the client handshakes before it is tracked (see
  * tls_test_client_late): the parent waits for the client's "handshake done"
- * signal, tracks it, then releases it into the data phase. The connection is
- * thus adopted mid-stream rather than seen from SSL_new.
+ * signal, tracks it, then releases it into the data phase.
  */
 static void
 tls_session_start_late(struct tls_session *ts, struct quark_queue *qq,
@@ -2270,10 +2257,8 @@ assert_tls_call(struct quark_tls_call *qtc, enum quark_tls_direction direction,
 	assert(qtc->truncated == want_truncated);
 	assert(qtc->total_len == want_total);
 	/*
-	 * None of these tests engineer a mid-chain drop (that needs either a
-	 * real bpf_probe_read_user failure or a saturated ring buffer,
-	 * neither of which is reproducible deterministically here) -- gap
-	 * must be clean, and so must every individual chunk in the chain.
+	 * None of these tests engineer a mid-chain drop -- gap must be clean,
+	 * and so must every individual chunk in the chain.
 	 */
 	assert(qtc->gap == 0);
 
@@ -2404,10 +2389,7 @@ t_tls_call(const struct test *t, struct quark_queue_attr *qa)
  * only after it has handshaked) must not be dropped silently. Its first
  * SSL_write adopts the connection on the spot: a conn_id is minted, flagged
  * PREFIX_UNKNOWN so the missing prefix is visible, and the payload is still
- * delivered under it. This is the late-attach / re-hook path -- the connection
- * and its traffic surface instead of being lost. The establish is emitted from
- * the same probe call as the first chunk, but always ahead of it (submitted
- * first, so it sorts first even on a timestamp tie), so drain order holds.
+ * delivered under it.
  */
 static int
 t_tls_late_adopt(const struct test *t, struct quark_queue_attr *qa)
@@ -2459,12 +2441,11 @@ t_tls_late_adopt(const struct test *t, struct quark_queue_attr *qa)
 }
 
 /*
- * A single SSL_write() call sees the whole application buffer atomically
- * (the uprobe reads it straight from the call's argument before the
- * library fragments it into TLS records), so the write direction is where
- * multi-chunk reassembly is deterministic to test. SSL_read() returns
- * whatever happens to be decrypted at call time, bounded by TLS's own
- * 16KiB per-record plaintext ceiling, so it isn't used here.
+ * A single SSL_write() call sees the whole application buffer atomically, so
+ * the write direction is where multi-chunk reassembly is deterministic to
+ * test. SSL_read() returns whatever happens to be decrypted at call time,
+ * bounded by TLS's own 16KiB per-record plaintext ceiling, so it isn't used
+ * here.
  */
 static int
 t_tls_multichunk(const struct test *t, struct quark_queue_attr *qa)
@@ -2567,9 +2548,7 @@ t_tls_truncated(const struct test *t, struct quark_queue_attr *qa)
  * Two tracked clients talking through the same system-wide uprobes at the
  * same time must never bleed into each other: each SSL_new mints its own
  * globally-unique conn_id, and each client's captured request bytes must come
- * back tagged with that client's conn_id and tgid. A regression to a per-tgid
- * conn_id counter, or an ssl->conn_id key that dropped tgid, would surface
- * here as a shared conn_id or a swapped payload.
+ * back tagged with that client's conn_id and tgid.
  */
 static int
 t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)

--- a/quark-test.c
+++ b/quark-test.c
@@ -2108,8 +2108,9 @@ tls_attach(struct quark_queue *qq)
 	if (tls_resolve((void *)SSL_free, &path, &free_off) != 0)
 		errx(1, "can't resolve SSL_free");
 
-	if (quark_queue_tls_attach(qq, path, new_off, read_off, write_off,
-	    free_off) != 0)
+	/* pid -1: system-wide, gated by the tracked_tgids allow-list. */
+	if (quark_queue_tls_attach(qq, -1, path, new_off, read_off, write_off,
+	    free_off) == NULL)
 		err(1, "quark_queue_tls_attach");
 }
 
@@ -2619,6 +2620,137 @@ t_tls_multiproc(const struct test *t, struct quark_queue_attr *qa)
 
 	tls_session_finish(&qq, &ts0);
 	tls_session_finish(&qq, &ts1);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * Like tls_session_start(), but attaches by symbol name to the client's own
+ * libssl scoped to its pid (which quark_queue_tls_attach_sym tracks itself),
+ * instead of the system-wide offset attach + explicit track the offset tests
+ * use. Returns the attachment handle so the caller can detach it.
+ */
+static struct quark_tls_attachment *
+tls_session_start_sym(struct tls_session *ts, struct quark_queue *qq,
+    const char *path, const char *req, size_t req_len,
+    const char *resp, size_t resp_len)
+{
+	struct quark_tls_attachment	*att;
+	int				 sv[2];
+	int				 syncfds[2];
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
+		err(1, "socketpair");
+	if (pipe(syncfds) == -1)
+		err(1, "pipe");
+
+	if ((ts->server = fork()) == -1)
+		err(1, "fork");
+	if (ts->server == 0) {
+		close(sv[1]);
+		close(syncfds[0]);
+		close(syncfds[1]);
+		tls_test_server(sv[0], req_len, resp, resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[0]);
+
+	if ((ts->client = fork()) == -1)
+		err(1, "fork");
+	if (ts->client == 0) {
+		close(syncfds[1]);
+		tls_test_client(sv[1], syncfds[0], req, req_len, resp_len);
+		/* NOTREACHED */
+	}
+	close(sv[1]);
+	close(syncfds[0]);
+
+	/* The client blocks on syncfds until we've attached to its pid. */
+	if ((att = quark_queue_tls_attach_sym(qq, ts->client, path)) == NULL)
+		err(1, "quark_queue_tls_attach_sym");
+
+	if (write(syncfds[1], "", 1) != 1)
+		err(1, "client sync write");
+	close(syncfds[1]);
+
+	return (att);
+}
+
+/*
+ * Symbol-based attach against the client's real libssl: resolves SSL_* by name
+ * (not by pre-computed offset) and captures the same establish + write.
+ */
+static int
+t_tls_attach_sym(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct tls_session		 ts;
+	struct quark_tls_attachment	*att;
+	const struct quark_event	*qev;
+	const char			*path;
+	u64				 conn_id, new_off;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	/* Only need libssl's path here; the symbols are resolved by name. */
+	if (tls_resolve((void *)SSL_new, &path, &new_off) != 0)
+		errx(1, "can't resolve SSL_new");
+	if (path[0] != '/')
+		errx(1, "resolved non-absolute path: %s", path);
+
+	att = tls_session_start_sym(&ts, &qq, path, tls_req_small,
+	    strlen(tls_req_small), tls_resp_small, strlen(tls_resp_small));
+
+	qev = drain_for_pid(&qq, ts.client);	/* FORK */
+	assert(qev->events & QUARK_EV_FORK);
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CONN_ESTABLISHED */
+	assert(qev->events == QUARK_EV_TLS_CONN_ESTABLISHED);
+	assert(qev->tls_conn->flags == 0);
+	conn_id = qev->tls_conn->conn_id;
+
+	qev = drain_for_pid(&qq, ts.client);	/* TLS_CALL: write (request) */
+	assert(qev->events == QUARK_EV_TLS_CALL);
+	assert_tls_call(qev->tls_call, QUARK_TLS_DIR_WRITE, conn_id,
+	    tls_req_small, strlen(tls_req_small), 0);
+
+	/* Detach via the handle mid-session; the rest just drains out. */
+	quark_queue_tls_detach(&qq, att);
+
+	tls_session_finish(&qq, &ts);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * A symbol attach against a target with no SSL_* symbols (and against a path
+ * that doesn't exist) must fail cleanly rather than crash or half-attach.
+ */
+static int
+t_tls_attach_sym_missing(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	struct quark_tls_attachment	*att;
+
+	qa->flags |= QQ_TLS;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	/* A real ELF that only imports SSL_* (undefined here), so none resolve. */
+	att = quark_queue_tls_attach_sym(&qq, getpid(), "/proc/self/exe");
+	assert(att == NULL);
+
+	/* A path that doesn't exist at all. */
+	att = quark_queue_tls_attach_sym(&qq, getpid(),
+	    "/nonexistent/definitely/not/a/library.so");
+	assert(att == NULL);
+
 	quark_queue_close(&qq);
 
 	return (0);
@@ -3244,6 +3376,8 @@ struct test all_tests[] = {
 	T_EBPF(t_tls_multichunk),
 	T_EBPF(t_tls_truncated),
 	T_EBPF(t_tls_multiproc),
+	T_EBPF(t_tls_attach_sym),
+	T_EBPF(t_tls_attach_sym_missing),
 #endif /* WITH_TLS_TESTS */
 	T_EBPF(t_cgroup_parse),
 	T_EBPF(t_namespace),

--- a/quark.c
+++ b/quark.c
@@ -4080,7 +4080,6 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
 	qa->max_env = 4096;		/* one page per process */
-	qa->max_tls_call = 1 << 20;	/* 1 MiB; 0 == unlimited */
 	qa->kubefd = -1;		/* disabled */
 	qa->ruleset = NULL;		/* no rules */
 }
@@ -4157,7 +4156,6 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	qq->cache_grace_time = MS_TO_NS(qa->cache_grace_time);
 	qq->hold_time = qa->hold_time;
 	qq->max_env = qa->max_env;
-	qq->max_tls_call = qa->max_tls_call;
 	qq->ruleset = qa->ruleset;
 	qq->length = 0;
 	qq->epollfd = -1;
@@ -4248,6 +4246,18 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	    bpf_queue_open(qq) != 0 &&
 	    kprobe_queue_open(qq) != 0) {
 		qwarnx("all backends failed");
+		goto fail;
+	}
+
+	/*
+	 * TLS capture is implemented only in the eBPF backend. If the caller
+	 * asked for it but QQ_ALL_BACKENDS fell back to a non-eBPF backend,
+	 * fail cleanly rather than hand back a queue whose tls_attach APIs
+	 * can't work.
+	 */
+	if ((qq->flags & QQ_TLS) && qq->stats.backend != QQ_EBPF) {
+		qwarnx("QQ_TLS requires the eBPF backend");
+		errno = ENOTSUP;
 		goto fail;
 	}
 
@@ -4479,10 +4489,10 @@ quark_can_aggregate_tty(struct quark_queue *qq,
 }
 
 /*
- * Unlike quark_can_aggregate_tty(), there is no size ceiling here: the BPF
- * side already caps the total bytes captured per call at qq->max_tls_call
- * before it ever emits the first chunk. Identity (conn_id, direction,
- * call_seq) is the only thing that decides whether two chunks belong together.
+ * Unlike quark_can_aggregate_tty(), there is no size ceiling here: a call is
+ * reassembled in full from however many chunks the BPF side split it into.
+ * Identity (conn_id, direction, call_seq) is the only thing that decides
+ * whether two chunks belong together.
  */
 int
 quark_can_aggregate_tls(struct quark_queue *qq,

--- a/quark.c
+++ b/quark.c
@@ -134,6 +134,7 @@ raw_event_alloc(int type)
 	case RAW_SHM:		/* caller allocates */
 	case RAW_TTY:		/* caller allocates */
 	case RAW_TLS_CONN:	/* caller allocates */
+	case RAW_TLS_CONN_CLOSE:	/* caller allocates */
 	case RAW_TLS_CHUNK:	/* caller allocates */
 		break;
 	default:
@@ -200,6 +201,7 @@ raw_event_free(struct raw_event *raw)
 		free(raw->tty.quark_tty);
 		break;
 	case RAW_TLS_CONN:
+	case RAW_TLS_CONN_CLOSE:
 		free(raw->tls_conn.quark_tls_conn);
 		break;
 	case RAW_TLS_CHUNK:
@@ -4862,7 +4864,8 @@ raw_event_tls_conn(struct quark_queue *qq, struct raw_event *raw)
 
 	qev = &qq->event_storage;
 
-	qev->events = QUARK_EV_TLS_CONN_ESTABLISHED;
+	qev->events = raw->type == RAW_TLS_CONN_CLOSE ?
+	    QUARK_EV_TLS_CONN_CLOSED : QUARK_EV_TLS_CONN_ESTABLISHED;
 	qev->process = quark_process_lookup(qq, raw->pid);
 	/* Steal it */
 	qev->tls_conn = raw->tls_conn.quark_tls_conn;
@@ -5280,6 +5283,7 @@ quark_queue_get_event(struct quark_queue *qq)
 			qev = raw_event_tty(qq, raw);
 			break;
 		case RAW_TLS_CONN:
+		case RAW_TLS_CONN_CLOSE:
 			qev = raw_event_tls_conn(qq, raw);
 			break;
 		case RAW_TLS_CHUNK:

--- a/quark.c
+++ b/quark.c
@@ -4481,21 +4481,12 @@ quark_can_aggregate_tty(struct quark_queue *qq,
 /*
  * Unlike quark_can_aggregate_tty(), there is no size ceiling here: the BPF
  * side already caps the total bytes captured per call at qq->max_tls_call
- * before it ever emits the first chunk, so chunk_total (and therefore the
- * number of raw_events that will ever offer themselves up for aggregation
- * here) is bounded by construction. Identity (conn_id, direction, call_seq)
- * is the only thing that decides whether two chunks belong together.
+ * before it ever emits the first chunk. Identity (conn_id, direction,
+ * call_seq) is the only thing that decides whether two chunks belong together.
  *
  * pt->chunk_idx is repurposed once aggregation starts, same as
  * quark_tty.total_len: it stops meaning "this node's own position" and
- * starts meaning "the last position absorbed into this chain." A gap
- * between two otherwise-contiguous chunks means one never arrived at all
- * (e.g. the ring buffer was full); ct->gap means this specific chunk
- * already knew it was bad at creation time (a non-trailing dropped
- * marker). Either way, once gap is set, total_len/data is no longer a
- * safe contiguous prefix of the original call - unlike a clean trailing
- * truncated, which a consumer can still treat as a valid (if incomplete)
- * prefix.
+ * starts meaning "the last position absorbed into this chain."
  */
 int
 quark_can_aggregate_tls(struct quark_queue *qq,
@@ -4522,11 +4513,8 @@ quark_can_aggregate_tls(struct quark_queue *qq,
 	/*
 	 * truncated is NOT refined here, on purpose: a call that arrives as
 	 * exactly one chunk never invokes this function at all (there is
-	 * nothing to aggregate it with), so deriving truncated incrementally
-	 * here would leave it stuck at its allocation-time default for the
-	 * common case. total_len, in contrast, is always correct regardless
-	 * of chunk count, so raw_event_tls_call() recomputes truncated from
-	 * it once, unconditionally, at delivery time.
+	 * nothing to aggregate it with). raw_event_tls_call() derives it from
+	 * total_len at delivery time instead.
 	 */
 	pt->total_len += ct->data_len;
 
@@ -4906,9 +4894,8 @@ raw_event_tls_call(struct quark_queue *qq, struct raw_event *raw)
 
 	/*
 	 * total_len is correct regardless of how many chunks made up this
-	 * call (1 or many), but quark_can_aggregate_tls() only ever runs
-	 * for 2+ chunks, so truncated must be derived from it here,
-	 * unconditionally, rather than relying on that pairwise step.
+	 * call, but quark_can_aggregate_tls() only ever runs for 2+ chunks, so
+	 * truncated must be derived from it here.
 	 */
 	head = raw->tls_chunk.quark_tls_call;
 	head->truncated = head->call_len > head->total_len ?

--- a/quark.c
+++ b/quark.c
@@ -4080,7 +4080,7 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
 	qa->max_env = 4096;		/* one page per process */
-	qa->max_tls_call = 1 << 20;	/* one mebibyte */
+	qa->max_tls_call = 0xffffffff;	/* TEMP debug: ~4 GiB, just under the u32 BPF cap so it can't truncate to 0/unlimited (revert to 1 << 20 / one mebibyte) */
 	qa->kubefd = -1;		/* disabled */
 	qa->ruleset = NULL;		/* no rules */
 }

--- a/quark.c
+++ b/quark.c
@@ -133,6 +133,8 @@ raw_event_alloc(int type)
 	case RAW_MODULE_LOAD:	/* caller allocates */
 	case RAW_SHM:		/* caller allocates */
 	case RAW_TTY:		/* caller allocates */
+	case RAW_TLS_CONN:	/* caller allocates */
+	case RAW_TLS_CHUNK:	/* caller allocates */
 		break;
 	default:
 		qwarnx("unhandled raw_type %d", raw->type);
@@ -196,6 +198,12 @@ raw_event_free(struct raw_event *raw)
 		break;
 	case RAW_TTY:
 		free(raw->tty.quark_tty);
+		break;
+	case RAW_TLS_CONN:
+		free(raw->tls_conn.quark_tls_conn);
+		break;
+	case RAW_TLS_CHUNK:
+		free(raw->tls_chunk.quark_tls_call);
 		break;
 	default:
 		qwarnx("unhandled raw_type %d", raw->type);
@@ -411,6 +419,22 @@ event_storage_clear(struct quark_queue *qq)
 	}
 	free(qq->event_storage.tty);
 	qq->event_storage.tty = NULL;
+
+	free(qq->event_storage.tls_conn);
+	qq->event_storage.tls_conn = NULL;
+
+	if (qq->event_storage.tls_call != NULL) {
+		struct quark_tls_call *current;
+		struct quark_tls_call *next = qq->event_storage.tls_call->next;
+		while (next != NULL) {
+			current = next;
+			next = current->next;
+			free(current);
+		}
+	}
+	free(qq->event_storage.tls_call);
+	qq->event_storage.tls_call = NULL;
+
 	qq->event_storage.id_change = 0;
 }
 
@@ -3725,6 +3749,7 @@ const quark_can_aggregate_fn base_agg_matrix[RAW_NUM_TYPES][RAW_NUM_TYPES] = {
 
 	[RAW_FILE][RAW_FILE]				= quark_can_aggregate_file,
 	[RAW_TTY][RAW_TTY]				= quark_can_aggregate_tty,
+	[RAW_TLS_CHUNK][RAW_TLS_CHUNK]			= quark_can_aggregate_tls,
 };
 
 /* used if qq->flags & QQ_MIN_AGG */
@@ -4053,6 +4078,7 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
 	qa->max_env = 4096;		/* one page per process */
+	qa->max_tls_call = 1 << 20;	/* one mebibyte */
 	qa->kubefd = -1;		/* disabled */
 	qa->ruleset = NULL;		/* no rules */
 }
@@ -4129,6 +4155,7 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	qq->cache_grace_time = MS_TO_NS(qa->cache_grace_time);
 	qq->hold_time = qa->hold_time;
 	qq->max_env = qa->max_env;
+	qq->max_tls_call = qa->max_tls_call;
 	qq->ruleset = qa->ruleset;
 	qq->length = 0;
 	qq->epollfd = -1;
@@ -4447,6 +4474,61 @@ quark_can_aggregate_tty(struct quark_queue *qq,
 	}
 
 	return (0);
+}
+
+/*
+ * Unlike quark_can_aggregate_tty(), there is no size ceiling here: the BPF
+ * side already caps the total bytes captured per call at qq->max_tls_call
+ * before it ever emits the first chunk, so chunk_total (and therefore the
+ * number of raw_events that will ever offer themselves up for aggregation
+ * here) is bounded by construction. Identity (conn_id, direction, call_seq)
+ * is the only thing that decides whether two chunks belong together.
+ *
+ * pt->chunk_idx is repurposed once aggregation starts, same as
+ * quark_tty.total_len: it stops meaning "this node's own position" and
+ * starts meaning "the last position absorbed into this chain." A gap
+ * between two otherwise-contiguous chunks means one never arrived at all
+ * (e.g. the ring buffer was full); ct->gap means this specific chunk
+ * already knew it was bad at creation time (a non-trailing dropped
+ * marker). Either way, once gap is set, total_len/data is no longer a
+ * safe contiguous prefix of the original call - unlike a clean trailing
+ * truncated, which a consumer can still treat as a valid (if incomplete)
+ * prefix.
+ */
+int
+quark_can_aggregate_tls(struct quark_queue *qq,
+    struct raw_event *p, struct raw_event *c)
+{
+	struct quark_tls_call	*pt, *ct;
+
+	pt = p->tls_chunk.quark_tls_call;
+	ct = c->tls_chunk.quark_tls_call;
+
+	if (pt->conn_id != ct->conn_id)
+		return (0);
+	if (pt->direction != ct->direction)
+		return (0);
+	if (pt->call_seq != ct->call_seq)
+		return (0);
+
+	if (ct->chunk_idx != pt->chunk_idx + 1)
+		pt->gap = 1;
+	if (ct->gap)
+		pt->gap = 1;
+	pt->chunk_idx = ct->chunk_idx;
+
+	/*
+	 * truncated is NOT refined here, on purpose: a call that arrives as
+	 * exactly one chunk never invokes this function at all (there is
+	 * nothing to aggregate it with), so deriving truncated incrementally
+	 * here would leave it stuck at its allocation-time default for the
+	 * common case. total_len, in contrast, is always correct regardless
+	 * of chunk count, so raw_event_tls_call() recomputes truncated from
+	 * it once, unconditionally, at delivery time.
+	 */
+	pt->total_len += ct->data_len;
+
+	return (1);
 }
 
 /*
@@ -4769,6 +4851,69 @@ raw_event_tty(struct quark_queue *qq, struct raw_event *raw)
 	/* Steal it */
 	qev->tty = raw->tty.quark_tty;
 	raw->tty.quark_tty = NULL;
+
+	return (qev);
+}
+
+static struct quark_event *
+raw_event_tls_conn(struct quark_queue *qq, struct raw_event *raw)
+{
+	struct quark_event	*qev;
+
+	qev = &qq->event_storage;
+
+	qev->events = QUARK_EV_TLS_CONN_ESTABLISHED;
+	qev->process = quark_process_lookup(qq, raw->pid);
+	/* Steal it */
+	qev->tls_conn = raw->tls_conn.quark_tls_conn;
+	raw->tls_conn.quark_tls_conn = NULL;
+
+	return (qev);
+}
+
+static struct quark_event *
+raw_event_tls_call(struct quark_queue *qq, struct raw_event *raw)
+{
+	struct quark_event	*qev;
+	struct raw_event	*agg, *next;
+	struct quark_tls_call	*head;
+
+	if (raw->tls_chunk.quark_tls_call == NULL) {
+		qwarnx("quark_tls_call is null");
+
+		return (NULL);
+	}
+
+	qev = &qq->event_storage;
+
+	qev->events = QUARK_EV_TLS_CALL;
+	qev->process = quark_process_lookup(qq, raw->pid);
+
+	/* Link raw (our head) to the first chunk in the agg queue */
+	next = TAILQ_FIRST(&raw->agg_queue);
+	if (next != NULL)
+		raw->tls_chunk.quark_tls_call->next = next->tls_chunk.quark_tls_call;
+
+	/* Link the remaining chunks */
+	TAILQ_FOREACH_SAFE(agg, &raw->agg_queue, agg_entry, next) {
+		if (next != NULL)
+			agg->tls_chunk.quark_tls_call->next = next->tls_chunk.quark_tls_call;
+		agg->tls_chunk.quark_tls_call = NULL;
+	}
+
+	/*
+	 * total_len is correct regardless of how many chunks made up this
+	 * call (1 or many), but quark_can_aggregate_tls() only ever runs
+	 * for 2+ chunks, so truncated must be derived from it here,
+	 * unconditionally, rather than relying on that pairwise step.
+	 */
+	head = raw->tls_chunk.quark_tls_call;
+	head->truncated = head->call_len > head->total_len ?
+	    head->call_len - head->total_len : 0;
+
+	/* Steal it */
+	qev->tls_call = head;
+	raw->tls_chunk.quark_tls_call = NULL;
 
 	return (qev);
 }
@@ -5133,6 +5278,12 @@ quark_queue_get_event(struct quark_queue *qq)
 			break;
 		case RAW_TTY:
 			qev = raw_event_tty(qq, raw);
+			break;
+		case RAW_TLS_CONN:
+			qev = raw_event_tls_conn(qq, raw);
+			break;
+		case RAW_TLS_CHUNK:
+			qev = raw_event_tls_call(qq, raw);
 			break;
 		default:
 			qwarnx("unhandled raw->type: %d", raw->type);

--- a/quark.c
+++ b/quark.c
@@ -4080,7 +4080,7 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
 	qa->max_env = 4096;		/* one page per process */
-	qa->max_tls_call = 0xffffffff;	/* TEMP debug: ~4 GiB, just under the u32 BPF cap so it can't truncate to 0/unlimited (revert to 1 << 20 / one mebibyte) */
+	qa->max_tls_call = 1 << 20;	/* 1 MiB; 0 == unlimited */
 	qa->kubefd = -1;		/* disabled */
 	qa->ruleset = NULL;		/* no rules */
 }

--- a/quark.c
+++ b/quark.c
@@ -4483,10 +4483,6 @@ quark_can_aggregate_tty(struct quark_queue *qq,
  * side already caps the total bytes captured per call at qq->max_tls_call
  * before it ever emits the first chunk. Identity (conn_id, direction,
  * call_seq) is the only thing that decides whether two chunks belong together.
- *
- * pt->chunk_idx is repurposed once aggregation starts, same as
- * quark_tty.total_len: it stops meaning "this node's own position" and
- * starts meaning "the last position absorbed into this chain."
  */
 int
 quark_can_aggregate_tls(struct quark_queue *qq,
@@ -4511,10 +4507,7 @@ quark_can_aggregate_tls(struct quark_queue *qq,
 	pt->chunk_idx = ct->chunk_idx;
 
 	/*
-	 * truncated is NOT refined here, on purpose: a call that arrives as
-	 * exactly one chunk never invokes this function at all (there is
-	 * nothing to aggregate it with). raw_event_tls_call() derives it from
-	 * total_len at delivery time instead.
+	 * truncated is defined during aggregation.
 	 */
 	pt->total_len += ct->data_len;
 
@@ -4892,11 +4885,6 @@ raw_event_tls_call(struct quark_queue *qq, struct raw_event *raw)
 		agg->tls_chunk.quark_tls_call = NULL;
 	}
 
-	/*
-	 * total_len is correct regardless of how many chunks made up this
-	 * call, but quark_can_aggregate_tls() only ever runs for 2+ chunks, so
-	 * truncated must be derived from it here.
-	 */
 	head = raw->tls_chunk.quark_tls_call;
 	head->truncated = head->call_len > head->total_len ?
 	    head->call_len - head->total_len : 0;

--- a/quark.h
+++ b/quark.h
@@ -146,28 +146,13 @@ int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 /*
  * Offset attach: pid (-1 for system-wide), path, then SSL_new, SSL_read,
- * SSL_write, SSL_free file offsets, all required. A system-wide attach (pid ==
- * -1) captures every process hitting these offsets, subject only to the
- * trusted-pid deny-list; a pid-scoped attach (pid >= 0) captures only that
- * process. Callers are recommended to track attachments by (dev, inode, offset)
- * and attach once per such tuple; the kernel refcounts uprobes by (inode,
- * offset) only. Returns an opaque handle or NULL.
+ * SSL_write, SSL_free file offsets, all required.
  */
 struct quark_tls_attachment *quark_queue_tls_attach(struct quark_queue *, int,
 			     const char *, u64, u64, u64, u64);
-/*
- * Symbol attach: pid (must be >= 0) and a library path. Resolves SSL_new,
- * SSL_free, SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex
- * (optional) by name. Scopes the uprobes to pid. Returns an opaque handle or
- * NULL.
- */
+
 struct quark_tls_attachment *quark_queue_tls_attach_sym(struct quark_queue *,
 			     int, const char *);
-/*
- * Detach a single attachment created by the two functions above. Idempotent and
- * self-validating: a repeated detach, a handle from another queue, or a NULL
- * handle is a no-op. Must be called on the thread that drains the queue.
- */
 void			 quark_queue_tls_detach(struct quark_queue *,
 			     struct quark_tls_attachment *);
 
@@ -462,23 +447,16 @@ struct raw_shm {
 
 enum quark_tls_direction {
 	QUARK_TLS_DIR_INVALID,
-	QUARK_TLS_DIR_WRITE,	/* outgoing request, SSL_write */
-	QUARK_TLS_DIR_READ,	/* incoming response, SSL_read */
+	QUARK_TLS_DIR_WRITE,
+	QUARK_TLS_DIR_READ,
 };
 
-/*
- * flags bit: the connection was adopted mid-stream (its SSL_new was never
- * seen, e.g. the probes attached after it was already open) rather than
- * observed from birth. Its captured byte stream does not start at the
- * connection's first byte, so call_seq 0 is not the true start.
- */
 #define QUARK_TLS_CONN_F_PREFIX_UNKNOWN	(1 << 0)
 
 struct quark_tls_conn {
-	u64	conn_id;	/* minted at SSL_new; globally unique and never
-				 * reused, so it can be keyed on alone */
+	u64	conn_id;
 	u32	tgid;
-	u32	flags;		/* QUARK_TLS_CONN_F_* */
+	u32	flags;
 };
 
 struct raw_tls_conn {
@@ -981,7 +959,7 @@ struct quark_queue_attr {
 	int			 cache_grace_time;	/* in ms */
 	int			 hold_time;		/* in ms */
 	size_t			 max_env;		/* max process environment in bytes */
-	size_t			 max_tls_call;		/* max bytes captured per TLS call; 0 == unlimited */
+	size_t			 max_tls_call;
 	int			 kubefd;		/* quark-kube-talker pipe, -1 disables */
 	struct quark_ruleset	*ruleset;		/* active ruleset */
 };
@@ -1010,7 +988,7 @@ struct quark_queue {
 	u64				 cache_grace_time;	/* in ns */
 	int				 hold_time;		/* in ms */
 	size_t				 max_env;		/* max process environment in bytes */
-	size_t				 max_tls_call;		/* max bytes captured per TLS call; 0 == unlimited */
+	size_t				 max_tls_call;
 	struct quark_kube		*qkube;			/* NULL if disabled */
 	int				 epollfd;
 	/* Backend related state */

--- a/quark.h
+++ b/quark.h
@@ -150,9 +150,6 @@ int			 quark_queue_trusted_pid_reset(struct quark_queue *);
  */
 struct quark_tls_attachment *quark_queue_tls_attach(struct quark_queue *, int,
 			     const char *, u64, u64, u64, u64);
-
-struct quark_tls_attachment *quark_queue_tls_attach_sym(struct quark_queue *,
-			     int, const char *);
 void			 quark_queue_tls_detach(struct quark_queue *,
 			     struct quark_tls_attachment *);
 
@@ -495,7 +492,8 @@ struct quark_tls_call {
 	u32				 chunk_total;	/* total chunks captured for this call */
 	size_t				 call_len;	/* true call length, before any capping */
 	size_t				 total_len;	/* total bytes in the agg chain: next */
-	size_t				 truncated;	/* bytes truncated past the per-call ceiling */
+	size_t				 truncated;	/* bytes not delivered: call_len - total_len
+						 * (e.g. chunks lost to ring-buffer pressure) */
 	int				 dropped;	/* 1 if this chunk's bytes are known-missing
 						 * (a bpf_probe_read_user failure marker) */
 	int				 gap;		/* 1 if some non-trailing chunk in this chain
@@ -959,7 +957,6 @@ struct quark_queue_attr {
 	int			 cache_grace_time;	/* in ms */
 	int			 hold_time;		/* in ms */
 	size_t			 max_env;		/* max process environment in bytes */
-	size_t			 max_tls_call;
 	int			 kubefd;		/* quark-kube-talker pipe, -1 disables */
 	struct quark_ruleset	*ruleset;		/* active ruleset */
 };
@@ -988,7 +985,6 @@ struct quark_queue {
 	u64				 cache_grace_time;	/* in ns */
 	int				 hold_time;		/* in ms */
 	size_t				 max_env;		/* max process environment in bytes */
-	size_t				 max_tls_call;
 	struct quark_kube		*qkube;			/* NULL if disabled */
 	int				 epollfd;
 	/* Backend related state */

--- a/quark.h
+++ b/quark.h
@@ -163,7 +163,11 @@ struct quark_tls_attachment *quark_queue_tls_attach(struct quark_queue *, int,
  */
 struct quark_tls_attachment *quark_queue_tls_attach_sym(struct quark_queue *,
 			     int, const char *);
-/* Detach a single attachment created by the two functions above. */
+/*
+ * Detach a single attachment created by the two functions above. Idempotent and
+ * self-validating: a repeated detach, a handle from another queue, or a NULL
+ * handle is a no-op. Must be called on the thread that drains the queue.
+ */
 void			 quark_queue_tls_detach(struct quark_queue *,
 			     struct quark_tls_attachment *);
 

--- a/quark.h
+++ b/quark.h
@@ -45,6 +45,7 @@ struct quark_queue_stats;
 struct quark_ruleset;
 struct quark_rule;
 struct quark_rule_field;
+struct quark_tls_attachment;
 typedef int (*quark_can_aggregate_fn)(struct quark_queue *,
     struct raw_event *, struct raw_event *);
 struct raw_event	*raw_event_alloc(int);
@@ -145,10 +146,28 @@ int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 int			 quark_queue_track_tgid(struct quark_queue *, u32);
 int			 quark_queue_untrack_tgid(struct quark_queue *, u32);
-/* path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. All four are
- * required. */
-int			 quark_queue_tls_attach(struct quark_queue *, const char *,
-			     u64, u64, u64, u64);
+/*
+ * Offset attach: pid (-1 for system-wide), path, then SSL_new, SSL_read,
+ * SSL_write, SSL_free file offsets, all required. A system-wide attach is gated
+ * by the tracked_tgids allow-list (quark_queue_track_tgid); a pid-scoped attach
+ * (pid >= 0) tracks its target itself. Callers are recommended to track
+ * attachments by (dev, inode, offset) and attach once per such tuple; the
+ * kernel refcounts uprobes by (inode, offset) only. Returns an opaque handle
+ * or NULL.
+ */
+struct quark_tls_attachment *quark_queue_tls_attach(struct quark_queue *, int,
+			     const char *, u64, u64, u64, u64);
+/*
+ * Symbol attach: pid (must be >= 0) and a library path. Resolves SSL_new,
+ * SSL_free, SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex
+ * (optional) by name. Scopes the uprobes to pid and tracks it itself. Returns
+ * an opaque handle or NULL.
+ */
+struct quark_tls_attachment *quark_queue_tls_attach_sym(struct quark_queue *,
+			     int, const char *);
+/* Detach a single attachment created by the two functions above. */
+void			 quark_queue_tls_detach(struct quark_queue *,
+			     struct quark_tls_attachment *);
 
 /* kprobe_queue.c */
 int			 kprobe_queue_open(struct quark_queue *);

--- a/quark.h
+++ b/quark.h
@@ -145,9 +145,11 @@ int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 int			 quark_queue_track_tgid(struct quark_queue *, u32);
 int			 quark_queue_untrack_tgid(struct quark_queue *, u32);
-/* path, ssl_new file offset, ssl_read file offset, ssl_write file offset */
+/* path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. All four are
+ * required: SSL_new mints the connection, SSL_read/SSL_write carry the data,
+ * and SSL_free tears it down (map cleanup + close event). */
 int			 quark_queue_tls_attach(struct quark_queue *, const char *,
-			     u64, u64, u64);
+			     u64, u64, u64, u64);
 
 /* kprobe_queue.c */
 int			 kprobe_queue_open(struct quark_queue *);
@@ -260,6 +262,7 @@ enum raw_types {
 	RAW_TTY,
 	RAW_GETPID,
 	RAW_TLS_CONN,
+	RAW_TLS_CONN_CLOSE,
 	RAW_TLS_CHUNK,
 	RAW_NUM_TYPES		/* must be last */
 };
@@ -443,12 +446,22 @@ enum quark_tls_direction {
 	QUARK_TLS_DIR_READ,	/* incoming response, SSL_read */
 };
 
+/*
+ * flags bit: the connection was adopted mid-stream (its SSL_new was never
+ * seen, e.g. the probes attached after it was already open) rather than
+ * observed from birth. Its captured byte stream does not start at the
+ * connection's first byte, so call_seq 0 is not the true start. A consumer
+ * that needs the opening bytes should treat such a connection as unreliable.
+ */
+#define QUARK_TLS_CONN_F_PREFIX_UNKNOWN	(1 << 0)
+
 struct quark_tls_conn {
 	u64	conn_id;	/* minted at SSL_new; globally unique across all
 				 * connections and processes, never reused, so it
 				 * can be keyed on alone. tgid gives the owning
 				 * process for correlation */
 	u32	tgid;
+	u32	flags;		/* QUARK_TLS_CONN_F_* */
 };
 
 struct raw_tls_conn {
@@ -565,6 +578,7 @@ struct quark_event {
 #define QUARK_EV_GETPID			(1 << 14)
 #define QUARK_EV_TLS_CONN_ESTABLISHED	(1 << 15)
 #define QUARK_EV_TLS_CALL		(1 << 16)
+#define QUARK_EV_TLS_CONN_CLOSED	(1 << 17)
 	u64				 events;
 	u64				 time;
 	const struct quark_process	*process;

--- a/quark.h
+++ b/quark.h
@@ -108,6 +108,8 @@ int			 quark_can_aggregate_file(struct quark_queue *,
 /* Default aggregation for tty events */
 int			 quark_can_aggregate_tty(struct quark_queue *,
 			     struct raw_event *, struct raw_event *);
+int			 quark_can_aggregate_tls(struct quark_queue *,
+			     struct raw_event *, struct raw_event *);
 
 /* quark.c: These are exported for testing only */
 int	 parse_container_cgroup(const char *, char *, size_t);
@@ -141,6 +143,11 @@ int			 bpf_queue_open(struct quark_queue *);
 struct bpf_probes	*quark_get_bpf_probes(struct quark_queue *);
 int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
+int			 quark_queue_track_tgid(struct quark_queue *, u32);
+int			 quark_queue_untrack_tgid(struct quark_queue *, u32);
+/* path, ssl_new file offset, ssl_read file offset, ssl_write file offset */
+int			 quark_queue_tls_attach(struct quark_queue *, const char *,
+			     u64, u64, u64);
 
 /* kprobe_queue.c */
 int			 kprobe_queue_open(struct quark_queue *);
@@ -252,6 +259,8 @@ enum raw_types {
 	RAW_SHM,
 	RAW_TTY,
 	RAW_GETPID,
+	RAW_TLS_CONN,
+	RAW_TLS_CHUNK,
 	RAW_NUM_TYPES		/* must be last */
 };
 
@@ -428,6 +437,24 @@ struct raw_shm {
 	struct quark_shm	*quark_shm;
 };
 
+enum quark_tls_direction {
+	QUARK_TLS_DIR_INVALID,
+	QUARK_TLS_DIR_WRITE,	/* outgoing request, SSL_write */
+	QUARK_TLS_DIR_READ,	/* incoming response, SSL_read */
+};
+
+struct quark_tls_conn {
+	u64	conn_id;	/* minted at SSL_new; globally unique across all
+				 * connections and processes, never reused, so it
+				 * can be keyed on alone. tgid gives the owning
+				 * process for correlation */
+	u32	tgid;
+};
+
+struct raw_tls_conn {
+	struct quark_tls_conn	*quark_tls_conn;
+};
+
 struct quark_tty {
 	struct quark_tty	*next;
 	size_t			 total_len;	/* total bytes in the agg chain: next */
@@ -446,6 +473,36 @@ struct quark_tty {
 
 struct raw_tty {
 	struct quark_tty	*quark_tty;
+};
+
+struct quark_tls_call {
+	struct quark_tls_call		*next;		/* aggregation chain, like quark_tty */
+	u64				 conn_id;	/* the quark_tls_conn this call belongs to */
+	u32				 tgid;
+	enum quark_tls_direction	 direction;
+	u64				 call_seq;	/* monotonic per (conn_id, direction) */
+	u32				 chunk_idx;	/* this chunk's position; on the head, mutated
+						 * during aggregation to track the last index
+						 * absorbed (same pattern quark_tty.total_len
+						 * already uses) */
+	u32				 chunk_total;	/* total chunks captured for this call */
+	size_t				 call_len;	/* true call length, before any capping */
+	size_t				 total_len;	/* total bytes in the agg chain: next */
+	size_t				 truncated;	/* bytes truncated past the per-call ceiling */
+	int				 dropped;	/* 1 if this specific chunk's bytes are
+						 * known-missing (a bpf_probe_read_user
+						 * failure marker) */
+	int				 gap;		/* 1 if some non-trailing chunk in this chain
+						 * never arrived or was dropped: total_len/data
+						 * is NOT a safe contiguous prefix of the
+						 * original call, unlike a clean trailing
+						 * truncation */
+	size_t				 data_len;
+	char				 data[];
+};
+
+struct raw_tls_chunk {
+	struct quark_tls_call	*quark_tls_call;
 };
 
 struct raw_event {
@@ -471,6 +528,8 @@ struct raw_event {
 		struct raw_module_load		module_load;
 		struct raw_shm			shm;
 		struct raw_tty			tty;
+		struct raw_tls_conn		tls_conn;
+		struct raw_tls_chunk		tls_chunk;
 	};
 };
 
@@ -504,6 +563,8 @@ struct quark_event {
 #define QUARK_EV_SHM			(1 << 12)
 #define QUARK_EV_TTY			(1 << 13)
 #define QUARK_EV_GETPID			(1 << 14)
+#define QUARK_EV_TLS_CONN_ESTABLISHED	(1 << 15)
+#define QUARK_EV_TLS_CALL		(1 << 16)
 	u64				 events;
 	u64				 time;
 	const struct quark_process	*process;
@@ -515,6 +576,8 @@ struct quark_event {
 	struct quark_module_load	*module_load;
 	struct quark_shm		*shm;
 	struct quark_tty		*tty;
+	struct quark_tls_conn		*tls_conn;
+	struct quark_tls_call		*tls_call;
 #define QUARK_ID_CHANGE_SETSID		(1 << 0)
 #define QUARK_ID_CHANGE_SETUID		(1 << 1)
 #define QUARK_ID_CHANGE_SETGID		(1 << 2)
@@ -883,12 +946,14 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
+#define QQ_TLS			(1 << 15)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)	/* QQ_NOVA excluded for now */
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */
 	int			 hold_time;		/* in ms */
 	size_t			 max_env;		/* max process environment in bytes */
+	size_t			 max_tls_call;		/* max bytes captured per TLS call; 0 == unlimited */
 	int			 kubefd;		/* quark-kube-talker pipe, -1 disables */
 	struct quark_ruleset	*ruleset;		/* active ruleset */
 };
@@ -917,6 +982,7 @@ struct quark_queue {
 	u64				 cache_grace_time;	/* in ns */
 	int				 hold_time;		/* in ms */
 	size_t				 max_env;		/* max process environment in bytes */
+	size_t				 max_tls_call;		/* max bytes captured per TLS call; 0 == unlimited */
 	struct quark_kube		*qkube;			/* NULL if disabled */
 	int				 epollfd;
 	/* Backend related state */

--- a/quark.h
+++ b/quark.h
@@ -146,8 +146,7 @@ int			 quark_queue_trusted_pid_reset(struct quark_queue *);
 int			 quark_queue_track_tgid(struct quark_queue *, u32);
 int			 quark_queue_untrack_tgid(struct quark_queue *, u32);
 /* path, then SSL_new, SSL_read, SSL_write, SSL_free file offsets. All four are
- * required: SSL_new mints the connection, SSL_read/SSL_write carry the data,
- * and SSL_free tears it down (map cleanup + close event). */
+ * required. */
 int			 quark_queue_tls_attach(struct quark_queue *, const char *,
 			     u64, u64, u64, u64);
 
@@ -450,16 +449,13 @@ enum quark_tls_direction {
  * flags bit: the connection was adopted mid-stream (its SSL_new was never
  * seen, e.g. the probes attached after it was already open) rather than
  * observed from birth. Its captured byte stream does not start at the
- * connection's first byte, so call_seq 0 is not the true start. A consumer
- * that needs the opening bytes should treat such a connection as unreliable.
+ * connection's first byte, so call_seq 0 is not the true start.
  */
 #define QUARK_TLS_CONN_F_PREFIX_UNKNOWN	(1 << 0)
 
 struct quark_tls_conn {
-	u64	conn_id;	/* minted at SSL_new; globally unique across all
-				 * connections and processes, never reused, so it
-				 * can be keyed on alone. tgid gives the owning
-				 * process for correlation */
+	u64	conn_id;	/* minted at SSL_new; globally unique and never
+				 * reused, so it can be keyed on alone */
 	u32	tgid;
 	u32	flags;		/* QUARK_TLS_CONN_F_* */
 };
@@ -496,20 +492,17 @@ struct quark_tls_call {
 	u64				 call_seq;	/* monotonic per (conn_id, direction) */
 	u32				 chunk_idx;	/* this chunk's position; on the head, mutated
 						 * during aggregation to track the last index
-						 * absorbed (same pattern quark_tty.total_len
-						 * already uses) */
+						 * absorbed */
 	u32				 chunk_total;	/* total chunks captured for this call */
 	size_t				 call_len;	/* true call length, before any capping */
 	size_t				 total_len;	/* total bytes in the agg chain: next */
 	size_t				 truncated;	/* bytes truncated past the per-call ceiling */
-	int				 dropped;	/* 1 if this specific chunk's bytes are
-						 * known-missing (a bpf_probe_read_user
-						 * failure marker) */
+	int				 dropped;	/* 1 if this chunk's bytes are known-missing
+						 * (a bpf_probe_read_user failure marker) */
 	int				 gap;		/* 1 if some non-trailing chunk in this chain
 						 * never arrived or was dropped: total_len/data
 						 * is NOT a safe contiguous prefix of the
-						 * original call, unlike a clean trailing
-						 * truncation */
+						 * original call */
 	size_t				 data_len;
 	char				 data[];
 };

--- a/quark.h
+++ b/quark.h
@@ -144,24 +144,22 @@ int			 bpf_queue_open(struct quark_queue *);
 struct bpf_probes	*quark_get_bpf_probes(struct quark_queue *);
 int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);
-int			 quark_queue_track_tgid(struct quark_queue *, u32);
-int			 quark_queue_untrack_tgid(struct quark_queue *, u32);
 /*
  * Offset attach: pid (-1 for system-wide), path, then SSL_new, SSL_read,
- * SSL_write, SSL_free file offsets, all required. A system-wide attach is gated
- * by the tracked_tgids allow-list (quark_queue_track_tgid); a pid-scoped attach
- * (pid >= 0) tracks its target itself. Callers are recommended to track
- * attachments by (dev, inode, offset) and attach once per such tuple; the
- * kernel refcounts uprobes by (inode, offset) only. Returns an opaque handle
- * or NULL.
+ * SSL_write, SSL_free file offsets, all required. A system-wide attach (pid ==
+ * -1) captures every process hitting these offsets, subject only to the
+ * trusted-pid deny-list; a pid-scoped attach (pid >= 0) captures only that
+ * process. Callers are recommended to track attachments by (dev, inode, offset)
+ * and attach once per such tuple; the kernel refcounts uprobes by (inode,
+ * offset) only. Returns an opaque handle or NULL.
  */
 struct quark_tls_attachment *quark_queue_tls_attach(struct quark_queue *, int,
 			     const char *, u64, u64, u64, u64);
 /*
  * Symbol attach: pid (must be >= 0) and a library path. Resolves SSL_new,
  * SSL_free, SSL_read, SSL_write (required) and SSL_read_ex, SSL_write_ex
- * (optional) by name. Scopes the uprobes to pid and tracks it itself. Returns
- * an opaque handle or NULL.
+ * (optional) by name. Scopes the uprobes to pid. Returns an opaque handle or
+ * NULL.
  */
 struct quark_tls_attachment *quark_queue_tls_attach_sym(struct quark_queue *,
 			     int, const char *);


### PR DESCRIPTION
This PR adds the possibility to attach uprobes properly to both the systems OpenSSL shared library (libssl*.so) through symbols and to binaries which includes their own compiled static linked OpenSSL/BoringSSL but has their symbols stripped (through offsets).

This represents a draft/opinion on an implementation rather than a required feature request. A few important notes below:

**Notes:**
- It's purely an additive feature, behind a flag that is disabled by default. Any existing user of quark should be able to upgrade and recompile without doing anything and should not break their implementation. If you find anything that contradicts that then please let me know.
- This is purely the functionality itself, it does not include any logic on how to trigger it but rather just the API itself, that keeps the PR "smaller" but also allows for additions in either quark or others that rely on quark to decide their own logic.
- It is not the responsibility of this feature to locate correct offsets, protect against things like TOCTOU or parse any of the data collected. 
- It is the responsibility of the feature to fail safely (for example missing symbols or ensuring all required probes connect correctly), to provide the required arguments to cleanly connect the uprobes, and to properly initialize and destroy any references on startup/shutdown.
- It would in theory work on any protocol, so to not bloat quark's codebase the handling of the actual plaintext bytes is left to the consumer (another quark function or a queue consumer).
- I tried my best to reuse quark's existing functionality and design, including the current event queue, if anyone wants it differently then please let me know as I am open to any feedback or pointers to different ways to implement it.

I won't be including any direction on "how" to retrieve correct offsets, or when/how to trigger this in the PR description but would be happy to discuss it elsewhere.

# Summary

## Answered questions:
1. Q: Currently the default ringbuffer is 4MB, the "best" scenario would be to give this a separate ringbuffer so that it won't have the possibility to block other more important events.
A: Currently we can increase the existing ringbuffer and test first, a second ringbuffer could work though it will still only be 1 queue. A second queue was not preferred.

2. Q: Providing the symbol resolution in quark adds a fair bit of extra code, what to do?.
A: Removed all the specific code for doing symbol resolution, you can still use the tls_attach function with offsets and resolve symbols in userspace. The symbol related functions is easier to add in separate PR.

3. Q: How do we handle lingering map entries for all the connection ID's for a process that for some reason was not freed (like if the process crashes).
A: Moved the code for cleaning up on process exit into the TLS ebpf program itself, mirroring the way that Process/Probe.bpf.c does it, on last thread exiting.

4. Q: Where should I exclude tests from Valgrind, as Uprobes causes SIGTRAP?
A: Removed the Makefile entries and added them to the tests themself as other tests currently do.

## How to use it:
Now to explain a bit about how it works, there is 2 usecases that the public API exposes, the logic to determine **WHEN** to do this is up to either a future quark addition (a rule action as a pure example) or determined by the program that imports quark, as these are attached on-demand, then drained exactly like other events through `GetEvent`

### TlsAttach
When a binary you want to attach to compiles its own static version of `OpenSSL/BoringSSL` you provide the `pid`, `path` and the `offsets` to use (new, read, write, free). It is recommended that you use `-1` as the `pid`, and track this by `(dev, inode)`. This is because you do not need to apply a new tls attachment each time someone starts the same binary or use the same inode object, so when your logic triggers a second time indicating possible new tls attachment, you check if the inode object is already attached and skips, but it's left up to the user on what they want to do. Multiple uprobes on the same inode objecct (but scoped to their specific pid) is refcounted, so it will still only create 1 int3 breakpoints rather than multiple.
It's the same with preventing TOCTOU and similar is up to the user through various common techniques.

### TlsAttachSym (Removed from this PR, will be opened separately, resolve symbols yourself at first)
Mainly meant as a helper for attaching to system shared libraries like `libssl.so`. Currently it does this by already defining the required symbol names.
All you provide is the pid and the inode object path and restricts you from passing `-1` as the PID to prevent mistakes, this is because the overhead is not in filtering out the events but the fact that it adds a `int3` breakpoint for ANY process using `libssl`.

### Draining events
Draining the collected events is done through the same mechanism as before, your `GetEvent` now returns one of three new types that you branch on:

- QUARK_EV_TLS_CONN_ESTABLISHED (ConnId, PID, PrefixUnknown, EventTime)
- QUARK_EV_TLS_CALL (The actual event struct and payload)
- QUARK_EV_TLS_CONN_CLOSED (ConnId, PID, EventTime)

### Closing down

Both `TlsAttach` and `TlsAttachSym` returns a handler, whenever you want to close it again you call `TlsDetach` with the provided handler.

When shutting down, quark will automatically close any handler still open as part of its normal graceful shutdown in case something didn't go wrong, but preferably this would already be empty.

Currently a process with remaining references to open connections are automatically cleaned up on process exit (as mentioned in the open questions at the top).


## Event Flow Chart

```mermaid
flowchart TD
  A["quark_queue_tls_attach / _attach_sym (userspace)"] -->|"one bpf_link per program, stored in ta->links[]"| B["uprobes now live on libssl in the target"]
  B --> C{"target calls an SSL_* function"}
  C -->|SSL_new returns| N["uretprobe__ssl_new"]
  C -->|SSL_write entry+return| W["uprobe/uretprobe__ssl_write"]
  C -->|SSL_read entry+return| R["uprobe/uretprobe__ssl_read"]
  C -->|SSL_free entry| F["uprobe__ssl_free"]
  N -->|"reserve+submit (fixed size)"| RB[("shared ringbuf")]
  W -->|"state set → get → capture"| CAP["tls_capture_io"]
  R -->|"state set → get → capture"| CAP
  CAP -->|"tls_emit_call → bpf_loop → tls_emit_chunk"| PCPU["per-CPU event_buffer_map (scratch)"]
  PCPU -->|"ebpf_ringbuf_write = copy in"| RB
  F -->|reserve+submit| RB
  RB -->|"ring_buffer__consume_n, called INSIDE GetEvent"| CB["bpf_ringbuf_cb → ebpf_events_to_raw"]
  CB -->|raw_event_insert| T["by_time + by_pidtime RB-trees"]
  T -->|"held ~hold_time, then oldest (RB_MIN)"| AGG["quark_queue_aggregate: chains chunks of one call"]
  AGG -->|raw_event_tls_conn / raw_event_tls_call| ES["event_storage (one reused quark_event)"]
  ES -->|"GetEvent() returns it"| GO["your Go Event → your drain"]
```

