### PR TITLE
allow endpoint-ci-admin full access to the Buildkite pipeline.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,6 +24,7 @@ spec:
       repository: elastic/quark
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
+        endpoint-ci-admin: {}
         sec-linux-platform:
           access_level: MANAGE_BUILD_AND_READ
         everyone:


### PR DESCRIPTION
Assigning full privileges on the Buildkite pipeline to `endpoint-ci-admin` group 
