### PR TITLE
Add module taints to module_load events

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -641,6 +641,7 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		qml->name = filename;
 		qml->version = version;
 		qml->src_version = src_version;
+		qml->taints = module->taints;
 		raw->module_load.quark_module_load = qml;
 
 		break;

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -376,6 +376,7 @@ struct ebpf_process_ptrace_event {
 struct ebpf_process_load_module_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
+    uint64_t taints;
     // Variable length fields: filename, mod version, mod srcversion
     struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -341,6 +341,7 @@ int BPF_PROG(module_load, struct module *mod)
     event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
 
     ebpf_pid_info__fill(&event->pids, task);
+    event->taints = BPF_CORE_READ(mod, taints);
 
     pid_t ppid      = BPF_CORE_READ(task, group_leader, real_parent, tgid);
     pid_t curr_tgid = BPF_CORE_READ(task, tgid);

--- a/quark.c
+++ b/quark.c
@@ -2050,6 +2050,21 @@ file_op_mask_str(u32 op_mask, char *buf, size_t len)
 	}
 }
 
+static void
+module_taints_str(u64 taints, char *buf, size_t len)
+{
+	/* One letter per taint bit, see struct taint_flag in kernel/panic.c */
+	const char	*tnts = "PFSRMBUDAWCIOELKXTN";
+	size_t		 i, n;
+
+	*buf = 0;
+	for (i = 0, n = 0; tnts[i] != 0 && n + 1 < len; i++) {
+		if (taints & ((u64)1 << i))
+			buf[n++] = tnts[i];
+	}
+	buf[n] = 0;
+}
+
 #define P(...)						\
 	do {						\
 		if (fprintf(f, __VA_ARGS__) < 0)	\
@@ -2075,6 +2090,7 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 	const struct quark_pod		*pod;
 	const struct quark_container	*container;
 	const struct quark_ptrace	*ptrace;
+	const struct quark_module_load	*qml;
 	int				 pid;
 
 	if (qev->events == QUARK_EV_BYPASS) {
@@ -2158,6 +2174,19 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		PF(fl, "pid=%d request=0x%llx addr=0x%llx data=0x%llx\n",
 		    ptrace->child_pid, ptrace->request,
 		    ptrace->addr, ptrace->data);
+	}
+
+	if (qev->events & QUARK_EV_MODULE_LOAD) {
+		fl = "MODULE";
+
+		qml = qev->module_load;
+		if (qml == NULL)
+			return (-1);
+
+		module_taints_str(qml->taints, buf, sizeof(buf));
+		PF(fl, "name=%s version=%s srcversion=%s taints=0x%llx (%s)\n",
+		    qml->name, qml->version, qml->src_version,
+		    qml->taints, buf);
 	}
 
 	if (qp == NULL)

--- a/quark.h
+++ b/quark.h
@@ -401,6 +401,7 @@ struct quark_module_load {
 	char *name;
 	char *version;
 	char *src_version;
+	u64   taints;
 };
 
 struct raw_module_load {


### PR DESCRIPTION
Read `mod->taints` in the `tp_btf/module_load probe`, carry it through `ebpf_process_load_module_event` and `quark_module_load`, and print `name`/`version`/`srcversion`/`taints` (with decoded taint letters) in `quark_event_dump` so `quark-mon -L` shows them.

Here's an example output:
```
->92166 (MODULE_LOAD)
  MODU  name=mdev version=0.1 srcversion=8A40FBDCD535D4FC5165472 taints=0x0 ()
  COMM  comm=modprobe
  CMDL  cmdline=[ modprobe, mdev ]
  PROC  ppid=92014
  PROC  uid=0 gid=0 suid=0 sgid=0 euid=0 egid=0 pgid=92166 sid=92013
  PROC  cap_inheritable=0x0 cap_permitted=0x1ffffffffff cap_effective=0x1ffffffffff
  PROC  cap_bset=0x0 cap_ambient=0x0
  PROC  time_boot=1783617159475227646 tty_major=136 tty_minor=4
  PROC  uts_inonum=4026531838 ipc_inonum=4026531839
  PROC  mnt_inonum=4026531832 net_inonum=4026531833
  PROC  entity_id=BmgBAP7rz0VbrsAY, entry_leader_type=UNKNOWN entry_leader=0
  CWD   cwd=/root
  EXE   exe=/usr/bin/kmod
  ENV   env_len=2398
  CGRP  cgroup=/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-fd328667-df2b-48d2-98e3-e50bfc74f338.scope
```