### PR TITLE
Add archlinux to krun-archlinux.sh and CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -512,3 +512,14 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       enableNestedVirtualization: true
+
+  - label: "quark-test on archlinux (rolling)"
+    key: test_archlinux
+    command: "./.buildkite/runtest_distro.sh archlinux rolling"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true

--- a/.buildkite/runtest_distro.sh
+++ b/.buildkite/runtest_distro.sh
@@ -28,14 +28,16 @@ sudo apt-get -qq install -y --no-install-recommends	\
      qemu-system-x86					\
      qemu-kvm						\
      rpm2cpio						\
+     zstd						\
      > /dev/null
 
 # Make sure we can run things on KVM
 sudo kvm-ok
 
 case "$DISTRO" in
-fedora)	sudo ./krun-fedora.sh initramfs.gz "$DISTROVER" quark-test $@;;
-rhel)	sudo ./krun-rhel.sh initramfs.gz "$DISTROVER" quark-test $@;;
-ubuntu)	sudo ./krun-ubuntu.sh initramfs.gz "$DISTROVER" quark-test $@;;
-*)	echo bad distribution "$DISTROVER" 1>&2;;
+fedora)		sudo ./krun-fedora.sh initramfs.gz "$DISTROVER" quark-test $@;;
+rhel)		sudo ./krun-rhel.sh initramfs.gz "$DISTROVER" quark-test $@;;
+ubuntu)		sudo ./krun-ubuntu.sh initramfs.gz "$DISTROVER" quark-test $@;;
+archlinux)	sudo ./krun-archlinux.sh initramfs.gz quark-test $@;;
+*)		echo bad distribution "$DISTROVER" 1>&2;;
 esac

--- a/krun-archlinux.sh
+++ b/krun-archlinux.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT=${0##*/}
+VERBOSE=0
+
+log() { (( VERBOSE )) && printf '%s\n' "INFO: $*" >&2 || true; }
+log_error() { printf '%s\n' "ERROR: $*" >&2; }
+die() { log_error "$*"; exit 1; }
+
+function usage
+{
+	echo "usage: $SCRIPT [-v] initramfs.gz command..." 1>&2
+	echo
+	echo "  -v              Verbose output"
+	echo "  initramfs.gz    Path to initramfs image"
+	echo "  command...      Command to run in guest"
+	echo
+	echo "Examples:"
+	echo "  $SCRIPT -v initramfs.gz quark-test -vvv"
+	exit 1
+}
+
+while getopts "vh" opt; do
+	case $opt in
+		v) VERBOSE=1 ;;
+		h) usage ;;
+		*) usage ;;
+	esac
+done
+shift $((OPTIND - 1))
+
+if [ $# -lt 2 ]; then
+	usage
+fi
+
+INITRAMFS="$1"
+shift
+
+[[ -f $INITRAMFS ]] || die "Initramfs not found: $INITRAMFS"
+[[ -f ./krun.sh ]] || die "Required launcher ./krun.sh is missing"
+
+URL="https://mirror.rackspace.com/archlinux/core/os/x86_64"
+
+log "Searching for Arch Linux kernel..."
+
+TMPDIR=$(mktemp -d "/tmp/$SCRIPT.XXXXXXXXXX")
+readonly TMPDIR
+cleanup()	{ [[ -d "$TMPDIR" ]] && rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+log "Fetching package list from $URL"
+PKGURL=$(lynx -dump -listonly "$URL" | grep "/linux-[0-9].*\.pkg\.tar" | grep -v "\.sig") || die "Can't fetch package list"
+PKGURL=${PKGURL##* }
+PKG=$(basename "$PKGURL")
+
+log "URL: $URL"
+log "PKGURL: $PKGURL"
+log "Downloading kernel package: $PKG"
+
+cd "$TMPDIR"
+curl -s "$PKGURL" -o "$PKG"
+zstd -dc "$PKG" | tar -x
+cd -
+
+VMLINUZ=$(find "$TMPDIR" -name "vmlinuz" | head -1)
+[[ -f "$VMLINUZ" ]] || die "vmlinuz not found in package"
+
+log "Target vmlinuz: $VMLINUZ"
+
+log "Kernel ready: $VMLINUZ"
+log "Handing off to ./krun.sh"
+
+./krun.sh "$INITRAMFS" "$VMLINUZ" "$@"


### PR DESCRIPTION
Pretty straightforward, same dance as ubuntu and fedora, except there's no
version since it's always rolling.

Archlinux updates kernels faster than ubuntu and fedora, so we might catch
problems earlier.

Prompted by an issue with cachyos where quark-test(8) will fail due to them
using LTO in the kernel and inlinining vfs_write() calls.

Users of cachyos can use the kernel distributed by archlinux, which does not
have LTO and therefore our probes are dandy.
