### PR TITLE
Prefer boottime timestamps for wallclock event stamping

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -172,7 +172,8 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		}
 
 		raw->task.exit_code = exit->exit_code;
-		raw->task.exit_time_event = raw->time;
+		raw->task.exit_time_event =
+		    ev->ts_boot ? ev->ts_boot : ev->ts;
 		ebpf_ctx_to_task(qq, &ebpf_ctx, &raw->task);
 
 		break;
@@ -814,6 +815,8 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		qwarnx("raw->pid is not set, did you forget me :( ?");
 		goto bad;
 	}
+
+	raw->time_boot = ev->ts_boot;
 
 	return (raw);
 

--- a/quark.c
+++ b/quark.c
@@ -5169,7 +5169,8 @@ quark_queue_get_event(struct quark_queue *qq)
 		}
 
 		if (qev != NULL)
-			qev->time = quark.boottime + raw->time;
+			qev->time = quark.boottime +
+			    (raw->time_boot ? raw->time_boot : raw->time);
 		raw_event_free(raw);
 	}
 

--- a/quark.h
+++ b/quark.h
@@ -459,6 +459,7 @@ struct raw_event {
 	u32					tid;
 	u32					cpu;
 	u64					time;
+	u64					time_boot; /* CLOCK_BOOTTIME variant. zero if unsupported */
 	int					type;
 	union {
 		struct raw_exec			exec;


### PR DESCRIPTION
The bpf backend stamps `raw->time` from the probes' `ts` field, which is `bpf_ktime_get_ns()` (`CLOCK_MONOTONIC`) and stops during suspend. The boot time epoch it is later added to includes suspended time, so after a suspend every event timestamp falls behind the wall clock by the total suspended time until reboot. Process start times do not have this problem since task `start_boottime` is `CLOCK_BOOTTIME`.

The probes already capture `ts_boot` (`bpf_ktime_get_boot_ns()`, zero on kernels older than 5.7). Carry it on the raw event and prefer it when converting to a wall clock timestamp in `quark_queue_get_event()` and for exit_time_event. `raw->time` stays monotonic since internal ordering and aging compare it against `now64()`, which is `CLOCK_MONOTONIC`.