### PR TITLE
Prefer CLOCK_BOOTTIME over CLOCK_MONOTONIC

### DIFF
--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -89,6 +89,13 @@
       <dd>Enable the KPROBE backend, see above.</dd>
       <dt id="QQ_ALL_BACKENDS"><a class="permalink" href="#QQ_ALL_BACKENDS"><code class="Dv">QQ_ALL_BACKENDS</code></a></dt>
       <dd>Shorthand for (QQ_EBPF | QQ_KPROBE).</dd>
+      <dt id="QQ_MONOTONIC"><a class="permalink" href="#QQ_MONOTONIC"><code class="Dv">QQ_MONOTONIC</code></a></dt>
+      <dd>Informational, not configuration: specifying it fails with
+          <code class="Er">EINVAL</code>. The backend that opens sets it on the
+          opened queue's <i class="Em">flags</i> when its event times are
+          CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which only the KPROBE
+          backend does. Monotonic times undercount by the total suspended time,
+          users that care about suspend must compensate.</dd>
       <dt id="QQ_THREAD_EVENTS"><a class="permalink" href="#QQ_THREAD_EVENTS"><code class="Dv">QQ_THREAD_EVENTS</code></a></dt>
       <dd>Include per-thread events, instead of per-process events. This option
           will be removed in the future, but it may be useful for
@@ -164,7 +171,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 11, 2025</td>
+    <td class="foot-date">July 17, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -49,8 +49,7 @@ enum ebpf_event_type {
 };
 
 struct ebpf_event_header {
-    uint64_t ts;
-    uint64_t ts_boot;
+    uint64_t ts; /* ns since boot, CLOCK_BOOTTIME (bpf_ktime_get_boot_ns) */
     uint64_t type;
 } __attribute__((packed));
 

--- a/elastic-ebpf/GPL/Events/File/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/File/Probe.bpf.c
@@ -166,8 +166,7 @@ static int vfs_unlink__exit(int ret)
     }
 
     event->hdr.type    = EBPF_EVENT_FILE_DELETE;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
 
@@ -300,8 +299,7 @@ static void prepare_and_send_file_event(struct file *f,
         return;
 
     event->hdr.type    = type;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     struct path p            = BPF_CORE_READ(f, f_path);
@@ -694,8 +692,7 @@ static int vfs_rename__exit(int ret)
     struct dentry *de = (struct dentry *)state->rename.de;
 
     event->hdr.type    = EBPF_EVENT_FILE_RENAME;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
     struct ebpf_namespace_info ns;
@@ -777,8 +774,7 @@ static void file_modify_event__emit(enum ebpf_file_change_type typ, struct path 
     }
 
     event->hdr.type    = EBPF_EVENT_FILE_MODIFY;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     event->change_type = typ;
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);

--- a/elastic-ebpf/GPL/Events/Helpers.h
+++ b/elastic-ebpf/GPL/Events/Helpers.h
@@ -413,14 +413,6 @@ static int is_equal_prefix(const char *str1, const char *str2, int len)
     return !strncmp(str1, str2, len);
 }
 
-static u64 bpf_ktime_get_boot_ns_helper()
-{
-    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns))
-        return bpf_ktime_get_boot_ns();
-    else
-        return 0;
-}
-
 extern void bpf_preempt_disable(void) __ksym __weak;
 
 static void preempt_disable(void)

--- a/elastic-ebpf/GPL/Events/Network/Network.h
+++ b/elastic-ebpf/GPL/Events/Network/Network.h
@@ -95,8 +95,7 @@ static int ebpf_network_event__fill(struct ebpf_net_event *evt, struct sock *sk)
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     ebpf_pid_info__fill(&evt->pids, task);
     bpf_get_current_comm(evt->comm, TASK_COMM_LEN);
-    evt->hdr.ts      = bpf_ktime_get_ns();
-    evt->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    evt->hdr.ts      = bpf_ktime_get_boot_ns();
 
 out:
     return err;

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -421,8 +421,7 @@ static int skb_in_or_egress(struct __sk_buff *skb, int direction,
         event = &ctx->event;
 
         event->hdr.type    = EBPF_EVENT_NETWORK_DNS_PKT;
-        event->hdr.ts      = bpf_ktime_get_ns();
-        event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+        event->hdr.ts      = bpf_ktime_get_boot_ns();
         event->tgid        = *tgid;
         event->cap_len     = cap_len;
         event->orig_len    = skb->len;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -45,8 +45,7 @@ int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct 
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_FORK;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->parent_pids, parent);
     ebpf_pid_info__fill(&event->child_pids, child);
     ebpf_cred_info__fill(&event->creds, parent);
@@ -99,8 +98,7 @@ int BPF_PROG(sched_process_exec,
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_EXEC;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
@@ -211,8 +209,7 @@ static int disassociate_ctty__enter(int on_exit)
         return 0;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_EXIT;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     // The exit _status_ is stored in the second byte of task->exit_code
     int exit_code    = BPF_CORE_READ(task, exit_code);
@@ -274,8 +271,7 @@ static int setsid__exit(int evtype)
         goto out;
 
     event->hdr.type    = evtype;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     ebpf_pid_info__fill(&event->pids, task);
     ebpf_cred_info__fill(&event->creds, task);
@@ -337,8 +333,7 @@ int BPF_PROG(module_load, struct module *mod)
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_LOAD_MODULE;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     ebpf_pid_info__fill(&event->pids, task);
     event->taints = BPF_CORE_READ(mod, taints);
@@ -408,8 +403,7 @@ static int ptrace_event(struct task_struct *child,
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_PTRACE;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
 
     ebpf_pid_info__fill(&event->pids, task);
 
@@ -484,8 +478,7 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_SHMGET;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
 
     event->key    = ex_args->key;
@@ -540,8 +533,7 @@ static int emit_memfd_create_event(const char *name)
         goto out;
 
     event->hdr.type    = EBPF_EVENT_PROCESS_MEMFD_CREATE;
-    event->hdr.ts      = bpf_ktime_get_ns();
-    event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts      = bpf_ktime_get_boot_ns();
     event->flags       = state->memfd.flags;
 
     ebpf_pid_info__fill(&event->pids, task);
@@ -631,8 +623,7 @@ static int commit_creds__enter(struct cred *new)
             goto out;
 
         event->hdr.type    = EBPF_EVENT_PROCESS_SETUID;
-        event->hdr.ts      = bpf_ktime_get_ns();
-        event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+        event->hdr.ts      = bpf_ktime_get_boot_ns();
 
         ebpf_pid_info__fill(&event->pids, task);
         ebpf_cred_info__fill(&event->creds, task);
@@ -661,8 +652,7 @@ static int commit_creds__enter(struct cred *new)
             goto out;
 
         event->hdr.type    = EBPF_EVENT_PROCESS_SETGID;
-        event->hdr.ts      = bpf_ktime_get_ns();
-        event->hdr.ts_boot = bpf_ktime_get_boot_ns_helper();
+        event->hdr.ts      = bpf_ktime_get_boot_ns();
 
         ebpf_pid_info__fill(&event->pids, task);
         ebpf_cred_info__fill(&event->creds, task);
@@ -730,8 +720,7 @@ static int output_tty_event(struct ebpf_tty_dev *slave, const void *base, size_t
 
     task                     = (struct task_struct *)bpf_get_current_task();
     event->hdr.type          = EBPF_EVENT_PROCESS_TTY_WRITE;
-    event->hdr.ts            = bpf_ktime_get_ns();
-    event->hdr.ts_boot       = bpf_ktime_get_boot_ns_helper();
+    event->hdr.ts            = bpf_ktime_get_boot_ns();
     event->tty_out_truncated = base_len > TTY_OUT_MAX ? base_len - TTY_OUT_MAX : 0;
     event->tty               = *slave;
     ebpf_pid_info__fill(&event->pids, task);

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1370,6 +1370,8 @@ kprobe_queue_open(struct quark_queue *qq)
 
 	if ((qq->flags & QQ_KPROBE) == 0)
 		return (errno = ENOTSUP, -1);
+	/* Perf stamps samples with the monotonic-ish sched clock */
+	qq->flags |= QQ_MONOTONIC;
 	qid = __atomic_fetch_add(&qids, 1, __ATOMIC_RELAXED);
 	if (kprobe_install_all(qid) == -1)
 		goto fail;

--- a/nova.bpf.c
+++ b/nova.bpf.c
@@ -125,15 +125,6 @@ probe_epilogue(void)
 	preempt_enable();
 }
 
-static __u64
-ktime_get_boot_ns(void)
-{
-	if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns))
-		return (bpf_ktime_get_boot_ns());
-	else
-		return (0);
-}
-
 static void
 task_to_nova(struct task_struct *task, struct nova_task *nt)
 {
@@ -404,8 +395,7 @@ output_reserve(struct output *o, __u32 head_len, __u32 total_len)
 
 	__builtin_memset(ev, 0, head_len);
 
-	ev->ts = bpf_ktime_get_ns();
-	ev->ts_boot = ktime_get_boot_ns();
+	ev->ts = bpf_ktime_get_boot_ns();
 
 	return (ev);
 }

--- a/nova.h
+++ b/nova.h
@@ -132,8 +132,7 @@ struct nova_event {
 	__u16	kind;		/* user filled */
 	__u16	pad1;		/* zeroed */
 	__u32	pad2;		/* zeroed */
-	__u64	ts;		/* auto */
-	__u64	ts_boot;	/* auto */
+	__u64	ts;		/* auto, ns since boot (CLOCK_BOOTTIME) */
 } __aligned(8);
 
 struct nova_task_event {

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -271,8 +271,8 @@ nova_ringbuf_cb(void *vqq, void *vdata, size_t len)
 	nt = NULL;
 	nte = NULL;
 
-	printf("nova event %s len=%zd ts=%llu ts_boot=%llu ",
-	    nova_kind_str(nev->kind), len, nev->ts, nev->ts_boot);
+	printf("nova event %s len=%zd ts=%llu ",
+	    nova_kind_str(nev->kind), len, nev->ts);
 
 	switch (nev->kind) {
 	case NOVA_FORK:		/* FALLTHROUGH */

--- a/quark-test.c
+++ b/quark-test.c
@@ -269,11 +269,13 @@ show_cursor(void)
 }
 
 static u64
-ns_since_epoch(void)
+ns_since_epoch(const struct quark_queue *qq)
 {
 	struct timespec ts;
+	clockid_t	clk;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1)
+	clk = qq->flags & QQ_MONOTONIC ? CLOCK_MONOTONIC : CLOCK_BOOTTIME;
+	if (clock_gettime(clk, &ts) == -1)
 		err(1, "clock_gettime");
 
 	return boottime + ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
@@ -840,6 +842,30 @@ t_probe(const struct test *t, struct quark_queue_attr *qa)
 }
 
 static int
+t_monotonic(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue	 qq;
+	struct quark_queue_attr	 attr;
+
+	/* Informational only, refused as configuration */
+	attr = *qa;
+	attr.flags |= QQ_MONOTONIC;
+	assert(quark_queue_open(&qq, &attr) == -1 && errno == EINVAL);
+
+	/* On an open queue it relays the backend's time domain */
+	attr = *qa;
+	if (quark_queue_open(&qq, &attr) != 0)
+		err(1, "%s: quark_queue_open", t->name);
+	if (qq.stats.backend == QQ_KPROBE)
+		assert(qq.flags & QQ_MONOTONIC);
+	else
+		assert((qq.flags & QQ_MONOTONIC) == 0);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+static int
 t_os_release(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct quark_queue	 qq;
@@ -884,10 +910,10 @@ fork_exec_exit(const struct test *t, struct quark_queue_attr *qa, int relative)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_since_epoch();
+	before = ns_since_epoch(&qq);
 	child = fork_exec_nop1(relative, 0);
 	qev = drain_for_pid(&qq, child);
-	after = ns_since_epoch();
+	after = ns_since_epoch(&qq);
 
 	/* check qev.events */
 	assert(qev->events & QUARK_EV_FORK);
@@ -1111,10 +1137,10 @@ t_file(const struct test *t, struct quark_queue_attr *qa)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_since_epoch();
+	before = ns_since_epoch(&qq);
 	if ((fd = mkstemp(path)) == -1)
 		err(1, "mkstemp");
-	after = ns_since_epoch();
+	after = ns_since_epoch(&qq);
 	assert(write(fd, "1", 1) == 1);
 	assert(write(fd, "2", 1) == 1);
 	assert(write(fd, "3", 1) == 1);
@@ -2398,6 +2424,9 @@ struct test all_tests[] = {
 	T_EBPF(t_probe),
 	T_KPROBE(t_probe),
 	T_NOVA(t_probe),
+	T_EBPF(t_monotonic),
+	T_KPROBE(t_monotonic),
+	T_NOVA(t_monotonic),
 	T_EBPF(t_os_release),
 	T_KPROBE(t_os_release),
 	T_EBPF(t_fork_exec_exit),

--- a/quark.c
+++ b/quark.c
@@ -240,11 +240,13 @@ raw_event_by_pidtime_cmp(struct raw_event *a, struct raw_event *b)
 }
 
 static inline u64
-now64(void)
+now64(const struct quark_queue *qq)
 {
 	struct timespec ts;
+	clockid_t	clk;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1)
+	clk = qq->flags & QQ_MONOTONIC ? CLOCK_MONOTONIC : CLOCK_BOOTTIME;
+	if (clock_gettime(clk, &ts) == -1)
 		return (0);
 
 	return ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
@@ -421,7 +423,7 @@ gc_mark(struct quark_queue *qq, struct gc_link *gc, enum gc_type type)
 	if (gc->gc_time)
 		return;
 
-	gc->gc_time = now64();
+	gc->gc_time = now64(qq);
 	gc->gc_type = type;
 	TAILQ_INSERT_TAIL(&qq->event_gc, gc, gc_entry);
 }
@@ -442,7 +444,7 @@ gc_collect(struct quark_queue *qq)
 	u64		 now;
 	int		 n;
 
-	now = now64();
+	now = now64(qq);
 	n = 0;
 	while ((gc = TAILQ_FIRST(&qq->event_gc)) != NULL) {
 		if (AGE(gc->gc_time, now) < qq->cache_grace_time)
@@ -1511,7 +1513,7 @@ kube_read_events(struct quark_queue *qq)
 	 * hammering with one syscall per event.
 	 */
 	if (!qkube->try_read) {
-		if ((now64() - qkube->last_read) >= (u64)MS_TO_NS(10))
+		if ((now64(qq) - qkube->last_read) >= (u64)MS_TO_NS(10))
 			qkube->try_read = 1;
 		else
 			return;
@@ -1524,7 +1526,7 @@ kube_read_events(struct quark_queue *qq)
 		return;
 	}
 	n = qread(qkube->fd, qkube->buf + qkube->buf_w, left_towrite);
-	qkube->last_read = now64();
+	qkube->last_read = now64(qq);
 	qkube->try_read = 0;
 	if (n == -1) {
 		if (errno == EAGAIN)
@@ -1650,7 +1652,7 @@ kube_prime(struct quark_queue *qq)
 	pfd.events = POLLIN;
 
 	qwarnx("priming kube events...");
-	deadline = now64() + (u64)MS_TO_NS(3000);
+	deadline = now64(qq) + (u64)MS_TO_NS(3000);
 	do {
 		if ((r = poll(&pfd, 1, 25)) == -1) {
 			qwarn("poll");
@@ -1665,7 +1667,7 @@ kube_prime(struct quark_queue *qq)
 		 */
 		if (qkube->fd == -1)
 			break;
-	} while (now64() < deadline);
+	} while (now64(qq) < deadline);
 
 	/*
 	 * We must have received at least the node information.
@@ -2941,7 +2943,7 @@ sproc_pid_sockets(struct quark_queue *qq,
 			continue;
 
 		qsk = socket_alloc_and_insert(qq, &ss->socket.local,
-		    &ss->socket.remote, SOCK_CONN_SCRAPE, 0, 0, pid, now64());
+		    &ss->socket.remote, SOCK_CONN_SCRAPE, 0, 0, pid, now64(qq));
 		if (qsk == NULL) {
 			qwarn("socket_alloc");
 			continue;
@@ -4133,6 +4135,10 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 		qa->max_length = 1;
 	}
 
+	/* QQ_MONOTONIC is informational, not configuration */
+	if (qa->flags & QQ_MONOTONIC)
+		return (errno = EINVAL, -1);
+
 	/* XXX hardcode QQ_NOVA for now XXX */
 	if ((qa->flags & (QQ_ALL_BACKENDS | QQ_NOVA)) == 0 ||
 	    qa->max_length <= 0 ||
@@ -4562,7 +4568,7 @@ quark_queue_pop_raw(struct quark_queue *qq)
 	 */
 	(void)quark_queue_populate(qq);
 
-	now = now64();
+	now = now64(qq);
 	min = RB_MIN(raw_event_by_time, &qq->raw_event_by_time);
 	if (min == NULL || !raw_event_expired(qq, min, now)) {
 		/* qq->idle++; */

--- a/quark.h
+++ b/quark.h
@@ -884,6 +884,11 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
+/*
+ * Informational only, not configuration: if set, event times are
+ * CLOCK_MONOTONIC, else CLOCK_BOOTTIME.
+ */
+#define QQ_MONOTONIC		(1 << 15)
 #define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)	/* QQ_NOVA excluded for now */
 	int			 flags;
 	int			 max_length;

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -89,6 +89,15 @@ EBPF is attempted first and falls back to KPROBE if both were specified.
 Enable the KPROBE backend, see above.
 .It Dv QQ_ALL_BACKENDS
 Shorthand for (QQ_EBPF | QQ_KPROBE).
+.It Dv QQ_MONOTONIC
+Informational, not configuration: specifying it fails with
+.Er EINVAL .
+The backend that opens sets it on the opened queue's
+.Em flags
+when its event times are CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which
+only the KPROBE backend does.
+Monotonic times undercount by the total suspended time, users that care
+about suspend must compensate.
 .It Dv QQ_THREAD_EVENTS
 Include per-thread events, instead of per-process events.
 This option will be removed in the future, but it may be useful for debugging.


### PR DESCRIPTION
The probes stamped events with bpf_ktime_get_ns(), which is
CLOCK_MONOTONIC and stops during suspend, so every emitted timestamp
fell behind the wallclock by the total suspended time until reboot.
Process start times never had this problem since task start_boottime
is CLOCK_BOOTTIME, meaning event times and start times did not even
share a domain.

The kernel test matrix confirmed every supported bpf configuration has
bpf_ktime_get_boot_ns (in the kernel since 5.8), so the probes now
stamp ts with it directly, and the separate ts_boot field along with
its CO-RE existence check helper are gone. The helper call is
unconditional: on kernels without it the programs fail to load,
bpf_queue_open() fails and quark falls back to the kprobe backend.

The kprobe backend is the only one left with monotonic times, as perf
stamps samples with the monotonic-ish sched clock. Introduce
QQ_MONOTONIC on the queue flags to relay this: informational only, set
by the kprobe backend on the opened queue, refused with EINVAL if
given as configuration. Monotonic times undercount by the total
suspended time, users that care about suspend must compensate.

now64() moves to the queue's time domain (CLOCK_BOOTTIME, or
CLOCK_MONOTONIC on QQ_MONOTONIC queues) so aggregation ordering and
aging always compare event times against a clock in the same domain.

Add t_monotonic to quark-test for all backends, checking the flag is
refused as configuration and relays the backend's domain after open.
Document QQ_MONOTONIC in quark_queue_open.3.