### PR TITLE
Remove boottime from quark times

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -123,3 +123,16 @@ Changes from 0.6 to 0.7
     system.
   o The quark utilities now display their manpage when invoked with
     "help", "-help" or "--help".
+
+Changes from 0.7 to 0.8
+~~~~~~~~~~~~~~~~~~~~~~~
+  o BREAKING, SILENTLY: quark_process.proc_time_boot,
+    quark_process.exit_time_event and quark_event.time are now
+    expressed in nanoseconds since boot instead of nanoseconds since
+    the epoch. Existing code compiles unchanged but any user treating
+    these fields as wallclock will emit timestamps that are off by
+    the boot time. Users that want wallclock time must convert with
+    the new quark_time_to_wallclock(). quark_get_boottime() and
+    quark_update_boottime() were also added, the latter refetches
+    boottime in case the host clock changed. The JSON ECS output is
+    unaffected and still emits wallclock dates.

--- a/ecs.c
+++ b/ecs.c
@@ -626,7 +626,8 @@ ecs_process(struct quark_queue *qq, struct hanson *h,
 		hanson_add_key_value(h, "entity_id", qp->proc_entity_id,
 		    first);
 
-		ecs_date(qp->proc_time_boot, start_time, sizeof(start_time));
+		ecs_date(quark_time_to_wallclock(qp->proc_time_boot),
+		    start_time, sizeof(start_time));
 		hanson_add_key_value(h, "start", start_time, first);
 		hanson_add_key_value_bool(h, "interactive", is_interactive(qp),
 		    first);
@@ -686,7 +687,8 @@ ecs_process(struct quark_queue *qq, struct hanson *h,
 	if (qp->flags & QUARK_F_EXIT) {
 		char	end_time[32];
 
-		ecs_date(qp->exit_time_event, end_time, sizeof(end_time));
+		ecs_date(quark_time_to_wallclock(qp->exit_time_event),
+		    end_time, sizeof(end_time));
 		hanson_add_key_value(h, "end", end_time, first);
 
 		hanson_add_key_value_int(h, "exit_code", qp->exit_code, first);

--- a/quark-test.c
+++ b/quark-test.c
@@ -84,7 +84,6 @@ static int	bflag;		/* run bpf tests */
 static int	kflag;		/* run kprobe tests */
 static int	nflag;		/* run nova tests */
 static int	tflag;		/* listen to the tracepipe */
-static u64	boottime;
 static int	fancy_tty;
 static int	in_valgrind;
 
@@ -270,7 +269,7 @@ show_cursor(void)
 }
 
 static u64
-ns_since_epoch(const struct quark_queue *qq)
+ns_clock(const struct quark_queue *qq)
 {
 	struct timespec ts;
 	clockid_t	clk;
@@ -279,7 +278,7 @@ ns_since_epoch(const struct quark_queue *qq)
 	if (clock_gettime(clk, &ts) == -1)
 		err(1, "clock_gettime");
 
-	return boottime + ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
+	return ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
 }
 
 static u32
@@ -911,10 +910,10 @@ fork_exec_exit(const struct test *t, struct quark_queue_attr *qa, int relative)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_since_epoch(&qq);
+	before = ns_clock(&qq);
 	child = fork_exec_nop1(relative, 0);
 	qev = drain_for_pid(&qq, child);
-	after = ns_since_epoch(&qq);
+	after = ns_clock(&qq);
 
 	/* check qev.events */
 	assert(qev->events & QUARK_EV_FORK);
@@ -1138,10 +1137,10 @@ t_file(const struct test *t, struct quark_queue_attr *qa)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_since_epoch(&qq);
+	before = ns_clock(&qq);
 	if ((fd = mkstemp(path)) == -1)
 		err(1, "mkstemp");
-	after = ns_since_epoch(&qq);
+	after = ns_clock(&qq);
 	assert(write(fd, "1", 1) == 1);
 	assert(write(fd, "2", 1) == 1);
 	assert(write(fd, "3", 1) == 1);
@@ -3137,8 +3136,6 @@ main(int argc, char *argv[])
 
 	if (tflag && noforkflag)
 		usage();
-
-	boottime = fetch_boottime();
 
 	/*
 	 * Run bpf and kprobe by default, don't run nova

--- a/quark.c
+++ b/quark.c
@@ -106,6 +106,37 @@ struct quark {
 	u64		boottime;
 } quark;
 
+int
+quark_update_boottime(void)
+{
+	u64	boottime;
+
+	if ((boottime = fetch_boottime()) == 0) {
+		qwarn("can't refetch btime");
+		return (-1);
+	}
+	if (boottime != quark.boottime) {
+		qwarnx("boottime updated %llu -> %llu",
+		    (unsigned long long)quark.boottime,
+		    (unsigned long long)boottime);
+		quark.boottime = boottime;
+	}
+
+	return (0);
+}
+
+u64
+quark_get_boottime(void)
+{
+	return (quark.boottime);
+}
+
+u64
+quark_time_to_wallclock(u64 time_since_boot)
+{
+	return (quark.boottime + time_since_boot);
+}
+
 struct raw_event *
 raw_event_alloc(int type)
 {
@@ -2404,7 +2435,7 @@ raw_event_process1(struct quark_queue *qq, struct raw_event *src,
 		qp->flags |= QUARK_F_EXIT;
 		qp->exit_code = raw_task->exit_code;
 		if (src->task.exit_time_event)
-			qp->exit_time_event = quark.boottime + raw_task->exit_time_event;
+			qp->exit_time_event = raw_task->exit_time_event;
 		break;
 	case RAW_COMM:
 		dst->events |= QUARK_EV_SETPROCTITLE;
@@ -2447,8 +2478,7 @@ raw_event_process1(struct quark_queue *qq, struct raw_event *src,
 		 * precision one.
 		 */
 		if (qp->proc_time_boot == 0)
-			qp->proc_time_boot = quark.boottime +
-			    raw_task->start_boottime;
+			qp->proc_time_boot = raw_task->start_boottime;
 		qp->proc_ppid = raw_task->ppid;
 		qp->proc_uid = raw_task->uid;
 		qp->proc_gid = raw_task->gid;
@@ -2683,7 +2713,6 @@ sproc_stat(struct quark_process *qp, int dfd)
 		qp->proc_tty_major = (tty >> 8) & 0xff;
 		qp->proc_tty_minor = ((tty >> 12) & 0xfff00) | (tty & 0xff);
 		qp->proc_time_boot =
-		    quark.boottime +
 		    ((starttime / (u64)quark.hz) * NS_PER_S) +
 		    (((starttime % (u64)quark.hz) * NS_PER_S) / (u64)quark.hz);
 
@@ -5169,7 +5198,7 @@ quark_queue_get_event1(struct quark_queue *qq)
 		}
 
 		if (qev != NULL)
-			qev->time = quark.boottime + raw->time;
+			qev->time = raw->time;
 		raw_event_free(raw);
 	}
 

--- a/quark.h
+++ b/quark.h
@@ -62,6 +62,9 @@ int			 quark_queue_get_epollfd(struct quark_queue *);
 void			 quark_queue_get_stats(struct quark_queue *,
 			     struct quark_queue_stats *);
 int			 quark_start_kube_talker(const char *, pid_t *);
+int			 quark_update_boottime(void);
+u64			 quark_get_boottime(void);
+u64			 quark_time_to_wallclock(u64);
 int			 quark_dump_process_cache_graph(struct quark_queue *,
 			     FILE *);
 int			 quark_dump_raw_event_graph(struct quark_queue *,


### PR DESCRIPTION
Times derived from quark.boottime were computed once and stored, so a system clock step after quark_init() (say NTP correcting a clock that was wrong at boot) left every stored and emitted timestamp shifted by the step size until restart.

Nothing computed with quark.boottime is stored or handed out anymore: qev->time, proc_time_boot and exit_time_event are raw ns since boot, translated at the last moment with the new quark_time_to_wallclock(). Since quark has no event loop, keeping the epoch honest is the user's job: detect a step (a CLOCK_REALTIME timerfd with TFD_TIMER_CANCEL_ON_SET, or polling the CLOCK_REALTIME - CLOCK_BOOTTIME delta, which only moves on steps) and call the new quark_update_boottime(). Corrections then apply retroactively to any raw time, including events that predate the step.

This also makes proc_entity_id immune to clock changes, as it now hashes the raw start time.

Breaking change: consumers that treated qev->time, proc_time_boot or exit_time_event as wallclock epoch ns must translate via quark_time_to_wallclock().