### PR TITLE
Add file.exec_change rule predicate

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -295,7 +295,7 @@ steps:
 
   - label: "quark-test on rhel 8.5 (no file)"
     key: test_rhel_8_5
-    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
+    command: "./.buildkite/runtest_distro.sh rhel 8.5 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2 -x t_rule_exec_change"
     depends_on:
       - make_docker
     agents:
@@ -306,7 +306,7 @@ steps:
 
   - label: "quark-test on rhel 8.6 (no file)"
     key: test_rhel_8_6
-    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
+    command: "./.buildkite/runtest_distro.sh rhel 8.6 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2 -x t_rule_exec_change"
     depends_on:
       - make_docker
     agents:
@@ -317,7 +317,7 @@ steps:
 
   - label: "quark-test on rhel 8.7 (no file)"
     key: test_rhel_8_7
-    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2"
+    command: "./.buildkite/runtest_distro.sh rhel 8.7 -x t_file_bypass -x t_file -x t_memfd -x t_shm_open -x t_rule_path -x t_rule_path2 -x t_rule_exec_change"
     depends_on:
       - make_docker
     agents:

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -428,7 +428,7 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		size_t				 path_len, sym_target_len, old_path_len;
 		size_t				 alloc_len, tmp_len;
 		struct quark_file		*file;
-		u32				 op_mask, dummy;
+		u32				 op_mask, change_mask, dummy;
 
 		if ((raw = raw_event_alloc(RAW_FILE)) == NULL)
 			goto bad;
@@ -441,6 +441,7 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		info = NULL;
 		vl = NULL;
 		op_mask = 0;
+		change_mask = 0;
 		switch (ev->type) {
 		case EBPF_EVENT_FILE_CREATE: {
 			struct ebpf_file_create_event *create =
@@ -467,6 +468,22 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 			vl = &modify->vl_fields;
 			raw->pid = modify->pids.tgid;
 			op_mask = QUARK_FILE_OP_MODIFY;
+			switch (modify->change_type) {
+			case EBPF_FILE_CHANGE_TYPE_CONTENT:
+				change_mask = QUARK_FILE_CH_CONTENT;
+				break;
+			case EBPF_FILE_CHANGE_TYPE_PERMISSIONS:
+				change_mask = QUARK_FILE_CH_PERMS;
+				break;
+			case EBPF_FILE_CHANGE_TYPE_OWNER:
+				change_mask = QUARK_FILE_CH_OWNER;
+				break;
+			case EBPF_FILE_CHANGE_TYPE_XATTRS:
+				change_mask = QUARK_FILE_CH_XATTRS;
+				break;
+			default:
+				break;
+			}
 			break;
 		}
 		case EBPF_EVENT_FILE_RENAME: {
@@ -569,6 +586,7 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		file->uid = info->uid;
 		file->gid = info->gid;
 		file->op_mask = op_mask;
+		file->change_mask = change_mask;
 
 		break;
 	}

--- a/nova.h
+++ b/nova.h
@@ -34,6 +34,7 @@
 #define QUARK_RF_EXE		(1ULL << 6)
 #define QUARK_RF_FILEPATH	(1ULL << 7)
 #define QUARK_RF_POISON		(1ULL << 8)
+#define QUARK_RF_FILE_EXEC_CHANGE (1ULL << 9)
 
 enum quark_rule_action {
 	QUARK_RA_INVALID,

--- a/nova_queue.c
+++ b/nova_queue.c
@@ -163,6 +163,11 @@ nova_rule_from_quark(struct nova_queue *nqq,
 		case QUARK_RF_POISON:
 			nr->poison_tag = field->poison_tag;
 			break;
+		case QUARK_RF_FILE_EXEC_CHANGE:
+			errno = ENOTSUP;
+			qwarn("file.exec_change is not supported in nova backend");
+			return (-1);
+			break;
 		default:
 			errno = EINVAL;
 			qwarn("bad field->code %llu", field->code);

--- a/parse.y
+++ b/parse.y
@@ -55,7 +55,7 @@ int	quark_lex(YYSTYPE *, struct quark_parser_ctx *);
 
 %token PASS DROP POISON ON ANY STRING
 %token PROCESS_PID PROCESS_PPID PROCESS_UID PROCESS_GID PROCESS_SID
-%token PROCESS_EXE FILE_PATH
+%token PROCESS_EXE FILE_PATH FILE_EXEC_CHANGE
 
 %%
 grammar:	/* empty  */
@@ -121,6 +121,8 @@ matchfield:	PROCESS_PID num_u32 {
 		} | FILE_PATH STRING {
 			$$.rf.code = QUARK_RF_FILEPATH;
 			$$.rf.wild.pre = (char *)$2.str;
+		} | FILE_EXEC_CHANGE {
+			$$.rf.code = QUARK_RF_FILE_EXEC_CHANGE;
 		} | POISON num_u64 {
 			$$.rf.code = QUARK_RF_POISON;
 			$$.rf.poison_tag = $2.num_u64;
@@ -194,6 +196,7 @@ static struct keyword {
 	{ "process.sid",	PROCESS_SID },
 	{ "process.exe",	PROCESS_EXE },
 	{ "file.path",		FILE_PATH },
+	{ "file.exec_change",	FILE_EXEC_CHANGE },
 };
 
 /*

--- a/quark-test.c
+++ b/quark-test.c
@@ -2029,6 +2029,90 @@ t_rule_path(const struct test *t, struct quark_queue_attr *qa)
 }
 
 static int
+t_rule_exec_change(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	struct quark_ruleset		 ruleset;
+	struct quark_rule		*pass_rule, *drop_rule;
+	char				 execpath[] = "/tmp/quark-test-exec.XXXXXX";
+	char				 modpath[] = "/tmp/quark-test-execmod.XXXXXX";
+	char				 plainpath[] = "/tmp/quark-test-plain.XXXXXX";
+	int				 execfd, modfd, plainfd;
+	char				*text_ruleset;
+
+	if ((execfd = mkstemp(execpath)) == -1)
+		err(1, "mkstemp");
+	if ((modfd = mkstemp(modpath)) == -1)
+		err(1, "mkstemp");
+	if ((plainfd = mkstemp(plainpath)) == -1)
+		err(1, "mkstemp");
+	/* modpath is already executable before we start watching */
+	if (chmod(modpath, 0755) == -1)
+		err(1, "chmod");
+
+	/*
+	 * Pass executable-change events under execpath, drop everything else.
+	 * We chmod execpath executable and leave plainpath alone, so we should
+	 * only see the execpath event.
+	 */
+	if (asprintf(&text_ruleset,
+	    "pass on process.pid %d file.path /tmp/quark-test-exec* file.exec_change\n"
+	    "drop on process.pid %d\n",
+	    getpid(), getpid()) == -1)
+		err(1, "asprintf");
+	ruleset_from_string(&ruleset, text_ruleset);
+	free(text_ruleset);
+
+	assert(ruleset.n_rules == 2);
+	pass_rule = &ruleset.rules[0];
+	assert(pass_rule->action == QUARK_RA_PASS);
+	assert(pass_rule->n_fields == 3);
+	drop_rule = &ruleset.rules[1];
+	assert(drop_rule->action == QUARK_RA_DROP);
+	assert(drop_rule->n_fields == 1);
+
+	qa->ruleset = &ruleset;
+	qa->flags |= QQ_FILE;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	/* Touch plainpath without making it executable, must be dropped */
+	assert(write(plainfd, "1", 1) == 1);
+	close(plainfd);
+	if (unlink(plainpath) == -1)
+		err(1, "unlink");
+	/* Modify contents of an already-executable file, must be dropped */
+	assert(write(modfd, "1", 1) == 1);
+	close(modfd);
+	if (unlink(modpath) == -1)
+		err(1, "unlink");
+	/* Make execpath executable, must pass */
+	assert(write(execfd, "1", 1) == 1);
+	if (chmod(execpath, 0755) == -1)
+		err(1, "chmod");
+	close(execfd);
+	if (unlink(execpath) == -1)
+		err(1, "unlink");
+
+	qev = drain_for_pid(&qq, getpid());
+	assert(qev->events & QUARK_EV_FILE);
+	assert(!strcmp(qev->file->path, execpath));
+	assert(qev->file->op_mask & QUARK_FILE_OP_MODIFY);
+	assert(qev->file->mode & (S_IXUSR | S_IXGRP | S_IXOTH));
+	/* Make sure it hits the rule once */
+	assert(pass_rule->hits == 1);
+	/* evals must be bigger than hits, since it must have dropped others */
+	assert(pass_rule->evals > pass_rule->hits);
+
+	quark_queue_close(&qq);
+	quark_ruleset_clear(&ruleset);
+
+	return (0);
+}
+
+static int
 t_rule_path2(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct quark_queue		 qq;
@@ -2291,6 +2375,7 @@ t_rule_parser(const struct test *t, struct quark_queue_attr *qa)
 		"pass on process.sid 11\n",
 		"drop on file.path /foo/bar\n",
 		"pass on file.path foo-bar\n",
+		"pass on file.path /foo/* file.exec_change\n",
 		"drop on process.exe /foo/bar\n",
 		"drop on process.exe /foo/*\n",
 		"drop on process.exe */bar\n",
@@ -2459,6 +2544,7 @@ struct test all_tests[] = {
 	T(t_hanson),
 	T(t_hanson_escape),
 	T_EBPF(t_rule_path),
+	T_EBPF(t_rule_exec_change),
 	T_EBPF(t_rule_path2),
 	T_EBPF(t_rule_poison),
 	T_EBPF(t_rule_poison_existing),

--- a/quark.c
+++ b/quark.c
@@ -4,6 +4,7 @@
 #include <sys/epoll.h>
 #include <sys/param.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 
@@ -4695,7 +4696,7 @@ raw_event_file(struct quark_queue *qq, struct raw_event *raw)
 {
 	struct quark_event	*qev;
 	struct raw_event	*agg;
-	u32			 op_mask;
+	u32			 op_mask, change_mask;
 
 	if (raw->file.quark_file == NULL) {
 		qwarnx("quark_file is null");
@@ -4713,13 +4714,16 @@ raw_event_file(struct quark_queue *qq, struct raw_event *raw)
 	 * raw_event.
 	 */
 	op_mask = raw->file.quark_file->op_mask;
+	change_mask = raw->file.quark_file->change_mask;
 	TAILQ_FOREACH(agg, &raw->agg_queue, agg_entry) {
 		op_mask |= agg->file.quark_file->op_mask;
+		change_mask |= agg->file.quark_file->change_mask;
 		raw = agg;
 	}
 
 	/* Steal the file */
 	raw->file.quark_file->op_mask = op_mask;
+	raw->file.quark_file->change_mask = change_mask;
 	qev->file = raw->file.quark_file;
 	raw->file.quark_file = NULL;
 
@@ -4933,6 +4937,12 @@ quark_rule_field_match(struct quark_rule *rule, struct quark_rule_field *field,
 		if (qev->file != NULL)
 			return (path_match(field, qev->file->path));
 		break;
+	case QUARK_RF_FILE_EXEC_CHANGE:
+		if (qev->file != NULL)
+			return (((qev->file->op_mask & QUARK_FILE_OP_CREATE) ||
+			    (qev->file->change_mask & QUARK_FILE_CH_PERMS)) &&
+			    (qev->file->mode & (S_IXUSR | S_IXGRP | S_IXOTH)));
+		break;
 	case QUARK_RF_POISON:
 		if (qp != NULL)
 			return (qp->poison_tag == field->poison_tag);
@@ -5066,6 +5076,8 @@ quark_rule_match_field(struct quark_rule *rule, struct quark_rule_field rf)
 			rf.wild.pre_len++; /* Include NUL in the comparison */
 		if (rf.wild.post_len > 0)
 			rf.wild.post_len++; /* Include NUL in the comparison */
+		break;
+	case QUARK_RF_FILE_EXEC_CHANGE:
 		break;
 	case QUARK_RF_POISON:
 		if (rf.poison_tag == 0)

--- a/quark.h
+++ b/quark.h
@@ -366,6 +366,11 @@ struct raw_packet {
 #define QUARK_FILE_OP_REMOVE	(1 << 2)
 #define QUARK_FILE_OP_MOVE	(1 << 3)
 
+#define QUARK_FILE_CH_CONTENT	(1 << 0)
+#define QUARK_FILE_CH_PERMS	(1 << 1)
+#define QUARK_FILE_CH_OWNER	(1 << 2)
+#define QUARK_FILE_CH_XATTRS	(1 << 3)
+
 struct quark_file {
 	const char	*path;		/* points to storage + 0 */
 	const char	*old_path;	/* NULL or points to storage + strlen(path) */
@@ -379,6 +384,7 @@ struct quark_file {
 	u32		 uid;
 	u32		 gid;
 	u32		 op_mask;	/* mask of QUARK_FILE_OP_* */
+	u32		 change_mask;	/* mask of QUARK_FILE_CH_* */
 	char		 storage[];	/* paths point here */
 };
 


### PR DESCRIPTION
Adds a new rule predicate which matches when a file's execute bit is set as a create or a permission change. It does not match on file content changes to already-executable files.

This also adds a file change mask, which will propagate the file change reasons from ebpf events to aggregated quark events.

This is not supported in the nova backend, and will fail with ENOTSUP, if there's an attempt to use this rule predicate with that backend.