### PR TITLE
Remove backend fallback from quark_queue_open

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -136,3 +136,10 @@ Changes from 0.7 to 0.8
     quark_update_boottime() were also added, the latter refetches
     boottime in case the host clock changed. The JSON ECS output is
     unaffected and still emits wallclock dates.
+  o BREAKING: quark_queue_open() now requires exactly one backend
+    flag (QQ_EBPF, QQ_KPROBE or QQ_NOVA) and fails with EINVAL
+    otherwise. The fallback that tried ebpf and fell back to kprobe
+    is gone: users that want a fallback must reopen the queue with
+    another backend themselves. QQ_ALL_BACKENDS was removed and
+    breaks at compile time. quark_queue_default_attr() now selects
+    only QQ_EBPF.

--- a/docs/quark-mon.8.html
+++ b/docs/quark-mon.8.html
@@ -25,7 +25,7 @@
 <table class="Nm">
   <tr>
     <td><code class="Nm">quark-mon</code></td>
-    <td>[<code class="Fl">-BbDEeFGgHhkMNSsTtv</code>]
+    <td>[<code class="Fl">-BbDEeFGgHhkMNnSsTtv</code>]
       [<code class="Fl">-C</code> <var class="Ar">filename</var>]
       [<code class="Fl">-K</code> <var class="Ar">kubeconfig</var>]
       [<code class="Fl">-l</code> <var class="Ar">maxlength</var>]
@@ -132,6 +132,8 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
   <dd>Run in a simple benchmark form that only counts and display stats.</dd>
   <dt id="N"><a class="permalink" href="#N"><code class="Fl">-N</code></a></dt>
   <dd>Enable DNS events (experimental).</dd>
+  <dt id="n"><a class="permalink" href="#n"><code class="Fl">-n</code></a></dt>
+  <dd>Attempt NOVA as the backend.</dd>
   <dt id="P"><a class="permalink" href="#P"><code class="Fl">-P</code></a>
     <var class="Ar">ppid</var></dt>
   <dd>Display only events where parent pid is <var class="Ar">ppid</var>.</dd>
@@ -158,10 +160,10 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
 <h1 class="Sh" id="BACKEND_SELECTION"><a class="permalink" href="#BACKEND_SELECTION">BACKEND
   SELECTION</a></h1>
 <p class="Pp">If no backend option is specified,
-    <code class="Nm">quark-mon</code> will attempt EBPF, and then kprobe if EBPF
-    failed. If only one of <code class="Fl">-b</code> or
-    <code class="Fl">-k</code> is passed, then <code class="Nm">quark-mon</code>
-    will be restricted to that option only.</p>
+    <code class="Nm">quark-mon</code> uses EBPF. Exactly one of
+    <code class="Fl">-b</code>, <code class="Fl">-k</code> or
+    <code class="Fl">-n</code> may be passed, there is no fallback between
+    backends.</p>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXIT_STATUS"><a class="permalink" href="#EXIT_STATUS">EXIT
@@ -220,7 +222,7 @@ The <code class="Nm">quark-mon</code> program listens to all incoming
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 21, 2026</td>
+    <td class="foot-date">August 6, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -41,10 +41,11 @@
 <p class="Pp">The <code class="Nm">quark_queue_open</code> function does the
     following:</p>
 <ul class="Bl-bullet">
-  <li>Attempts to use the best backend available unless otherwise especified.
-      This includes loading the EBPF programs for EBPF or the probes for
-      KPROBES. Only one backend is used and it defaults to EBPF and falls back
-      to KPROBE.</li>
+  <li>Attempts to use the selected backend. This includes loading the EBPF
+      programs for EBPF or the probes for KPROBES. Exactly one backend must be
+      selected, anything else fails with <code class="Er">EINVAL</code>. There
+      is no fallback: users that want one must retry with another backend
+      themselves if <code class="Nm">quark_queue_open</code> fails.</li>
   <li>On its first call it will also initialize global host state, like BTF
       offsets and HZ.</li>
   <li>Initializes the various lists and internal buffers of
@@ -83,12 +84,10 @@
   <dd>Bitmask of:
     <dl class="Bl-tag">
       <dt id="QQ_EBPF"><a class="permalink" href="#QQ_EBPF"><code class="Dv">QQ_EBPF</code></a></dt>
-      <dd>Enable the EBPF backend. EBPF is attempted first and falls back to
-          KPROBE if both were specified.</dd>
+      <dd>Use the EBPF backend, this is the default of
+          <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>.</dd>
       <dt id="QQ_KPROBE"><a class="permalink" href="#QQ_KPROBE"><code class="Dv">QQ_KPROBE</code></a></dt>
-      <dd>Enable the KPROBE backend, see above.</dd>
-      <dt id="QQ_ALL_BACKENDS"><a class="permalink" href="#QQ_ALL_BACKENDS"><code class="Dv">QQ_ALL_BACKENDS</code></a></dt>
-      <dd>Shorthand for (QQ_EBPF | QQ_KPROBE).</dd>
+      <dd>Use the KPROBE backend.</dd>
       <dt id="QQ_MONOTONIC"><a class="permalink" href="#QQ_MONOTONIC"><code class="Dv">QQ_MONOTONIC</code></a></dt>
       <dd>Informational, not configuration: specifying it fails with
           <code class="Er">EINVAL</code>. The backend that opens sets it on the
@@ -171,7 +170,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">July 17, 2026</td>
+    <td class="foot-date">August 6, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -216,7 +216,6 @@ const (
 	QQ_TTY           = int(C.QQ_TTY)
 	QQ_PTRACE        = int(C.QQ_PTRACE)
 	QQ_MODULE_LOAD   = int(C.QQ_MODULE_LOAD)
-	QQ_ALL_BACKENDS  = int(C.QQ_ALL_BACKENDS)
 
 	// Event.events
 	QUARK_EV_FORK             = uint64(C.QUARK_EV_FORK)

--- a/go/quark/quark_test.go
+++ b/go/quark/quark_test.go
@@ -54,6 +54,7 @@ func TestQuark(t *testing.T) {
 		attr := DefaultQueueAttr()
 		attr.HoldTime = 100
 
+		attr.Flags &= ^(QQ_EBPF | QQ_KPROBE)
 		attr.Flags |= QQ_EBPF
 		testStats(t, attr)
 	})
@@ -62,6 +63,7 @@ func TestQuark(t *testing.T) {
 		attr := DefaultQueueAttr()
 		attr.HoldTime = 100
 
+		attr.Flags &= ^(QQ_EBPF | QQ_KPROBE)
 		attr.Flags |= QQ_KPROBE
 		testStats(t, attr)
 	})

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -138,14 +138,13 @@ Print version and exit.
 .Sh BACKEND SELECTION
 If no backend option is specified,
 .Nm
-will attempt EBPF, and then kprobe if EBPF failed.
-If only one of
-.Fl b
-or
+uses EBPF.
+Exactly one of
+.Fl b ,
 .Fl k
-is passed, then
-.Nm
-will be restricted to that option only.
+or
+.Fl n
+may be passed, there is no fallback between backends.
 .Sh EXIT STATUS
 .Nm
 exits with 0 in if a SIGINT was sent, or 1 in case of error.

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 	void 				(*print_event)(struct quark_queue *, const struct quark_event *);
 
 	quark_queue_default_attr(&qa);
-	qa.flags &= ~QQ_ALL_BACKENDS;
+	qa.flags &= ~(QQ_EBPF | QQ_KPROBE | QQ_NOVA);
 	maxnodes = -1;
 	do_priv_drop = 0;
 	filter_ppid = 0;
@@ -341,8 +341,8 @@ main(int argc, char *argv[])
 		qa.flags |= QQ_EBPF;
 	}
 
-	if ((qa.flags & QQ_ALL_BACKENDS) == 0)
-		qa.flags |= QQ_ALL_BACKENDS;
+	if ((qa.flags & (QQ_EBPF | QQ_KPROBE | QQ_NOVA)) == 0)
+		qa.flags |= QQ_EBPF;
 
 	bzero(&sigact, sizeof(sigact));
 	sigact.sa_flags = SA_RESTART | SA_RESETHAND;

--- a/quark-test.c
+++ b/quark-test.c
@@ -138,7 +138,7 @@ backend_of_attr(struct quark_queue_attr *qa)
 
 	if (qa == NULL)
 		return (-1);
-	else if (((qa->flags & QQ_ALL_BACKENDS) == QQ_ALL_BACKENDS))
+	else if (((qa->flags & (QQ_EBPF | QQ_KPROBE)) == (QQ_EBPF | QQ_KPROBE)))
 		errx(1, "backend must be explicit");
 	else if (qa->flags & QQ_EBPF)
 		be = QQ_EBPF;
@@ -1874,6 +1874,39 @@ t_cgroup_parse(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
+/*
+ * quark_queue_open() must refuse anything but exactly one backend
+ * with EINVAL, and the default attr must select only EBPF.
+ */
+static int
+t_backend_flags(const struct test *t, struct quark_queue_attr *unused)
+{
+	struct quark_queue	 qq;
+	struct quark_queue_attr	 attr;
+	size_t			 i;
+	int			 bad_backends[] = {
+		0,
+		QQ_EBPF | QQ_KPROBE,
+		QQ_EBPF | QQ_NOVA,
+		QQ_KPROBE | QQ_NOVA,
+		QQ_EBPF | QQ_KPROBE | QQ_NOVA,
+	};
+
+	quark_queue_default_attr(&attr);
+	assert((attr.flags & (QQ_EBPF | QQ_KPROBE | QQ_NOVA)) == QQ_EBPF);
+
+	for (i = 0; i < nitems(bad_backends); i++) {
+		quark_queue_default_attr(&attr);
+		attr.flags &= ~(QQ_EBPF | QQ_KPROBE | QQ_NOVA);
+		attr.flags |= bad_backends[i];
+		errno = 0;
+		assert(quark_queue_open(&qq, &attr) == -1);
+		assert(errno == EINVAL);
+	}
+
+	return (0);
+}
+
 static int
 t_hanson(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -2690,6 +2723,7 @@ struct test all_tests[] = {
 	T_EBPF(t_set_agg_matrix),
 	T_EBPF(t_stats),
 	T_KPROBE(t_stats),
+	T(t_backend_flags),
 	T(t_hanson),
 	T(t_hanson_escape),
 	T_EBPF(t_rule_path),
@@ -3000,19 +3034,19 @@ run_tests(int argc, char *argv[])
 	struct progress		 progress;
 
 	quark_queue_default_attr(&bpf_attr);
-	bpf_attr.flags &= ~QQ_ALL_BACKENDS;
+	bpf_attr.flags &= ~(QQ_EBPF | QQ_KPROBE | QQ_NOVA);
 	bpf_attr.flags |= QQ_EBPF | QQ_ENTRY_LEADER;
 	bpf_attr.hold_time = 100;
 	bpf_attr.max_env = 32768;
 
 	quark_queue_default_attr(&kprobe_attr);
-	kprobe_attr.flags &= ~QQ_ALL_BACKENDS;
+	kprobe_attr.flags &= ~(QQ_EBPF | QQ_KPROBE | QQ_NOVA);
 	kprobe_attr.flags |= QQ_KPROBE | QQ_ENTRY_LEADER;
 	kprobe_attr.hold_time = 100;
 	kprobe_attr.max_env = 32768;
 
 	quark_queue_default_attr(&nova_attr);
-	nova_attr.flags &= ~QQ_ALL_BACKENDS;
+	nova_attr.flags &= ~(QQ_EBPF | QQ_KPROBE | QQ_NOVA);
 	nova_attr.flags |= QQ_NOVA | QQ_ENTRY_LEADER;
 	nova_attr.hold_time = 100;
 	nova_attr.max_env = 32768;

--- a/quark.c
+++ b/quark.c
@@ -4109,7 +4109,7 @@ quark_queue_default_attr(struct quark_queue_attr *qa)
 {
 	bzero(qa, sizeof(*qa));
 
-	qa->flags = QQ_ALL_BACKENDS;
+	qa->flags = QQ_EBPF;
 	qa->max_length = 10000;
 	qa->cache_grace_time = 4000;	/* four seconds */
 	qa->hold_time = 1000;		/* one second */
@@ -4124,6 +4124,7 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	struct quark_queue_attr	 qa_default;
 	struct timespec		 unused;
 	char			*ver;
+	int			 backends;
 
 	if ((ver = getenv("QUARK_VERBOSE")) != NULL) {
 		const char *errstr;
@@ -4169,9 +4170,14 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	if (qa->flags & QQ_MONOTONIC)
 		return (errno = EINVAL, -1);
 
-	/* XXX hardcode QQ_NOVA for now XXX */
-	if ((qa->flags & (QQ_ALL_BACKENDS | QQ_NOVA)) == 0 ||
-	    qa->max_length <= 0 ||
+	/* Exactly one backend must be selected */
+	backends = qa->flags & (QQ_EBPF | QQ_KPROBE | QQ_NOVA);
+	if (backends != QQ_EBPF &&
+	    backends != QQ_KPROBE &&
+	    backends != QQ_NOVA)
+		return (errno = EINVAL, -1);
+
+	if (qa->max_length <= 0 ||
 	    qa->cache_grace_time < 0 ||
 	    qa->hold_time < 10)
 		return (errno = EINVAL, -1);
@@ -4278,13 +4284,24 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 	}
 
 	/*
-	 * Open the rings
+	 * Open the ring of the selected backend, there is no fallback:
+	 * users that want one must retry with another backend themselves.
 	 */
-	if (nova_queue_open(qq) != 0 &&
-	    bpf_queue_open(qq) != 0 &&
-	    kprobe_queue_open(qq) != 0) {
-		qwarnx("all backends failed");
-		goto fail;
+	if (backends == QQ_EBPF) {
+		if (bpf_queue_open(qq) != 0) {
+			qwarnx("can't open the ebpf backend");
+			goto fail;
+		}
+	} else if (backends == QQ_KPROBE) {
+		if (kprobe_queue_open(qq) != 0) {
+			qwarnx("can't open the kprobe backend");
+			goto fail;
+		}
+	} else if (backends == QQ_NOVA) {
+		if (nova_queue_open(qq) != 0) {
+			qwarnx("can't open the nova backend");
+			goto fail;
+		}
 	}
 
 	if ((qq->flags & QQ_BYPASS) == 0) {

--- a/quark.h
+++ b/quark.h
@@ -898,7 +898,6 @@ struct quark_queue_attr {
  * CLOCK_MONOTONIC, else CLOCK_BOOTTIME.
  */
 #define QQ_MONOTONIC		(1 << 15)
-#define QQ_ALL_BACKENDS		(QQ_KPROBE | QQ_EBPF)	/* QQ_NOVA excluded for now */
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -30,9 +30,14 @@ The
 function does the following:
 .Bl -bullet
 .It
-Attempts to use the best backend available unless otherwise especified.
+Attempts to use the selected backend.
 This includes loading the EBPF programs for EBPF or the probes for KPROBES.
-Only one backend is used and it defaults to EBPF and falls back to KPROBE.
+Exactly one backend must be selected, anything else fails with
+.Er EINVAL .
+There is no fallback: users that want one must retry with another
+backend themselves if
+.Nm
+fails.
 .It
 On its first call it will also initialize global host state, like BTF offsets
 and HZ.
@@ -83,12 +88,10 @@ struct quark_queue_attr {
 Bitmask of:
 .Bl -tag -width QQ_THREAD_EVENTS
 .It Dv QQ_EBPF
-Enable the EBPF backend.
-EBPF is attempted first and falls back to KPROBE if both were specified.
+Use the EBPF backend, this is the default of
+.Xr quark_queue_default_attr 3 .
 .It Dv QQ_KPROBE
-Enable the KPROBE backend, see above.
-.It Dv QQ_ALL_BACKENDS
-Shorthand for (QQ_EBPF | QQ_KPROBE).
+Use the KPROBE backend.
 .It Dv QQ_MONOTONIC
 Informational, not configuration: specifying it fails with
 .Er EINVAL .


### PR DESCRIPTION
Closes #366.

quark_queue_open() tried every enabled backend in order and used the
first that worked, so a user asking for ebpf could silently end up on
kprobe, and when everything failed there was no way to tell which
backend failed or why.

- quark_queue_open() now requires exactly one of QQ_EBPF, QQ_KPROBE or
  QQ_NOVA and fails with EINVAL otherwise, dispatching explicitly to the
  selected backend with a per-backend error message.
- quark_queue_default_attr() selects only QQ_EBPF.
- QQ_ALL_BACKENDS is deleted from quark.h and the Go bindings, so
  downstream breaks at compile time instead of silently changing
  behaviour.
- quark-mon(8) defaults to ebpf when no backend option is given; -b/-k/-n
  are now mutually exclusive.
- quark_queue_open(3) and quark-mon(8) manpages updated, HTML regenerated,
  CHANGES gains a BREAKING bullet under 0.8.

Users that want the old behaviour must reopen the queue with another
backend themselves when quark_queue_open() fails: that policy now
belongs to the application, which can decide whether to fall back
unconditionally or only on specific failures.

The new t_backend_flags regression test checks the default attr is
ebpf-only and that zero or multiple backend flags fail with EINVAL. It
was verified to fail against main before this change (aborts on the
default-attr assertion) and passes with it.
