### PR TITLE
Fetch Packages.gz by hash in krun-ubuntu.sh

### DIFF
--- a/krun-ubuntu.sh
+++ b/krun-ubuntu.sh
@@ -114,8 +114,27 @@ for repo in "${REPOS[@]}"; do
 			tbl && $NF==pk {print $1;exit}' "$TMPDIR/Release") || true
 	fi
 
-	curl "${CURL_OPTS[@]}" "$BASE_URL/$PKG_PATH" -o "$TMPDIR/Packages.gz" ||
-		{ log "No Packages.gz for $repo (arch not built?)"; continue; }
+	# Prefer the content-addressed by-hash path: the archive is a
+	# pool of mirrors and dists/ files change several times a day,
+	# so fetching Packages.gz by name can return a file that does
+	# not match the Release we just read (the two requests may hit
+	# different backends). The by-hash object for our Release is
+	# immutable and retained across a few generations, so it can't
+	# tear. Fall back to the named path if by-hash is unavailable.
+	PKG_FETCHED=0
+	if [[ -n $EXPECTED_HASH ]] &&
+	    grep -q '^Acquire-By-Hash: yes' "$TMPDIR/Release"; then
+		BYHASH_URL="$BASE_URL/dists/$repo/main/binary-$ARCH/by-hash/SHA256/$EXPECTED_HASH"
+		log "Fetching Packages.gz by hash"
+		curl "${CURL_OPTS[@]}" "$BYHASH_URL" -o "$TMPDIR/Packages.gz" &&
+			PKG_FETCHED=1 ||
+			log "by-hash fetch failed; falling back to named path"
+	fi
+
+	if [[ $PKG_FETCHED -eq 0 ]]; then
+		curl "${CURL_OPTS[@]}" "$BASE_URL/$PKG_PATH" -o "$TMPDIR/Packages.gz" ||
+			{ log "No Packages.gz for $repo (arch not built?)"; continue; }
+	fi
 
 	if [[ -n $EXPECTED_HASH ]]; then
 		[[ $(sha256sum "$TMPDIR/Packages.gz" | awk '{print $1}') == "$EXPECTED_HASH" ]] ||


### PR DESCRIPTION
CI jobs regularly die with `Checksum mismatch for Packages.gz (possible
MITM)`. It's not MITM: archive.ubuntu.com is a pool of mirrors and the
dists/ indices are republished several times a day. The Release fetch
and the Packages.gz fetch are two separate requests that can hit
different backends in different sync states, so the named Packages.gz
often doesn't match the Release we just read. With six ubuntu jobs per
build, each probing up to three repos, the race bites often.

Fix: fetch Packages.gz from the content-addressed `by-hash` path using
the SHA256 we already parse from Release. The object is immutable and
retained across generations, so it can't tear regardless of which
backend serves it — this is how apt itself avoids the same race. Falls
back to the named path when Release lacks `Acquire-By-Hash`, and the
existing checksum verification is kept either way.

Verified against the live archive: noble-updates fetches by hash with a
matching checksum; bionic and focal also advertise Acquire-By-Hash, so
every supported release takes the new path. The full script was
exercised end to end for 24.04 with a stubbed krun.sh (kernel found,
downloaded, extracted, handed off).

The fedora/rhel/archlinux krun scripts don't verify index checksums at
all, so they can't hit this particular failure; no change there.
