### PR TITLE
Don't fail the proc scrape on a duplicate socket inode

### DIFF
--- a/quark.c
+++ b/quark.c
@@ -3141,9 +3141,16 @@ sproc_net_tcp_line(struct quark_queue *qq, const char *line, int af,
 
 		col = RB_INSERT(sproc_socket_by_inode, by_inode, ss);
 		if (col != NULL) {
+			/*
+			 * The kernel can list the same socket twice in a
+			 * single dump of /proc/net/tcp: it's read in
+			 * chunks and a connection opening in between
+			 * shifts the ones we already read further down.
+			 * Normal, not corruption, keep the first copy.
+			 */
 			free(ss);
-			qwarnx("socket collision");
-			return (errno = EEXIST, -1);
+			qdebugx("duplicate socket inode %lu, skipping", inode);
+			return (0);
 		}
 	}
 


### PR DESCRIPTION
sproc_net_tcp_line() treated a collision in the by_inode tree as fatal and returned EEXIST, which fails sproc_scrape() and in turn the whole quark_queue_open(). A duplicate is not an error: /proc/net/tcp is read over many read()s and the kernel resumes iteration by (bucket, offset) in tcp_seek_last_pos(), so a socket hashed into the head of an already visited bucket in between shifts the entries we consumed one slot down and the last one is emitted a second time. The odds grow with the size and the churn of the connection table, so the busiest hosts are the ones that fail to open a queue at all.

Both rows describe the same inode, so keep the first one and carry on.