### PR TITLE
Add functions to insert pods/containers to the new trees

### DIFF
--- a/quark.c
+++ b/quark.c
@@ -2439,6 +2439,100 @@ quark_container_lookup(struct quark_queue *qq, const char *container_id)
 	return (container_lookup(qq, (char *)container_id));
 }
 
+struct quark_pod *
+quark_pod_create(struct quark_queue *qq, const char *uid,
+    const char *name, const char *ns, const char *phase)
+{
+	struct quark_pod	*pod;
+
+	if (pod_lookup_by_uid(qq, (char *)uid) != NULL)
+		return (errno = EEXIST, NULL);
+
+	pod = calloc(1, sizeof(*pod));
+	if (pod == NULL)
+		return (NULL);
+	RB_INIT(&pod->containers);
+	RB_INIT(&pod->labels);
+	pod->uid = strdup(uid);
+	if (pod->uid == NULL)
+		goto fail;
+	if (name != NULL && (pod->name = strdup(name)) == NULL)
+		goto fail;
+	if (ns != NULL && (pod->ns = strdup(ns)) == NULL)
+		goto fail;
+	if (phase != NULL && (pod->phase = strdup(phase)) == NULL)
+		goto fail;
+	if (pod_insert(qq, pod) == -1)
+		goto fail;
+
+	return (pod);
+fail:
+	free(pod->uid);
+	free(pod->name);
+	free(pod->ns);
+	free(pod->phase);
+	free(pod);
+	return (NULL);
+}
+
+struct quark_container *
+quark_container_create(struct quark_queue *qq, const char *container_id,
+    const char *pod_uid, const char *name, const char *image)
+{
+	struct quark_container	*container, *col;
+	struct quark_pod	*pod = NULL;
+
+	if (pod_uid != NULL) {
+		pod = pod_lookup_by_uid(qq, (char *)pod_uid);
+		if (pod == NULL)
+			return (NULL);
+	}
+
+	if (container_lookup(qq, (char *)container_id) != NULL)
+		return (errno = EEXIST, NULL);
+
+	container = calloc(1, sizeof(*container));
+	if (container == NULL)
+		return (NULL);
+	TAILQ_INIT(&container->processes);
+	container->container_id = strdup(container_id);
+	if (container->container_id == NULL)
+		goto fail;
+	if (name != NULL && (container->name = strdup(name)) == NULL)
+		goto fail;
+	if (image != NULL && (container->image = strdup(image)) == NULL)
+		goto fail;
+
+	col = container_by_id_RB_INSERT(&qq->container_by_id, container);
+	if (unlikely(col != NULL)) {
+		errno = EEXIST;
+		goto fail;
+	}
+	container->linked_by_id = 1;
+
+	if (pod != NULL) {
+		container->pod = pod;
+		col = pod_containers_RB_INSERT(&pod->containers, container);
+		if (unlikely(col != NULL)) {
+			errno = EEXIST;
+			goto fail;
+		}
+		container->linked_by_pod = 1;
+	}
+
+	return (container);
+fail:
+	if (container->linked_by_id)
+		container_delete(qq, container);
+	else {
+		free(container->container_id);
+		free(container->name);
+		free(container->image);
+		free(container);
+	}
+	return (NULL);
+}
+
 void
 quark_process_iter_init(struct quark_process_iter *qi, struct quark_queue *qq)
 {

--- a/quark.h
+++ b/quark.h
@@ -90,6 +90,11 @@ struct quark_container	*quark_container_get(struct quark_queue *,
 			     const char *, const char *);
 const struct quark_container *quark_container_lookup(struct quark_queue *,
 			     const char *);
+struct quark_pod	*quark_pod_create(struct quark_queue *, const char *,
+			     const char *, const char *, const char *);
+struct quark_container	*quark_container_create(struct quark_queue *,
+			     const char *, const char *, const char *,
+			     const char *);
 void			 quark_ruleset_init(struct quark_ruleset *);
 void			 quark_ruleset_clear(struct quark_ruleset *);
 int			 quark_ruleset_parse(struct quark_ruleset *, FILE *,


### PR DESCRIPTION
Add C functions to create pods and containers in the queue.
Copy the supplied values into each new object.
Permit optional fields to be NULL.
Permit containers without a pod.

Return NULL and set errno to EEXIST for a duplicate ID.
Return NULL and set errno to ESRCH if the requested pod is missing.

Address the code review comments.
Print `<unknown>` for missing pod and container fields in event output.
Add creation, lookup, and error tests.
Add event output tests for missing fields and supplied values.

The Docker build passed with `make ARCH=arm64 docker`.
All six pod and container tests passed on Linux.
The diff check passed.
The Kubernetes integration test was not run.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
