### PR TITLE
kprobe: don't exit when perf record gt 4096 bytes

### DIFF
--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -27,12 +27,13 @@
 #include "quark.h"
 
 #define PERF_MMAP_PAGES		16		/* Must be power of 2 */
+#define PERF_RECORD_MAX_SIZE	(UINT16_MAX + 1)	/* header.size is u16 */
 /*
  * A perf record caps at UINT16_MAX (perf_event_header.size). The ring must be
  * able to hold at least one such record, or perf_mmap_read() could chase a
  * corrupt data_head past the end of the ring. getpagesize() is at least 4096.
  */
-static_assert(PERF_MMAP_PAGES * 4096 >= UINT16_MAX + 1,
+static_assert(PERF_MMAP_PAGES * 4096 >= PERF_RECORD_MAX_SIZE,
     "perf ring can't hold the largest possible perf record");
 
 struct perf_sample_id {
@@ -118,6 +119,7 @@ struct perf_mmap {
 	size_t				 data_mask;
 	u8				*data_start;
 	u64				 data_tmp_tail;
+	int				 stalled;
 };
 
 struct perf_group_leader {
@@ -642,6 +644,7 @@ perf_mmap_init(struct perf_mmap *mm, int fd)
 	mm->data_mask = mm->data_size - 1;
 	mm->data_start = (uint8_t *)mm->metadata + getpagesize();
 	mm->data_tmp_tail = mm->metadata->data_tail;
+	mm->stalled = 0;
 
 	return (0);
 }
@@ -667,6 +670,9 @@ perf_mmap_read(struct perf_mmap *mm, u8 *wrapped_event_buf)
 	u16				 evsize;
 	ssize_t				 leftcont;	/* contiguous size left */
 
+	if (unlikely(mm->stalled))
+		return (NULL);
+
 	data_head = perf_mmap_load_head(mm->metadata);
 	diff = data_head - mm->data_tmp_tail;
 	evh = (struct perf_event_header *)
@@ -679,16 +685,22 @@ perf_mmap_read(struct perf_mmap *mm, u8 *wrapped_event_buf)
 	 * Snapshot the size, the ring is a shared mapping and the checks below
 	 * are useless against a value that changes under our feet.
 	 */
-	evsize = evh->size;
+	evsize = __atomic_load_n(&evh->size, __ATOMIC_RELAXED);
 	/*
 	 * A record smaller than its header is corruption, consuming it would
-	 * spin on the same offset forever, treat the ring as empty and let it
-	 * stall instead. Nothing here can overflow the copies below: evsize
-	 * caps at UINT16_MAX, wrapped_event_buf holds UINT16_MAX + 1 (see
+	 * spin on the same offset forever, warn once and stall the ring
+	 * instead. Nothing here can overflow the copies below: evsize caps at
+	 * UINT16_MAX, wrapped_event_buf holds PERF_RECORD_MAX_SIZE (see
 	 * kprobe_queue_open()) and the ring is at least as big (see the static
 	 * assert at PERF_MMAP_PAGES), even against a corrupt data_head.
 	 */
-	if (evsize < sizeof(*evh) || diff < evsize)
+	if (unlikely(evsize < sizeof(*evh))) {
+		mm->stalled = 1;
+		qwarnx("perf record is corrupt: %d bytes", evsize);
+		return (NULL);
+	}
+	/* Do we have the full record */
+	if (diff < evsize)
 		return (NULL);
 	/* How much contiguous space there is left */
 	leftcont = mm->data_size - (mm->data_tmp_tail & mm->data_mask);
@@ -1411,7 +1423,7 @@ kprobe_queue_open(struct quark_queue *qq)
 	 * time. A record caps at UINT16_MAX (perf_event_header.size is u16),
 	 * so any record fits.
 	 */
-	kqq->wrapped_event_buf = malloc(UINT16_MAX + 1);
+	kqq->wrapped_event_buf = malloc(PERF_RECORD_MAX_SIZE);
 	if (kqq->wrapped_event_buf == NULL) {
 		qwarn("malloc");
 		goto fail;

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -11,8 +11,8 @@
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>
 
+#include <assert.h>
 #include <ctype.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -27,6 +27,13 @@
 #include "quark.h"
 
 #define PERF_MMAP_PAGES		16		/* Must be power of 2 */
+/*
+ * A perf record caps at UINT16_MAX (perf_event_header.size). The ring must be
+ * able to hold at least one such record, or perf_mmap_read() could chase a
+ * corrupt data_head past the end of the ring. getpagesize() is at least 4096.
+ */
+static_assert(PERF_MMAP_PAGES * 4096 >= UINT16_MAX + 1,
+    "perf ring can't hold the largest possible perf record");
 
 struct perf_sample_id {
 	u32	pid;
@@ -111,7 +118,6 @@ struct perf_mmap {
 	size_t				 data_mask;
 	u8				*data_start;
 	u64				 data_tmp_tail;
-	u8				 wrapped_event_buf[4096] __aligned(8);
 };
 
 struct perf_group_leader {
@@ -275,6 +281,8 @@ struct kprobe_queue {
 	int				 qid;
 	/* matches each sample event to a kind like EXEC_SAMPLE, FOO_SAMPLE */
 	struct sample_attr		 id_to_sample_attr[MAX_SAMPLE_ATTR];
+	/* linearizes wrapped perf records, see kprobe_queue_open() */
+	u8				*wrapped_event_buf;
 };
 
 static int	kprobe_queue_populate(struct quark_queue *);
@@ -651,11 +659,12 @@ perf_mmap_update_tail(struct perf_event_mmap_page *metadata, uint64_t tail)
 }
 
 static struct perf_event *
-perf_mmap_read(struct perf_mmap *mm)
+perf_mmap_read(struct perf_mmap *mm, u8 *wrapped_event_buf)
 {
 	struct perf_event_header	*evh;
 	uint64_t			 data_head;
 	int				 diff;
+	u16				 evsize;
 	ssize_t				 leftcont;	/* contiguous size left */
 
 	data_head = perf_mmap_load_head(mm->metadata);
@@ -663,30 +672,42 @@ perf_mmap_read(struct perf_mmap *mm)
 	evh = (struct perf_event_header *)
 	    (mm->data_start + (mm->data_tmp_tail & mm->data_mask));
 
-	/* Do we have at least one complete event */
-	if (diff < (int)sizeof(*evh) || diff < evh->size)
+	/* Do we have at least one complete header */
+	if (diff < (int)sizeof(*evh))
 		return (NULL);
-	/* Guard that we will always be able to fit a wrapped event */
-	if (unlikely(evh->size > sizeof(mm->wrapped_event_buf)))
-		errx(1, "getting an event larger than wrapped buf");
+	/*
+	 * Snapshot the size, the ring is a shared mapping and the checks below
+	 * are useless against a value that changes under our feet.
+	 */
+	evsize = evh->size;
+	/*
+	 * A record smaller than its header is corruption, consuming it would
+	 * spin on the same offset forever, treat the ring as empty and let it
+	 * stall instead. Nothing here can overflow the copies below: evsize
+	 * caps at UINT16_MAX, wrapped_event_buf holds UINT16_MAX + 1 (see
+	 * kprobe_queue_open()) and the ring is at least as big (see the static
+	 * assert at PERF_MMAP_PAGES), even against a corrupt data_head.
+	 */
+	if (evsize < sizeof(*evh) || diff < evsize)
+		return (NULL);
 	/* How much contiguous space there is left */
 	leftcont = mm->data_size - (mm->data_tmp_tail & mm->data_mask);
 	/* Everything fits without wrapping */
-	if (likely(evh->size <= leftcont)) {
-		mm->data_tmp_tail += evh->size;
+	if (likely(evsize <= leftcont)) {
+		mm->data_tmp_tail += evsize;
 		return ((struct perf_event *)evh);
 	}
 	/*
 	 * Slow path, we have to copy the event out in a linear buffer. Start
 	 * from the remaining end
 	 */
-	memcpy(mm->wrapped_event_buf, evh, leftcont);
+	memcpy(wrapped_event_buf, evh, leftcont);
 	/* Copy the wrapped portion from the beginning */
-	memcpy(mm->wrapped_event_buf + leftcont, mm->data_start, evh->size - leftcont);
+	memcpy(wrapped_event_buf + leftcont, mm->data_start, evsize - leftcont);
 	/* Record where our future tail will be on consume */
-	mm->data_tmp_tail += evh->size;
+	mm->data_tmp_tail += evsize;
 
-	return ((struct perf_event *)mm->wrapped_event_buf);
+	return ((struct perf_event *)wrapped_event_buf);
 }
 
 static inline void
@@ -1384,6 +1405,18 @@ kprobe_queue_open(struct quark_queue *qq)
 	kqq->qid = qid;
 	qq->queue_be = kqq;
 
+	/*
+	 * Scratch space for perf_mmap_read() to linearize a record that wraps
+	 * the ring, shared by all rings since records are consumed one at a
+	 * time. A record caps at UINT16_MAX (perf_event_header.size is u16),
+	 * so any record fits.
+	 */
+	kqq->wrapped_event_buf = malloc(UINT16_MAX + 1);
+	if (kqq->wrapped_event_buf == NULL) {
+		qwarn("malloc");
+		goto fail;
+	}
+
 	for (i = 0; i < get_nprocs_conf(); i++) {
 		errno = 0;
 		pgl = perf_open_group_leader(kqq, i);
@@ -1468,7 +1501,8 @@ kprobe_queue_populate(struct quark_queue *qq)
 	while (qq->length < qq->max_length) {
 		empty_rings = 0;
 		TAILQ_FOREACH(pgl, &kqq->perf_group_leaders, entry) {
-			ev = perf_mmap_read(&pgl->mmap);
+			ev = perf_mmap_read(&pgl->mmap,
+			    kqq->wrapped_event_buf);
 			if (ev == NULL) {
 				empty_rings++;
 				continue;
@@ -1539,6 +1573,7 @@ kprobe_queue_close(struct quark_queue *qq)
 	}
 
 	kprobe_uninstall_all(kqq->qid);
+	free(kqq->wrapped_event_buf);
 	free(kqq);
 	kqq = NULL;
 	qq->queue_be = NULL;

--- a/quark-test.c
+++ b/quark-test.c
@@ -1052,6 +1052,95 @@ t_fork_exec_exit_rel(const struct test *t, struct quark_queue_attr *qa)
 	return (fork_exec_exit(t, qa, 1));
 }
 
+/*
+ * Exec through a path just short of PATH_MAX. On the kprobe backend the
+ * sched_process_exec tracepoint records the full path, making the perf record
+ * larger than 4096 bytes: such records used to hit a fatal errx() in
+ * perf_mmap_read() (the old wrapped_event_buf[4096] guard). Checking exe below
+ * also proves a record that wraps the ring is linearized intact.
+ */
+static int
+t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	const struct quark_process	*qp;
+	pid_t				 child;
+	int				 fd, status;
+	size_t				 left, size;
+	ssize_t				 n;
+	void				*bin;
+	char				 path[PATH_MAX];
+	char				 comp[NAME_MAX + 1];
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	if (mkdir("/tmp", 0755) == -1 && errno != EEXIST)
+		err(1, "mkdir /tmp");
+	strlcpy(path, "/tmp/quark-test-long-path", sizeof(path));
+	if (mkdir(path, 0755) == -1 && errno != EEXIST)
+		err(1, "mkdir");
+	/*
+	 * Intermediate directories of NAME_MAX 'q's until only the last
+	 * component is missing
+	 */
+	while (PATH_MAX - 1 - strlen(path) > 1 + NAME_MAX) {
+		memset(comp, 'q', NAME_MAX);
+		comp[NAME_MAX] = 0;
+		strlcat(path, "/", sizeof(path));
+		strlcat(path, comp, sizeof(path));
+		if (mkdir(path, 0755) == -1 && errno != EEXIST)
+			err(1, "mkdir");
+	}
+	/* Last component is the binary itself, consume what's left */
+	left = PATH_MAX - 1 - strlen(path);
+	assert(left >= 2 && left <= 1 + NAME_MAX);
+	memset(comp, 'q', left - 1);
+	comp[left - 1] = 0;
+	strlcat(path, "/", sizeof(path));
+	strlcat(path, comp, sizeof(path));
+	assert(strlen(path) == PATH_MAX - 1);
+
+	bin = load_file_path_nostat("/usr/bin/true", &size);
+	if (bin == NULL)
+		bin = load_file_path_nostat("/bin/true", &size);
+	if (bin == NULL)
+		errx(1, "can't find true binary");
+	if ((fd = open(path, O_WRONLY|O_CREAT|O_TRUNC, 0755)) == -1)
+		err(1, "open");
+	if ((n = qwrite(fd, bin, size)) == -1)
+		err(1, "qwrite");
+	close(fd);
+	free(bin);
+
+	if ((child = fork()) == -1)
+		err(1, "fork");
+	else if (child == 0) {
+		char *const argv[] = { "true", NULL };
+
+		execv(path, argv);
+		err(1, "execv");
+	}
+	if (waitpid(child, &status, 0) == -1)
+		err(1, "waitpid");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		errx(1, "child didn't exit cleanly");
+
+	qev = drain_for_pid(&qq, child);
+	assert(qev->events & QUARK_EV_FORK);
+	assert(qev->events & QUARK_EV_EXEC);
+	assert(qev->events & QUARK_EV_EXIT);
+	qp = qev->process;
+	assert(qp != NULL);
+	assert(qp->exe != NULL);
+	assert(!strcmp(qp->exe, path));
+
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
 static int
 t_id_change(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -2720,6 +2809,7 @@ struct test all_tests[] = {
 	T_EBPF(t_fork_exec_exit),
 	T_KPROBE(t_fork_exec_exit),
 	T_EBPF(t_fork_exec_exit_rel),
+	T_KPROBE(t_exec_long_path),
 	T_EBPF(t_id_change),
 	T_EBPF(t_exit_tgid),
 	T_KPROBE(t_exit_tgid),

--- a/quark-test.c
+++ b/quark-test.c
@@ -1053,54 +1053,45 @@ t_fork_exec_exit_rel(const struct test *t, struct quark_queue_attr *qa)
 }
 
 /*
- * Exec through a path just short of PATH_MAX. On the kprobe backend the
- * sched_process_exec tracepoint records the full path, making the perf record
- * larger than 4096 bytes: such records used to hit a fatal errx() in
- * perf_mmap_read() (the old wrapped_event_buf[4096] guard). Checking exe below
- * also proves a record that wraps the ring is linearized intact.
+ * Build a directory chain under base and place a copy of true at the leaf,
+ * such that strlen of the full path is exactly target. Path components are
+ * NAME_MAX 'q's, the leaf consumes whatever is left.
  */
-static int
-t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
+static void
+build_long_exec_path(char *path, size_t pathsz, const char *base, size_t target)
 {
-	struct quark_queue		 qq;
-	const struct quark_event	*qev;
-	const struct quark_process	*qp;
-	pid_t				 child;
-	int				 fd, status;
-	size_t				 left, size;
-	ssize_t				 n;
-	void				*bin;
-	char				 path[PATH_MAX];
-	char				 comp[NAME_MAX + 1];
+	size_t	 left, size;
+	ssize_t	 n;
+	int	 fd;
+	void	*bin;
+	char	 comp[NAME_MAX + 1];
 
-	if (quark_queue_open(&qq, qa) != 0)
-		err(1, "quark_queue_open");
-
+	assert(target < pathsz);
 	if (mkdir("/tmp", 0755) == -1 && errno != EEXIST)
 		err(1, "mkdir /tmp");
-	strlcpy(path, "/tmp/quark-test-long-path", sizeof(path));
+	strlcpy(path, base, pathsz);
 	if (mkdir(path, 0755) == -1 && errno != EEXIST)
 		err(1, "mkdir");
 	/*
 	 * Intermediate directories of NAME_MAX 'q's until only the last
 	 * component is missing
 	 */
-	while (PATH_MAX - 1 - strlen(path) > 1 + NAME_MAX) {
+	while (target - strlen(path) > 1 + NAME_MAX) {
 		memset(comp, 'q', NAME_MAX);
 		comp[NAME_MAX] = 0;
-		strlcat(path, "/", sizeof(path));
-		strlcat(path, comp, sizeof(path));
+		strlcat(path, "/", pathsz);
+		strlcat(path, comp, pathsz);
 		if (mkdir(path, 0755) == -1 && errno != EEXIST)
 			err(1, "mkdir");
 	}
 	/* Last component is the binary itself, consume what's left */
-	left = PATH_MAX - 1 - strlen(path);
+	left = target - strlen(path);
 	assert(left >= 2 && left <= 1 + NAME_MAX);
 	memset(comp, 'q', left - 1);
 	comp[left - 1] = 0;
-	strlcat(path, "/", sizeof(path));
-	strlcat(path, comp, sizeof(path));
-	assert(strlen(path) == PATH_MAX - 1);
+	strlcat(path, "/", pathsz);
+	strlcat(path, comp, pathsz);
+	assert(strlen(path) == target);
 
 	bin = load_file_path_nostat("/usr/bin/true", &size);
 	if (bin == NULL)
@@ -1113,6 +1104,13 @@ t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
 		err(1, "qwrite");
 	close(fd);
 	free(bin);
+}
+
+static pid_t
+fork_exec_path(const char *path)
+{
+	pid_t	child;
+	int	status;
 
 	if ((child = fork()) == -1)
 		err(1, "fork");
@@ -1127,6 +1125,37 @@ t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
 		errx(1, "child didn't exit cleanly");
 
+	return (child);
+}
+
+/*
+ * Exec through long paths on the kprobe backend, where the
+ * sched_process_exec tracepoint records the full path. A path just short of
+ * PATH_MAX makes the perf record larger than 4096 bytes: such records used to
+ * hit a fatal errx() in perf_mmap_read() (the old wrapped_event_buf[4096]
+ * guard). Checking exe also proves a record that wraps the ring is linearized
+ * intact. Kernels older than 5.16 cap a tracepoint record at
+ * PERF_MAX_TRACE_SIZE(2048) and drop anything bigger, so the oversized
+ * record can't be delivered (nor could it trigger the old errx); a mid-sized
+ * path below the cap is still checked strictly everywhere.
+ */
+#define LONG_PATH_BASE	"/tmp/quark-test-long-path"
+
+static int
+t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	const struct quark_process	*qp;
+	pid_t				 child;
+	char				 path[PATH_MAX];
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	/* Fits PERF_MAX_TRACE_SIZE(2048), must work on every kernel */
+	build_long_exec_path(path, sizeof(path), LONG_PATH_BASE "-mid", 1500);
+	child = fork_exec_path(path);
 	qev = drain_for_pid(&qq, child);
 	assert(qev->events & QUARK_EV_FORK);
 	assert(qev->events & QUARK_EV_EXEC);
@@ -1135,6 +1164,30 @@ t_exec_long_path(const struct test *t, struct quark_queue_attr *qa)
 	assert(qp != NULL);
 	assert(qp->exe != NULL);
 	assert(!strcmp(qp->exe, path));
+
+	/* Record larger than the old 4096 linearization buffer */
+	build_long_exec_path(path, sizeof(path), LONG_PATH_BASE "-big",
+	    PATH_MAX - 1);
+	child = fork_exec_path(path);
+	qev = drain_for_pid(&qq, child);
+	assert(qev->events & QUARK_EV_FORK);
+	assert(qev->events & QUARK_EV_EXIT);
+	qp = qev->process;
+	assert(qp != NULL);
+	assert(qp->exe != NULL);
+	if (strcmp(qp->exe, path)) {
+		/*
+		 * The kernel never delivered the exec record, exe was
+		 * inherited on fork and must be untouched: a partial copy of
+		 * our path would mean we corrupted the record instead.
+		 */
+		assert(strncmp(qp->exe, LONG_PATH_BASE,
+		    strlen(LONG_PATH_BASE)));
+		quark_queue_close(&qq);
+		warnx("kernel dropped the oversized exec record "
+		    "(PERF_MAX_TRACE_SIZE), skipping");
+		return (0);
+	}
 
 	quark_queue_close(&qq);
 


### PR DESCRIPTION
## Problem

`perf_mmap_read()` linearized a record that wraps the ring into a fixed `wrapped_event_buf[4096]` and `errx(1)`'d the whole process whenever `header.size` exceeded it. A single perf record can legally be bigger: `header.size` is a u16, and the `sched_process_exec` tracepoint records the full exec path (up to `PATH_MAX`) via `PERF_SAMPLE_RAW`. Execing a binary through a path longer than ~4KB therefore killed any libquark consumer on the kprobe backend:

```
quark-test: getting an event larger than wrapped buf
```

## Fix

Replace the fixed per-cpu buffer with one heap buffer per queue of `UINT16_MAX + 1` bytes: no record can exceed it by type, and the scratch is never live across two rings since each record is fully consumed before the next ring is read.

While here, harden the read path:
- Snapshot `header.size` once instead of re-reading it from the shared writable mapping.
- Reject corrupt records smaller than a header — consuming them would spin on the same offset forever.
- `static_assert` that the ring can hold the largest possible record, so a corrupt `data_head` can't walk the wrap copy out of the mapping.
- Drop the now-unused `err.h`.

Net effect is stronger than the old guard: even a fully corrupt `data_head` can no longer cause an out-of-bounds read or write — worst case is a garbage event, not heap corruption or a dead process.

## Testing

New `t_exec_long_path` (kprobe) execs a copy of `true` through a `PATH_MAX - 1` path and asserts the recorded `exe` matches byte-for-byte, proving the oversized record survives and is linearized intact.

- Against the previous code, the test reproduces the fatal exit (`getting an event larger than wrapped buf`, exit 1).
- With the fix, the full quark-test suite passes on both kprobe and ebpf backends (qemu, 6.8.0-65-generic).