### PR TITLE
CHANGES: socket times also moved to nanoseconds since boot

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -127,7 +127,8 @@ Changes from 0.6 to 0.7
 Changes from 0.7 to 0.8
 ~~~~~~~~~~~~~~~~~~~~~~~
   o BREAKING, SILENTLY: quark_process.proc_time_boot,
-    quark_process.exit_time_event and quark_event.time are now
+    quark_process.exit_time_event, quark_event.time,
+    quark_socket.established_time and quark_socket.close_time are now
     expressed in nanoseconds since boot instead of nanoseconds since
     the epoch. Existing code compiles unchanged but any user treating
     these fields as wallclock will emit timestamps that are off by


### PR DESCRIPTION
Split out of #372, which mixed a changelog fix, manpages and Go bindings; this carries only the changelog fix.

The 0.8 BREAKING, SILENTLY entry missed quark_socket established_time and close_time, which also moved to nanoseconds since boot.
