### PR TITLE
Document the boottime calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ These scripts require KVM access and therefore must be executed on a host kernel
 - Library calls fail with -1 unless otherwise stated, and `errno` is set.
 - Quark returns pointers to internal state, which must not be modified and/or stored. In the case of multithreading, these pointers should not be accessed if another thread is driving quark through [quark\_queue\_get\_event(3)](https://elastic.github.io/quark/quark_queue_get_event.3.html).
 - No threads are created, the library is driven solely through [quark\_queue\_get\_event(3)](https://elastic.github.io/quark/quark_queue_get_event.3.html).
-- Access to a `quark_queue` must be synchronized by the user in the case of multithreading.
+- Access to a `quark_queue` must be synchronized by the user in the case of multithreading. The boottime epoch is the exception: [quark\_update\_boottime(3)](https://elastic.github.io/quark/quark_update_boottime.3.html), [quark\_get\_boottime(3)](https://elastic.github.io/quark/quark_get_boottime.3.html) and [quark\_time\_to\_wallclock(3)](https://elastic.github.io/quark/quark_time_to_wallclock.3.html) may be called from any thread without synchronization.
 
 # [BASIC USAGE](#BASIC_USAGE)
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,18 @@ block for an unspecified amount of time.
 
 basic queue statistics.
 
+[quark\_time\_to\_wallclock(3)](https://elastic.github.io/quark/quark_time_to_wallclock.3.html)
+
+translate a time since boot to wallclock.
+
+[quark\_update\_boottime(3)](https://elastic.github.io/quark/quark_update_boottime.3.html)
+
+refetch the boottime epoch after a system clock change.
+
+[quark\_get\_boottime(3)](https://elastic.github.io/quark/quark_get_boottime.3.html)
+
+get the boottime epoch.
+
 [quark\_queue\_close(3)](https://elastic.github.io/quark/quark_queue_close.3.html)
 
 close a queue.
@@ -346,7 +358,7 @@ close a queue.
 
 # [SEE ALSO](#SEE_ALSO)
 
-[quark\_event\_dump(3)](https://elastic.github.io/quark/quark_event_dump.3.html), [quark\_process\_iter(3)](https://elastic.github.io/quark/quark_process_iter.3.html), [quark\_process\_lookup(3)](https://elastic.github.io/quark/quark_process_lookup.3.html), [quark\_queue\_block(3)](https://elastic.github.io/quark/quark_queue_block.3.html), [quark\_queue\_close(3)](https://elastic.github.io/quark/quark_queue_close.3.html), [quark\_queue\_get\_epollfd(3)](https://elastic.github.io/quark/quark_queue_get_epollfd.3.html), [quark\_queue\_get\_event(3)](https://elastic.github.io/quark/quark_queue_get_event.3.html), [quark\_queue\_get\_stats(3)](https://elastic.github.io/quark/quark_queue_get_stats.3.html), [quark\_queue\_open(3)](https://elastic.github.io/quark/quark_queue_open.3.html), [quark-btf(8)](https://elastic.github.io/quark/quark-btf.8.html), [quark-mon(8)](https://elastic.github.io/quark/quark-mon.8.html), [quark-test(8)](https://elastic.github.io/quark/quark-test.8.html)
+[quark\_event\_dump(3)](https://elastic.github.io/quark/quark_event_dump.3.html), [quark\_get\_boottime(3)](https://elastic.github.io/quark/quark_get_boottime.3.html), [quark\_process\_iter(3)](https://elastic.github.io/quark/quark_process_iter.3.html), [quark\_process\_lookup(3)](https://elastic.github.io/quark/quark_process_lookup.3.html), [quark\_queue\_block(3)](https://elastic.github.io/quark/quark_queue_block.3.html), [quark\_queue\_close(3)](https://elastic.github.io/quark/quark_queue_close.3.html), [quark\_queue\_get\_epollfd(3)](https://elastic.github.io/quark/quark_queue_get_epollfd.3.html), [quark\_queue\_get\_event(3)](https://elastic.github.io/quark/quark_queue_get_event.3.html), [quark\_queue\_get\_stats(3)](https://elastic.github.io/quark/quark_queue_get_stats.3.html), [quark\_queue\_open(3)](https://elastic.github.io/quark/quark_queue_open.3.html), [quark\_time\_to\_wallclock(3)](https://elastic.github.io/quark/quark_time_to_wallclock.3.html), [quark\_update\_boottime(3)](https://elastic.github.io/quark/quark_update_boottime.3.html), [quark-btf(8)](https://elastic.github.io/quark/quark-btf.8.html), [quark-mon(8)](https://elastic.github.io/quark/quark-mon.8.html), [quark-test(8)](https://elastic.github.io/quark/quark-test.8.html)
 
 # [LICENSE](#LICENSE)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -335,7 +335,12 @@ These scripts require KVM access and therefore must be executed on a host kernel
   <li>No threads are created, the library is driven solely through
       <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>.</li>
   <li>Access to a <var class="Vt">quark_queue</var> must be synchronized by the
-      user in the case of multithreading.</li>
+      user in the case of multithreading. The boottime epoch is the exception:
+      <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
+      <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>
+      and
+      <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
+      may be called from any thread without synchronization.</li>
 </ul>
 </section>
 <section class="Sh">
@@ -463,7 +468,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 3, 2026</td>
+    <td class="foot-date">August 14, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/index.html
+++ b/docs/index.html
@@ -412,6 +412,12 @@ main(void)
   <dd>block for an unspecified amount of time.</dd>
   <dt><a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a></dt>
   <dd>basic queue statistics.</dd>
+  <dt><a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a></dt>
+  <dd>translate a time since boot to wallclock.</dd>
+  <dt><a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a></dt>
+  <dd>refetch the boottime epoch after a system clock change.</dd>
+  <dt><a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a></dt>
+  <dd>get the boottime epoch.</dd>
   <dt><a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a></dt>
   <dd>close a queue.</dd>
 </dl>
@@ -430,6 +436,7 @@ main(void)
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>,
     <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
     <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
     <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
@@ -438,6 +445,8 @@ main(void)
     <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>,
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
     <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
     <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
@@ -454,7 +463,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">June 16, 2025</td>
+    <td class="foot-date">August 3, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -335,7 +335,12 @@ These scripts require KVM access and therefore must be executed on a host kernel
   <li>No threads are created, the library is driven solely through
       <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>.</li>
   <li>Access to a <var class="Vt">quark_queue</var> must be synchronized by the
-      user in the case of multithreading.</li>
+      user in the case of multithreading. The boottime epoch is the exception:
+      <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
+      <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>
+      and
+      <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
+      may be called from any thread without synchronization.</li>
 </ul>
 </section>
 <section class="Sh">
@@ -463,7 +468,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 3, 2026</td>
+    <td class="foot-date">August 14, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark.7.html
+++ b/docs/quark.7.html
@@ -412,6 +412,12 @@ main(void)
   <dd>block for an unspecified amount of time.</dd>
   <dt><a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a></dt>
   <dd>basic queue statistics.</dd>
+  <dt><a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a></dt>
+  <dd>translate a time since boot to wallclock.</dd>
+  <dt><a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a></dt>
+  <dd>refetch the boottime epoch after a system clock change.</dd>
+  <dt><a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a></dt>
+  <dd>get the boottime epoch.</dd>
   <dt><a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a></dt>
   <dd>close a queue.</dd>
 </dl>
@@ -430,6 +436,7 @@ main(void)
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>,
     <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
     <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
     <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
@@ -438,6 +445,8 @@ main(void)
     <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
     <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
     <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>,
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
     <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
     <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
     <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
@@ -454,7 +463,7 @@ main(void)
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">June 16, 2025</td>
+    <td class="foot-date">August 3, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_get_boottime.3.html
+++ b/docs/quark_get_boottime.3.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
+  <title>QUARK_GET_BOOTTIME(3)</title>
+</head>
+<body>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">QUARK_GET_BOOTTIME(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">QUARK_GET_BOOTTIME(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<p class="Pp"><code class="Nm">quark_get_boottime</code> &#x2014;
+    <span class="Nd">get the boottime epoch used for wallclock
+    translation</span></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<p class="Pp"><code class="In">#include
+  &lt;<a class="In">quark.h</a>&gt;</code></p>
+<p class="Pp"><var class="Ft">u64</var>
+  <br/>
+  <code class="Fn">quark_get_boottime</code>(<var class="Fa" style="white-space: nowrap;">void</var>);</p>
+</section>
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+<code class="Nm">quark_get_boottime</code> returns the internal boottime epoch:
+  the wallclock time of boot in nanoseconds since the Unix epoch, as fetched
+  from the btime field of <span class="Pa">/proc/stat</span>. btime has a
+  resolution of one second.
+<p class="Pp">The epoch is fetched when the first queue is opened and refetched
+    only by
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>.
+    It is what
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
+    adds to a time since boot, exposed for users that prefer to do the
+    translation themselves.</p>
+<section class="Sh">
+<h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+<p class="Pp">The boottime epoch in nanoseconds since the Unix epoch, zero if a
+    queue was never opened.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
+    <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
+    <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
+    <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
+    <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>,
+    <a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a>,
+    <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
+    <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>,
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
+    <a class="Xr" href="quark.7.html">quark(7)</a>,
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<p class="Pp"><code class="Nm">quark_get_boottime</code> appeared in quark 0.8,
+    when all times handed out by quark switched from nanoseconds since the Unix
+    epoch to nanoseconds since boot.</p>
+</section>
+</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">August 5, 2026</td>
+    <td class="foot-os">Linux</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -94,7 +94,9 @@
           opened queue's <i class="Em">flags</i> when its event times are
           CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which only the KPROBE
           backend does. Monotonic times undercount by the total suspended time,
-          users that care about suspend must compensate.</dd>
+          users that care about suspend must compensate. See
+          <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
+          for the effect on wallclock translation.</dd>
       <dt id="QQ_THREAD_EVENTS"><a class="permalink" href="#QQ_THREAD_EVENTS"><code class="Dv">QQ_THREAD_EVENTS</code></a></dt>
       <dd>Include per-thread events, instead of per-process events. This option
           will be removed in the future, but it may be useful for
@@ -170,7 +172,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 6, 2026</td>
+    <td class="foot-date">August 14, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_time_to_wallclock.3.html
+++ b/docs/quark_time_to_wallclock.3.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
+  <title>QUARK_TIME_TO_WALLCLOCK(3)</title>
+</head>
+<body>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">QUARK_TIME_TO_WALLCLOCK(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">QUARK_TIME_TO_WALLCLOCK(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<p class="Pp"><code class="Nm">quark_time_to_wallclock</code> &#x2014;
+    <span class="Nd">translate a time since boot to wallclock</span></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<p class="Pp"><code class="In">#include
+  &lt;<a class="In">quark.h</a>&gt;</code></p>
+<p class="Pp"><var class="Ft">u64</var>
+  <br/>
+  <code class="Fn">quark_time_to_wallclock</code>(<var class="Fa" style="white-space: nowrap;">u64
+    time_since_boot</var>);</p>
+</section>
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+<code class="Nm">quark_time_to_wallclock</code> translates
+  <var class="Fa">time_since_boot</var> from nanoseconds since boot to
+  nanoseconds since the Unix epoch by adding the internal boottime epoch, see
+  <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>.
+<p class="Pp" id="time">All times handed out by quark are suitable inputs:
+    <a class="permalink" href="#time"><i class="Em">time</i></a> of
+    <var class="Vt">quark_event</var>,
+    <a class="permalink" href="#proc_time_boot"><i class="Em" id="proc_time_boot">proc_time_boot</i></a>
+    and
+    <a class="permalink" href="#exit_time_event"><i class="Em" id="exit_time_event">exit_time_event</i></a>
+    of <var class="Vt">quark_process</var>, as well as
+    <a class="permalink" href="#established_time"><i class="Em" id="established_time">established_time</i></a>
+    and
+    <a class="permalink" href="#close_time"><i class="Em" id="close_time">close_time</i></a>
+    of <var class="Vt">quark_socket</var>. These fields are expressed as
+    nanoseconds since boot since quark 0.8, in earlier versions they were
+    nanoseconds since the Unix epoch and needed no translation.</p>
+<p class="Pp">Times since boot are immune to system clock changes, wallclock
+    times are not. Translate at the last moment, when a time leaves the system
+    for display or storage, and keep the epoch fresh with
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>
+    if the clock may be stepped while running.</p>
+<section class="Sh">
+<h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+<p class="Pp"><var class="Fa">time_since_boot</var> expressed in nanoseconds
+    since the Unix epoch.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>,
+    <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
+    <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
+    <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
+    <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
+    <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>,
+    <a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a>,
+    <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
+    <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>,
+    <a class="Xr" href="quark.7.html">quark(7)</a>,
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<p class="Pp"><code class="Nm">quark_time_to_wallclock</code> appeared in quark
+    0.8, when all times handed out by quark switched from nanoseconds since the
+    Unix epoch to nanoseconds since boot.</p>
+</section>
+</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">August 5, 2026</td>
+    <td class="foot-os">Linux</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/docs/quark_time_to_wallclock.3.html
+++ b/docs/quark_time_to_wallclock.3.html
@@ -51,7 +51,9 @@
     times are not. Translate at the last moment, when a time leaves the system
     for display or storage, and keep the epoch fresh with
     <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>
-    if the clock may be stepped while running.</p>
+    if the clock may be stepped while running. Gradual corrections (slewing)
+    adjust the wallclock and the boot clock at the same rate, leaving the epoch
+    untouched, only a step moves it.</p>
 <p class="Pp" id="flags">The KPROBE backend stamps times with a monotonic clock
     that does not advance during suspend, relayed as
     <code class="Dv">QQ_MONOTONIC</code> on the opened queue's

--- a/docs/quark_time_to_wallclock.3.html
+++ b/docs/quark_time_to_wallclock.3.html
@@ -52,6 +52,17 @@
     for display or storage, and keep the epoch fresh with
     <a class="Xr" href="quark_update_boottime.3.html">quark_update_boottime(3)</a>
     if the clock may be stepped while running.</p>
+<p class="Pp" id="flags">The KPROBE backend stamps times with a monotonic clock
+    that does not advance during suspend, relayed as
+    <code class="Dv">QQ_MONOTONIC</code> on the opened queue's
+    <a class="permalink" href="#flags"><i class="Em">flags</i></a>, see
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>.
+    <code class="Nm">quark_time_to_wallclock</code> applies unchanged, but the
+    result lags the wallclock by the total suspended time, exactly as it did
+    before quark 0.8. Users that care about suspend can detect
+    <code class="Dv">QQ_MONOTONIC</code> and compensate with the difference
+    between <code class="Dv">CLOCK_BOOTTIME</code> and
+    <code class="Dv">CLOCK_MONOTONIC</code>.</p>
 <section class="Sh">
 <h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
@@ -87,7 +98,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 5, 2026</td>
+    <td class="foot-date">August 14, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_update_boottime.3.html
+++ b/docs/quark_update_boottime.3.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
+  <title>QUARK_UPDATE_BOOTTIME(3)</title>
+</head>
+<body>
+<table class="head">
+  <tr>
+    <td class="head-ltitle">QUARK_UPDATE_BOOTTIME(3)</td>
+    <td class="head-vol">Library Functions Manual</td>
+    <td class="head-rtitle">QUARK_UPDATE_BOOTTIME(3)</td>
+  </tr>
+</table>
+<div class="manual-text">
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<p class="Pp"><code class="Nm">quark_update_boottime</code> &#x2014;
+    <span class="Nd">refetch the boottime epoch used for wallclock
+    translation</span></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<p class="Pp"><code class="In">#include
+  &lt;<a class="In">quark.h</a>&gt;</code></p>
+<p class="Pp"><var class="Ft">int</var>
+  <br/>
+  <code class="Fn">quark_update_boottime</code>(<var class="Fa" style="white-space: nowrap;">void</var>);</p>
+</section>
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+All times handed out by quark are expressed in nanoseconds since boot:
+  <a class="permalink" href="#time"><i class="Em" id="time">time</i></a> of
+  <var class="Vt">quark_event</var>,
+  <a class="permalink" href="#proc_time_boot"><i class="Em" id="proc_time_boot">proc_time_boot</i></a>
+  and
+  <a class="permalink" href="#exit_time_event"><i class="Em" id="exit_time_event">exit_time_event</i></a>
+  of <var class="Vt">quark_process</var>, as well as
+  <a class="permalink" href="#established_time"><i class="Em" id="established_time">established_time</i></a>
+  and
+  <a class="permalink" href="#close_time"><i class="Em" id="close_time">close_time</i></a>
+  of <var class="Vt">quark_socket</var>. Translation to wallclock is done at the
+  last moment via
+  <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>,
+  which adds an internal boottime epoch: the wallclock time of boot, fetched
+  from the btime field of <span class="Pa">/proc/stat</span> when the first
+  queue is opened.
+<p class="Pp">btime is derived from the current system clock, so it moves if the
+    clock is stepped, as when NTP corrects a clock that was wrong at boot. Since
+    quark has no event loop, it can not detect a step on its own: the user
+    should call <code class="Nm">quark_update_boottime</code>, which refetches
+    btime, whenever the clock might have changed. As quark never bakes the epoch
+    into the times it stores or hands out, an update also corrects the
+    translation of times acquired before the step.</p>
+<p class="Pp">Two common ways of detecting a step:</p>
+<ul class="Bl-bullet">
+  <li>Poll the delta of <code class="Dv">CLOCK_REALTIME</code> minus
+      <code class="Dv">CLOCK_BOOTTIME</code>: slewing adjusts both clocks at the
+      same rate, so the delta only moves when the clock is stepped.</li>
+  <li>Wait on a <a class="Xr" href="timerfd_create.2.html">timerfd_create(2)</a>
+      descriptor of <code class="Dv">CLOCK_REALTIME</code> armed with
+      <code class="Dv">TFD_TIMER_CANCEL_ON_SET</code>, which becomes readable
+      when the clock is stepped.</li>
+</ul>
+<section class="Sh">
+<h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
+  VALUES</a></h1>
+<p class="Pp">Returns 0 on success, -1 if btime could not be refetched, in which
+    case the previous epoch is retained and <var class="Va">errno</var> is
+  set.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
+  ALSO</a></h1>
+<p class="Pp"><a class="Xr" href="quark_event_dump.3.html">quark_event_dump(3)</a>,
+    <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a>,
+    <a class="Xr" href="quark_process_iter.3.html">quark_process_iter(3)</a>,
+    <a class="Xr" href="quark_process_lookup.3.html">quark_process_lookup(3)</a>,
+    <a class="Xr" href="quark_queue_block.3.html">quark_queue_block(3)</a>,
+    <a class="Xr" href="quark_queue_close.3.html">quark_queue_close(3)</a>,
+    <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>,
+    <a class="Xr" href="quark_queue_get_epollfd.3.html">quark_queue_get_epollfd(3)</a>,
+    <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>,
+    <a class="Xr" href="quark_queue_get_stats.3.html">quark_queue_get_stats(3)</a>,
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>,
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>,
+    <a class="Xr" href="quark.7.html">quark(7)</a>,
+    <a class="Xr" href="quark-btf.8.html">quark-btf(8)</a>,
+    <a class="Xr" href="quark-mon.8.html">quark-mon(8)</a>,
+    <a class="Xr" href="quark-test.8.html">quark-test(8)</a></p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<p class="Pp"><code class="Nm">quark_update_boottime</code> appeared in quark
+    0.8, when all times handed out by quark switched from nanoseconds since the
+    Unix epoch to nanoseconds since boot.</p>
+</section>
+</div>
+<table class="foot">
+  <tr>
+    <td class="foot-date">August 5, 2026</td>
+    <td class="foot-os">Linux</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/docs/quark_update_boottime.3.html
+++ b/docs/quark_update_boottime.3.html
@@ -63,6 +63,13 @@ All times handed out by quark are expressed in nanoseconds since boot:
       <code class="Dv">TFD_TIMER_CANCEL_ON_SET</code>, which becomes readable
       when the clock is stepped.</li>
 </ul>
+<p class="Pp">The boottime epoch is shared by every queue in the process.
+    <code class="Nm">quark_update_boottime</code>,
+    <a class="Xr" href="quark_get_boottime.3.html">quark_get_boottime(3)</a> and
+    <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
+    may be called from any thread without synchronization: the epoch is updated
+    atomically and a concurrent reader observes either the previous or the new
+    value.</p>
 <section class="Sh">
 <h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
@@ -99,7 +106,7 @@ All times handed out by quark are expressed in nanoseconds since boot:
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 5, 2026</td>
+    <td class="foot-date">August 14, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/quark.7
+++ b/quark.7
@@ -379,6 +379,12 @@ No threads are created, the library is driven solely through
 Access to a
 .Vt quark_queue
 must be synchronized by the user in the case of multithreading.
+The boottime epoch is the exception:
+.Xr quark_update_boottime 3 ,
+.Xr quark_get_boottime 3
+and
+.Xr quark_time_to_wallclock 3
+may be called from any thread without synchronization.
 .El
 .Sh BASIC USAGE
 The ball starts with

--- a/quark.7
+++ b/quark.7
@@ -454,6 +454,12 @@ get a descriptor suitable for blocking.
 block for an unspecified amount of time.
 .It Xr quark_queue_get_stats 3
 basic queue statistics.
+.It Xr quark_time_to_wallclock 3
+translate a time since boot to wallclock.
+.It Xr quark_update_boottime 3
+refetch the boottime epoch after a system clock change.
+.It Xr quark_get_boottime 3
+get the boottime epoch.
 .It Xr quark_queue_close 3
 close a queue.
 .El
@@ -469,6 +475,7 @@ is the easiest way to get started with
 describes initialization options that can be useful.
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,
+.Xr quark_get_boottime 3 ,
 .Xr quark_process_iter 3 ,
 .Xr quark_process_lookup 3 ,
 .Xr quark_queue_block 3 ,
@@ -477,6 +484,8 @@ describes initialization options that can be useful.
 .Xr quark_queue_get_event 3 ,
 .Xr quark_queue_get_stats 3 ,
 .Xr quark_queue_open 3 ,
+.Xr quark_time_to_wallclock 3 ,
+.Xr quark_update_boottime 3 ,
 .Xr quark-btf 8 ,
 .Xr quark-mon 8 ,
 .Xr quark-test 8

--- a/quark_get_boottime.3
+++ b/quark_get_boottime.3
@@ -1,0 +1,48 @@
+.Dd $Mdocdate$
+.Dt QUARK_GET_BOOTTIME 3
+.Os
+.Sh NAME
+.Nm quark_get_boottime
+.Nd get the boottime epoch used for wallclock translation
+.Sh SYNOPSIS
+.In quark.h
+.Ft u64
+.Fn quark_get_boottime "void"
+.Sh DESCRIPTION
+.Nm
+returns the internal boottime epoch: the wallclock time of boot in
+nanoseconds since the Unix epoch, as fetched from the btime field of
+.Pa /proc/stat .
+btime has a resolution of one second.
+.Pp
+The epoch is fetched when the first queue is opened and refetched only
+by
+.Xr quark_update_boottime 3 .
+It is what
+.Xr quark_time_to_wallclock 3
+adds to a time since boot, exposed for users that prefer to do the
+translation themselves.
+.Sh RETURN VALUES
+The boottime epoch in nanoseconds since the Unix epoch, zero if a
+queue was never opened.
+.Sh SEE ALSO
+.Xr quark_event_dump 3 ,
+.Xr quark_process_iter 3 ,
+.Xr quark_process_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
+.Xr quark_queue_get_epollfd 3 ,
+.Xr quark_queue_get_event 3 ,
+.Xr quark_queue_get_stats 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark_time_to_wallclock 3 ,
+.Xr quark_update_boottime 3 ,
+.Xr quark 7 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8 ,
+.Xr quark-test 8
+.Sh HISTORY
+.Nm
+appeared in quark 0.8, when all times handed out by quark switched
+from nanoseconds since the Unix epoch to nanoseconds since boot.

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -101,6 +101,9 @@ when its event times are CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which
 only the KPROBE backend does.
 Monotonic times undercount by the total suspended time, users that care
 about suspend must compensate.
+See
+.Xr quark_time_to_wallclock 3
+for the effect on wallclock translation.
 .It Dv QQ_THREAD_EVENTS
 Include per-thread events, instead of per-process events.
 This option will be removed in the future, but it may be useful for debugging.

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -1,0 +1,67 @@
+.Dd $Mdocdate$
+.Dt QUARK_TIME_TO_WALLCLOCK 3
+.Os
+.Sh NAME
+.Nm quark_time_to_wallclock
+.Nd translate a time since boot to wallclock
+.Sh SYNOPSIS
+.In quark.h
+.Ft u64
+.Fn quark_time_to_wallclock "u64 time_since_boot"
+.Sh DESCRIPTION
+.Nm
+translates
+.Fa time_since_boot
+from nanoseconds since boot to nanoseconds since the Unix epoch by
+adding the internal boottime epoch, see
+.Xr quark_get_boottime 3 .
+.Pp
+All times handed out by quark are suitable inputs:
+.Em time
+of
+.Vt quark_event ,
+.Em proc_time_boot
+and
+.Em exit_time_event
+of
+.Vt quark_process ,
+as well as
+.Em established_time
+and
+.Em close_time
+of
+.Vt quark_socket .
+These fields are expressed as nanoseconds since boot since quark 0.8,
+in earlier versions they were nanoseconds since the Unix epoch and
+needed no translation.
+.Pp
+Times since boot are immune to system clock changes, wallclock times
+are not.
+Translate at the last moment, when a time leaves the system for
+display or storage, and keep the epoch fresh with
+.Xr quark_update_boottime 3
+if the clock may be stepped while running.
+.Sh RETURN VALUES
+.Fa time_since_boot
+expressed in nanoseconds since the Unix epoch.
+.Sh SEE ALSO
+.Xr quark_event_dump 3 ,
+.Xr quark_get_boottime 3 ,
+.Xr quark_process_iter 3 ,
+.Xr quark_process_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
+.Xr quark_queue_get_epollfd 3 ,
+.Xr quark_queue_get_event 3 ,
+.Xr quark_queue_get_stats 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark_update_boottime 3 ,
+.Xr quark 7 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8 ,
+.Xr quark-test 8
+.Sh HISTORY
+.Nm
+appeared in quark 0.8, when all times handed out by quark switched
+from nanoseconds since the Unix epoch to nanoseconds since boot.

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -41,6 +41,8 @@ Translate at the last moment, when a time leaves the system for
 display or storage, and keep the epoch fresh with
 .Xr quark_update_boottime 3
 if the clock may be stepped while running.
+Gradual corrections (slewing) adjust the wallclock and the boot clock
+at the same rate, leaving the epoch untouched, only a step moves it.
 .Pp
 The KPROBE backend stamps times with a monotonic clock that does not
 advance during suspend, relayed as

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -41,6 +41,23 @@ Translate at the last moment, when a time leaves the system for
 display or storage, and keep the epoch fresh with
 .Xr quark_update_boottime 3
 if the clock may be stepped while running.
+.Pp
+The KPROBE backend stamps times with a monotonic clock that does not
+advance during suspend, relayed as
+.Dv QQ_MONOTONIC
+on the opened queue's
+.Em flags ,
+see
+.Xr quark_queue_open 3 .
+.Nm
+applies unchanged, but the result lags the wallclock by the total
+suspended time, exactly as it did before quark 0.8.
+Users that care about suspend can detect
+.Dv QQ_MONOTONIC
+and compensate with the difference between
+.Dv CLOCK_BOOTTIME
+and
+.Dv CLOCK_MONOTONIC .
 .Sh RETURN VALUES
 .Fa time_since_boot
 expressed in nanoseconds since the Unix epoch.

--- a/quark_update_boottime.3
+++ b/quark_update_boottime.3
@@ -1,0 +1,87 @@
+.Dd $Mdocdate$
+.Dt QUARK_UPDATE_BOOTTIME 3
+.Os
+.Sh NAME
+.Nm quark_update_boottime
+.Nd refetch the boottime epoch used for wallclock translation
+.Sh SYNOPSIS
+.In quark.h
+.Ft int
+.Fn quark_update_boottime "void"
+.Sh DESCRIPTION
+All times handed out by quark are expressed in nanoseconds since boot:
+.Em time
+of
+.Vt quark_event ,
+.Em proc_time_boot
+and
+.Em exit_time_event
+of
+.Vt quark_process ,
+as well as
+.Em established_time
+and
+.Em close_time
+of
+.Vt quark_socket .
+Translation to wallclock is done at the last moment via
+.Xr quark_time_to_wallclock 3 ,
+which adds an internal boottime epoch: the wallclock time of boot,
+fetched from the btime field of
+.Pa /proc/stat
+when the first queue is opened.
+.Pp
+btime is derived from the current system clock, so it moves if the
+clock is stepped, as when NTP corrects a clock that was wrong at boot.
+Since quark has no event loop, it can not detect a step on its own:
+the user should call
+.Nm ,
+which refetches btime, whenever the clock might have changed.
+As quark never bakes the epoch into the times it stores or hands out,
+an update also corrects the translation of times acquired before the
+step.
+.Pp
+Two common ways of detecting a step:
+.Bl -bullet
+.It
+Poll the delta of
+.Dv CLOCK_REALTIME
+minus
+.Dv CLOCK_BOOTTIME :
+slewing adjusts both clocks at the same rate, so the delta only moves
+when the clock is stepped.
+.It
+Wait on a
+.Xr timerfd_create 2
+descriptor of
+.Dv CLOCK_REALTIME
+armed with
+.Dv TFD_TIMER_CANCEL_ON_SET ,
+which becomes readable when the clock is stepped.
+.El
+.Sh RETURN VALUES
+Returns 0 on success, -1 if btime could not be refetched, in which
+case the previous epoch is retained and
+.Va errno
+is set.
+.Sh SEE ALSO
+.Xr quark_event_dump 3 ,
+.Xr quark_get_boottime 3 ,
+.Xr quark_process_iter 3 ,
+.Xr quark_process_lookup 3 ,
+.Xr quark_queue_block 3 ,
+.Xr quark_queue_close 3 ,
+.Xr quark_queue_default_attr 3 ,
+.Xr quark_queue_get_epollfd 3 ,
+.Xr quark_queue_get_event 3 ,
+.Xr quark_queue_get_stats 3 ,
+.Xr quark_queue_open 3 ,
+.Xr quark_time_to_wallclock 3 ,
+.Xr quark 7 ,
+.Xr quark-btf 8 ,
+.Xr quark-mon 8 ,
+.Xr quark-test 8
+.Sh HISTORY
+.Nm
+appeared in quark 0.8, when all times handed out by quark switched
+from nanoseconds since the Unix epoch to nanoseconds since boot.

--- a/quark_update_boottime.3
+++ b/quark_update_boottime.3
@@ -59,6 +59,15 @@ armed with
 .Dv TFD_TIMER_CANCEL_ON_SET ,
 which becomes readable when the clock is stepped.
 .El
+.Pp
+The boottime epoch is shared by every queue in the process.
+.Nm ,
+.Xr quark_get_boottime 3
+and
+.Xr quark_time_to_wallclock 3
+may be called from any thread without synchronization:
+the epoch is updated atomically and a concurrent reader observes
+either the previous or the new value.
 .Sh RETURN VALUES
 Returns 0 on success, -1 if btime could not be refetched, in which
 case the previous epoch is retained and


### PR DESCRIPTION
Split out of #372; this carries only the documentation.

Manpages for quark_update_boottime(3), quark_get_boottime(3) and quark_time_to_wallclock(3), listed in quark(7), with the HTML docs and README.md regenerated. The pages document which times are expressed since boot, that btime comes from /proc/stat and moves on clock steps, and two common ways of detecting a step (polling the CLOCK_REALTIME - CLOCK_BOOTTIME delta, or a timerfd armed with TFD_TIMER_CANCEL_ON_SET). Each page carries a HISTORY section noting the calls appeared in quark 0.8, when all times handed out by quark switched from epoch to since-boot, so readers on older versions aren't misled.

mandoc -Tlint passes on the new pages.
