### PR TITLE
go: expose the boottime calls

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -144,3 +144,5 @@ Changes from 0.7 to 0.8
     another backend themselves. QQ_ALL_BACKENDS was removed and
     breaks at compile time. quark_queue_default_attr() now selects
     only QQ_EBPF.
+  o The Go bindings (go/quark) learned UpdateBoottime(), Boottime()
+    and TimeToWallclock(), mirroring the C calls.

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -462,6 +462,34 @@ func SetVerbose(level int) {
 	C.quark_verbose = C.int(level)
 }
 
+// UpdateBoottime refetches the boottime epoch used by TimeToWallclock.
+// Call it when the system clock might have been stepped, as when NTP
+// corrects a clock that was wrong at boot.
+func UpdateBoottime() error {
+	ret, err := C.quark_update_boottime()
+	if ret == -1 {
+		return wrapErrno(err)
+	}
+
+	return nil
+}
+
+// Boottime returns the boottime epoch used by TimeToWallclock: the
+// wallclock time of boot in nanoseconds since the Unix epoch, zero
+// before the first queue is opened.
+func Boottime() uint64 {
+	return uint64(C.quark_get_boottime())
+}
+
+// TimeToWallclock translates timeSinceBoot from nanoseconds since boot,
+// as in Proc.TimeBoot, Exit.ExitTimeProcess, Socket.EstablishedTime and
+// Socket.CloseTime, to nanoseconds since the Unix epoch. Times since
+// boot are immune to system clock changes; translate at the last moment
+// and keep the epoch fresh with UpdateBoottime.
+func TimeToWallclock(timeSinceBoot uint64) uint64 {
+	return uint64(C.quark_time_to_wallclock(C.u64(timeSinceBoot)))
+}
+
 // processFromC converts the C process structure to a go process.
 func processFromC(cProcess *C.struct_quark_process) Process {
 	var process Process

--- a/go/quark/quark_test.go
+++ b/go/quark/quark_test.go
@@ -116,3 +116,11 @@ func drainFor(qq *Queue, d time.Duration) ([]Event, error) {
 
 	return allQevs, nil
 }
+
+func TestBoottime(t *testing.T) {
+	require.NoError(t, UpdateBoottime())
+
+	boottime := Boottime()
+	require.NotZero(t, boottime)
+	require.Equal(t, boottime+12345, TimeToWallclock(12345))
+}


### PR DESCRIPTION
Split out of #372; this carries only the Go bindings.

The in-tree Go bindings (go/quark) learn UpdateBoottime(), Boottime() and TimeToWallclock(), mirroring the C calls, plus a non-root test (passes locally; TestQuark still requires root).

Code identical to #372, where go vet and gofmt were clean; re-checked here along with a test-binary link.

Note: the go/quark PRs split out of #372/#386 each append a CHANGES bullet, so whichever merges later needs a trivial rebase.
