### PR TITLE
go: expose passwd and group lookups

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -151,3 +151,6 @@ Changes from 0.7 to 0.8
   o The Go bindings (go/quark) learned QueueAttr.RuleText for
     installing a ruleset on the queue. Processes matched by poison
     rules carry the tag in Process.PoisonTag.
+  o The Go bindings (go/quark) learned PasswdLookup() and
+    GroupLookup(), mirroring quark_passwd_lookup(3) and
+    quark_group_lookup(3).

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -129,6 +129,19 @@ type Process struct {
 	PoisonTag uint64 // Set by matching poison rules, zero if none matched
 }
 
+// Passwd is a cached passwd(5) entry, see PasswdLookup.
+type Passwd struct {
+	Name string
+	Uid  uint32
+	Gid  uint32
+}
+
+// Group is a cached group(5) entry, see GroupLookup.
+type Group struct {
+	Name string
+	Gid  uint32
+}
+
 // Socket represents a connection between two endpoints
 type Socket struct {
 	Local           netip.AddrPort
@@ -493,6 +506,37 @@ func (queue *Queue) Lookup(pid int) (Process, bool) {
 	}
 
 	return processFromC(process), true
+}
+
+// PasswdLookup looks up uid in quark's passwd(5) cache, mirroring
+// quark_passwd_lookup(3). The boolean is false if uid is unknown.
+func (queue *Queue) PasswdLookup(uid uint32) (Passwd, bool) {
+	passwd, _ := C.quark_passwd_lookup(queue.quarkQueue, C.uid_t(uid))
+
+	if passwd == nil {
+		return Passwd{}, false
+	}
+
+	return Passwd{
+		Name: C.GoString(passwd.name),
+		Uid:  uint32(passwd.uid),
+		Gid:  uint32(passwd.gid),
+	}, true
+}
+
+// GroupLookup looks up gid in quark's group(5) cache, mirroring
+// quark_group_lookup(3). The boolean is false if gid is unknown.
+func (queue *Queue) GroupLookup(gid uint32) (Group, bool) {
+	group, _ := C.quark_group_lookup(queue.quarkQueue, C.gid_t(gid))
+
+	if group == nil {
+		return Group{}, false
+	}
+
+	return Group{
+		Name: C.GoString(group.name),
+		Gid:  uint32(group.gid),
+	}, true
 }
 
 // Block blocks until there are events or an undefined timeout

--- a/go/quark/quark_test.go
+++ b/go/quark/quark_test.go
@@ -107,6 +107,29 @@ func TestQuark(t *testing.T) {
 		}
 		require.True(t, foundChild)
 	})
+
+	t.Run("PasswdGroupLookup", func(t *testing.T) {
+		queue, err := OpenQueue(DefaultQueueAttr())
+		require.NoError(t, err)
+
+		defer queue.Close()
+
+		passwd, ok := queue.PasswdLookup(0)
+		require.True(t, ok)
+		require.Equal(t, "root", passwd.Name)
+		require.Zero(t, passwd.Uid)
+		require.Zero(t, passwd.Gid)
+
+		group, ok := queue.GroupLookup(0)
+		require.True(t, ok)
+		require.Equal(t, "root", group.Name)
+		require.Zero(t, group.Gid)
+
+		_, ok = queue.PasswdLookup(4294967290)
+		require.False(t, ok)
+		_, ok = queue.GroupLookup(4294967290)
+		require.False(t, ok)
+	})
 }
 
 // TestRuleText tests ruleset parsing, which happens before any


### PR DESCRIPTION
Split out of #386; this carries only the user/group name lookups.

PasswdLookup() and GroupLookup() mirror quark_passwd_lookup(3) and quark_group_lookup(3). The otel quark receiver currently skips user.name/group.name in its ECS output with a comment noting the binding doesn't exist.

Tests: TestQuark gains PasswdGroupLookup (uid/gid 0 resolve to root, unknown ids miss).

Code identical to #386, where the full Go suite passed as root on real hardware and under krun with an initramfs augmented with glibc and /etc/passwd; gofmt, go vet and a test-binary link re-checked here.

Note: the go/quark PRs split out of #372/#386 each append a CHANGES bullet, so whichever merges later needs a trivial rebase.
