### PR TITLE
go: expose rulesets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -148,3 +148,6 @@ Changes from 0.7 to 0.8
     and TimeToWallclock(), mirroring the C calls.
   o The Go bindings (go/quark) learned the
     QUARK_EV_SOCK_CONN_ESTABLISHED constant.
+  o The Go bindings (go/quark) learned QueueAttr.RuleText for
+    installing a ruleset on the queue. Processes matched by poison
+    rules carry the tag in Process.PoisonTag.

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -9,7 +9,9 @@ package quark
 #cgo CFLAGS: -I${SRCDIR}/../../
 #cgo LDFLAGS: -Wl,--wrap=fmemopen ${SRCDIR}/../../libquark_big.a
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include "quark.h"
 
 #ifdef __x86_64__
@@ -44,6 +46,26 @@ get_event_as_ecs(struct quark_queue *qq, char **ecs_buf, size_t *ecs_buf_len)
 
 	return (0);
 
+}
+
+static int
+ruleset_from_string(struct quark_ruleset *ruleset, const char *s,
+    char *err_buf, size_t err_buf_len)
+{
+	FILE	*in;
+	int	 r;
+
+	if ((in = fmemopen((void *)s, strlen(s), "r")) == NULL) {
+		snprintf(err_buf, err_buf_len, "fmemopen: %s",
+		    strerror(errno));
+		return (-1);
+	}
+
+	r = quark_ruleset_parse(ruleset, in, err_buf, err_buf_len);
+
+	fclose(in);
+
+	return (r);
 }
 */
 import "C"
@@ -96,14 +118,15 @@ type Exit struct {
 
 // Process represents a single process.
 type Process struct {
-	Pid     uint32 // Always present
-	Proc    Proc   // Only meaningful if Proc.Valid (QUARK_F_PROC)
-	Exit    Exit   // Only meaningful if Exit.Valid (QUARK_F_EXIT)
-	Comm    string
-	Exe     string
-	Cmdline []string
-	Cwd     string
-	Cgroup  string
+	Pid       uint32 // Always present
+	Proc      Proc   // Only meaningful if Proc.Valid (QUARK_F_PROC)
+	Exit      Exit   // Only meaningful if Exit.Valid (QUARK_F_EXIT)
+	Comm      string
+	Exe       string
+	Cmdline   []string
+	Cwd       string
+	Cgroup    string
+	PoisonTag uint64 // Set by matching poison rules, zero if none matched
 }
 
 // Socket represents a connection between two endpoints
@@ -197,7 +220,8 @@ type Event struct {
 
 // Queue holds the state of a quark instance.
 type Queue struct {
-	quarkQueue *C.struct_quark_queue // pointer to the queue structure
+	quarkQueue *C.struct_quark_queue   // pointer to the queue structure
+	ruleset    *C.struct_quark_ruleset // active ruleset, nil if none
 	epollFd    int
 }
 
@@ -268,6 +292,10 @@ type QueueAttr struct {
 	MaxLength      int
 	CacheGraceTime int
 	HoldTime       int
+	// RuleText is a ruleset in the rule DSL, parsed and installed on
+	// the queue by OpenQueue. Empty means no rules. Processes matched
+	// by poison rules carry the tag in Process.PoisonTag.
+	RuleText string
 }
 
 // Documented in https://elastic.github.io/quark/quark_queue_get_stats.3.html.
@@ -311,6 +339,38 @@ func DefaultQueueAttr() QueueAttr {
 	}
 }
 
+// rulesetFromText parses text in the rule DSL into a C-allocated
+// ruleset, which the caller owns and must release with freeRuleset.
+func rulesetFromText(text string) (*C.struct_quark_ruleset, error) {
+	p, err := C.calloc(C.size_t(1), C.sizeof_struct_quark_ruleset)
+	if p == nil {
+		return nil, wrapErrno(err)
+	}
+	ruleset := (*C.struct_quark_ruleset)(p)
+
+	ctext := C.CString(text)
+	defer C.free(unsafe.Pointer(ctext))
+	errBuf := make([]byte, 1024)
+
+	if C.ruleset_from_string(ruleset, ctext,
+		(*C.char)(unsafe.Pointer(&errBuf[0])), C.size_t(len(errBuf))) != 0 {
+		freeRuleset(ruleset)
+		errStr := string(errBuf)
+		if nul := bytes.IndexByte(errBuf, 0); nul != -1 {
+			errStr = string(errBuf[:nul])
+		}
+		return nil, fmt.Errorf("can't parse ruleset: %s", errStr)
+	}
+
+	return ruleset, nil
+}
+
+// freeRuleset releases a ruleset allocated by rulesetFromText.
+func freeRuleset(ruleset *C.struct_quark_ruleset) {
+	C.quark_ruleset_clear(ruleset)
+	C.free(unsafe.Pointer(ruleset))
+}
+
 // OpenQueue opens a Quark Queue with the given attributes.
 func OpenQueue(attr QueueAttr) (*Queue, error) {
 	var queue Queue
@@ -318,8 +378,20 @@ func OpenQueue(attr QueueAttr) (*Queue, error) {
 
 	C.quark_queue_default_attr(&cattr)
 
+	if attr.RuleText != "" {
+		ruleset, err := rulesetFromText(attr.RuleText)
+		if err != nil {
+			return nil, err
+		}
+		queue.ruleset = ruleset
+		cattr.ruleset = ruleset
+	}
+
 	p, err := C.calloc(C.size_t(1), C.sizeof_struct_quark_queue)
 	if p == nil {
+		if queue.ruleset != nil {
+			freeRuleset(queue.ruleset)
+		}
 		return nil, wrapErrno(err)
 	}
 	queue.quarkQueue = (*C.struct_quark_queue)(p)
@@ -331,6 +403,9 @@ func OpenQueue(attr QueueAttr) (*Queue, error) {
 	ok, err := C.quark_queue_open(queue.quarkQueue, &cattr)
 	if ok == -1 {
 		C.free(unsafe.Pointer(queue.quarkQueue))
+		if queue.ruleset != nil {
+			freeRuleset(queue.ruleset)
+		}
 		return nil, wrapErrno(err)
 	}
 
@@ -344,6 +419,10 @@ func (queue *Queue) Close() {
 	C.quark_queue_close(queue.quarkQueue)
 	C.free(unsafe.Pointer(queue.quarkQueue))
 	queue.quarkQueue = nil
+	if queue.ruleset != nil {
+		freeRuleset(queue.ruleset)
+		queue.ruleset = nil
+	}
 }
 
 func (queue *Queue) GetEvent() (Event, bool) {
@@ -551,6 +630,7 @@ func processFromC(cProcess *C.struct_quark_process) Process {
 	if cProcess.cgroup != nil {
 		process.Cgroup = C.GoString(cProcess.cgroup)
 	}
+	process.PoisonTag = uint64(cProcess.poison_tag)
 
 	return process
 }

--- a/go/quark/quark_test.go
+++ b/go/quark/quark_test.go
@@ -4,6 +4,7 @@
 package quark
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -67,6 +68,59 @@ func TestQuark(t *testing.T) {
 		attr.Flags |= QQ_KPROBE
 		testStats(t, attr)
 	})
+
+	t.Run("RulePoison", func(t *testing.T) {
+		const poisonTag = 1805
+
+		// Poison our children, pass only poisoned events, drop the
+		// rest, as in t_rule_poison of quark-test.
+		attr := DefaultQueueAttr()
+		attr.HoldTime = 25
+		attr.RuleText = fmt.Sprintf(
+			"poison %d on process.ppid %d\n"+
+				"pass on poison %d\n"+
+				"drop on any",
+			poisonTag, os.Getpid(), poisonTag)
+
+		queue, err := OpenQueue(attr)
+		require.NoError(t, err)
+
+		defer queue.Close()
+
+		// XXX assumes /bin/true exists
+		cmd := exec.Command("/bin/true")
+		err = cmd.Run()
+		require.NoError(t, err)
+
+		qevs, err := drainFor(queue, 200*time.Millisecond)
+		require.NoError(t, err)
+		require.NotEmpty(t, qevs)
+
+		// Everything that survived the ruleset must carry the tag,
+		// and our child must be in there.
+		foundChild := false
+		for _, qev := range qevs {
+			require.Equal(t, uint64(poisonTag), qev.Process.PoisonTag)
+			if qev.Process.Pid == uint32(cmd.Process.Pid) {
+				foundChild = true
+			}
+		}
+		require.True(t, foundChild)
+	})
+}
+
+// TestRuleText tests ruleset parsing, which happens before any
+// privileged operation, so it doesn't require root.
+func TestRuleText(t *testing.T) {
+	ruleset, err := rulesetFromText("drop on any")
+	require.NoError(t, err)
+	require.NotNil(t, ruleset)
+	freeRuleset(ruleset)
+
+	attr := DefaultQueueAttr()
+	attr.RuleText = "this is not a valid rule"
+	_, err = OpenQueue(attr)
+	require.ErrorContains(t, err, "can't parse ruleset")
 }
 
 func testStats(t *testing.T, attr QueueAttr) {


### PR DESCRIPTION
Split out of #386; this carries only the rule DSL exposure.

`QueueAttr.RuleText` installs a ruleset on the queue. It's parsed with `quark_ruleset_parse()` inside `OpenQueue()` — before any privileged operation, so parse errors surface without root — via an fmemopen shim borrowed from quark-test's `ruleset_from_string1()`. The C ruleset is owned by the `Queue` and released on `Close()` (the queue only borrows the pointer). Processes matched by poison rules carry the tag in the new `Process.PoisonTag` (set unconditionally, zero = no match, same semantics as `quark_process.poison_tag`). Until now the DSL — including `file.exec_change` — was unusable from Go.

Tests: `TestRuleText` covers parse success/failure without root; `TestQuark` gains `RulePoison`, a Go port of `t_rule_poison` (poison children by ppid, pass only poisoned, drop the rest — every surviving event must carry the tag). RulePoison uses `/bin/true` rather than `/bin/echo` so it also runs in the initramfs VM.

Code identical to #386, where the full Go suite passed as root on real hardware and under krun; gofmt, go vet and a test-binary link re-checked here.

Note: the go/quark PRs split out of #372/#386 each append a CHANGES bullet, so whichever merges later needs a trivial rebase.
