### PR TITLE
Track perf ring stalls in quark_queue_get_stats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -159,3 +159,7 @@ Changes from 0.7 to 0.8
   o The Go bindings (go/quark) learned Queue.DisableAggregation(),
     which clears every entry in the aggregation matrix. Call it after
     OpenQueue() and before the queue is consumed.
+
+Changes from 0.8 to 0.9
+~~~~~~~~~~~~~~~~~~~~~~~
+  o quark_queue_stats{} got a "stalls" member.

--- a/docs/quark_queue_get_stats.3.html
+++ b/docs/quark_queue_get_stats.3.html
@@ -41,6 +41,8 @@
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	u64	garbage_collections;
+	u64	stalls;
 	int	backend;
 };</pre>
 </div>
@@ -60,7 +62,7 @@
   <dd>The opposite of <i class="Em">aggregations</i>. It is increased by one
       when we didn't aggregate.</dd>
   <dt id="lost"><a class="permalink" href="#lost"><i class="Em">lost</i></a></dt>
-  <dd>A a counter of missed backend events. This can happen if the user didn't
+  <dd>A counter of missed backend events. This can happen if the user didn't
       call
       <a class="Xr" href="quark_queue_get_event.3.html">quark_queue_get_event(3)</a>
       fast enough or if
@@ -68,6 +70,14 @@
       simply can't handle the load, the former is way more likely. It is a state
       counter representing total loss, the user should compare to an old reading
       to know if it increased.</dd>
+  <dt id="garbage_collections"><a class="permalink" href="#garbage_collections"><i class="Em">garbage_collections</i></a></dt>
+  <dd>A counter of cached objects (processes, sockets and pods) that were
+      deleted after expiring their grace time.</dd>
+  <dt id="stalls"><a class="permalink" href="#stalls"><i class="Em">stalls</i></a></dt>
+  <dd>A counter of perf rings that are stalled due to corrupt records. A stalled
+      ring is abandoned and no further events are read from it. Only meaningful
+      on the <code class="Dv">QQ_KPROBE</code> backend, zero on
+      <code class="Dv">QQ_EBPF</code>.</dd>
   <dt id="backend"><a class="permalink" href="#backend"><i class="Em">backend</i></a></dt>
   <dd>Active queue backend, either <code class="Dv">QQ_EBPF</code> or
       <code class="Dv">QQ_KPROBE</code>.</dd>
@@ -90,7 +100,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">December 1, 2024</td>
+    <td class="foot-date">August 26, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -326,6 +326,7 @@ type Stats struct {
 	NonAggregations    uint64
 	Lost               uint64
 	GarbageCollections uint64
+	Stalls             uint64
 	Backend            int
 }
 
@@ -583,6 +584,7 @@ func (queue *Queue) Stats() Stats {
 	stats.NonAggregations = uint64(cStats.non_aggregations)
 	stats.Lost = uint64(cStats.lost)
 	stats.GarbageCollections = uint64(cStats.garbage_collections)
+	stats.Stalls = uint64(cStats.stalls)
 	stats.Backend = int(cStats.backend)
 
 	return stats

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1540,7 +1540,17 @@ kprobe_queue_populate(struct quark_queue *qq)
 static int
 kprobe_queue_update_stats(struct quark_queue *qq)
 {
-	/* NADA */
+	struct kprobe_queue 		*kqq = qq->queue_be;
+	struct perf_group_leader	*pgl;
+	u64				 stalls = 0;
+
+	TAILQ_FOREACH(pgl, &kqq->perf_group_leaders, entry)
+		stalls += pgl->mmap.stalled;
+
+	// A stalled ring remains stalled so we shouldn't be aggregating
+        // stalls across kprobe_queue_update_stats calls.
+	qq->stats.stalls = stalls;
+
 	return (0);
 }
 

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1542,7 +1542,7 @@ kprobe_queue_update_stats(struct quark_queue *qq)
 {
 	struct kprobe_queue 		*kqq = qq->queue_be;
 	struct perf_group_leader	*pgl;
-	u64				stalls = 0;
+	u64				 stalls = 0;
 
 	TAILQ_FOREACH(pgl, &kqq->perf_group_leaders, entry)
 		stalls += pgl->mmap.stalled;

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -1542,13 +1542,13 @@ kprobe_queue_update_stats(struct quark_queue *qq)
 {
 	struct kprobe_queue 		*kqq = qq->queue_be;
 	struct perf_group_leader	*pgl;
-	u64				 stalls = 0;
+	u64				stalls = 0;
 
 	TAILQ_FOREACH(pgl, &kqq->perf_group_leaders, entry)
 		stalls += pgl->mmap.stalled;
 
 	// A stalled ring remains stalled so we shouldn't be aggregating
-        // stalls across kprobe_queue_update_stats calls.
+	// stalls across kprobe_queue_update_stats calls.
 	qq->stats.stalls = stalls;
 
 	return (0);

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -35,13 +35,15 @@ dump_stats(struct quark_queue *qq)
 	    "%14s"
 	    "%14s"
 	    "%14s"
+	    "%14s"
 	    "%14s",
 	    "insertions",
 	    "removals",
 	    "aggs",
 	    "non-aggs",
 	    "lost",
-	    "gc-cols"
+	    "gc-cols",
+	    "stalls"
 	);
 	fputc('\n', stderr);
 	fprintf(stderr,
@@ -50,9 +52,10 @@ dump_stats(struct quark_queue *qq)
 	    "%14llu"
 	    "%14llu"
 	    "%14llu"
+	    "%14llu"
 	    "%14llu",
 	    s.insertions, s.removals, s.aggregations,
-	    s.non_aggregations, s.lost, s.garbage_collections);
+	    s.non_aggregations, s.lost, s.garbage_collections, s.stalls);
 	fputc('\n', stderr);
 }
 

--- a/quark.h
+++ b/quark.h
@@ -866,8 +866,9 @@ struct quark_queue_stats {
 	u64	non_aggregations;
 	u64	lost;
 	u64	garbage_collections;
-	int	backend;	/* active backend, QQ_EBPF or QQ_KPROBE */
-	/* TODO u64	peak_nodes; */
+	int	backend;    /* active backend, QQ_EBPF or QQ_KPROBE */
+	u64	stalls;     /* stalled perf rings due to corruption */
+	/* TODO u64    peak_nodes; */
 };
 
 struct quark_queue_ops {

--- a/quark.h
+++ b/quark.h
@@ -866,8 +866,8 @@ struct quark_queue_stats {
 	u64	non_aggregations;
 	u64	lost;
 	u64	garbage_collections;
+	u64	stalls;     /* stalled perf rings due to corruption, only for QQ_KPROBE */
 	int	backend;    /* active backend, QQ_EBPF or QQ_KPROBE */
-	u64	stalls;     /* stalled perf rings due to corruption */
 	/* TODO u64    peak_nodes; */
 };
 

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -23,6 +23,8 @@ struct quark_queue_stats {
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	u64	garbage_collections;
+	u64	stalls;
 	int	backend;
 };
 .Ed
@@ -51,6 +53,16 @@ fast enough or if
 simply can't handle the load, the former is way more likely.
 It is a state counter representing total loss, the user should compare to an old
 reading to know if it increased.
+.It Em garbage_collections
+A counter of cached objects (processes, sockets and pods) that were
+deleted after expiring their grace time.
+.It Em stalls
+A counter of perf rings that are stalled due to corrupt records.
+A stalled ring is abandoned and no further events are read from it.
+Only meaningful on the
+.Dv QQ_KPROBE
+backend, zero on
+.Dv QQ_EBPF .
 .It Em backend
 Active queue backend, either
 .Dv QQ_EBPF

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -43,7 +43,7 @@ The opposite of
 .Em aggregations .
 It is increased by one when we didn't aggregate.
 .It Em lost
-A a counter of missed backend events.
+A counter of missed backend events.
 This can happen if the user didn't call
 .Xr quark_queue_get_event 3
 fast enough or if


### PR DESCRIPTION
### Summary

Adds a counter for perf rings that are stalled due to corruption.

**TODO:**
- [x] Update manpage and html

Also see:
- #385
- https://github.com/elastic/quark/pull/385#issuecomment-5429783796