### PR TITLE
Collect executable mprotect attempts at LSM hook

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -394,7 +394,7 @@ steps:
 
   - label: "quark-test on rhel 9.3 (memfd+shmget broken)"
     key: test_rhel_9_3
-    command: "./.buildkite/runtest_distro.sh rhel 9.3 -x t_memfd -x t_shmget -x t_mprotect"
+    command: "./.buildkite/runtest_distro.sh rhel 9.3 -x t_memfd -x t_shmget"
     depends_on:
       - make_docker
     agents:

--- a/CHANGES
+++ b/CHANGES
@@ -97,6 +97,9 @@ Changes from 0.5 to 0.6
 Changes from 0.6 to 0.7
 ~~~~~~~~~~~~~~~~~~~~~~~
   o BPF_CC is gone, just use CLANG='zig cc' now.
-  o Added mprotect() syscall events (QUARK_EV_MPROTECT, -u on quark-mon).
-    The eBPF probe emits successful calls requesting execute permission
-    (X, RX, WX, or RWX); non-executable masks and failed calls are suppressed.
+  o Added executable mprotect() attempt events (QUARK_EV_MPROTECT, -u on
+    quark-mon). The eBPF probe reports each VMA that reaches the
+    security_file_mprotect() check with effective execute permission, including
+    previous/requested/effective protection and backing-file identity. These
+    events cover mprotect(), pkey_mprotect(), and compat callers, but do not
+    assert that the protection change ultimately succeeded.

--- a/CHANGES
+++ b/CHANGES
@@ -103,3 +103,5 @@ Changes from 0.6 to 0.7
     previous/requested/effective protection and backing-file identity. These
     events cover mprotect(), pkey_mprotect(), and compat callers, but do not
     assert that the protection change ultimately succeeded.
+  o quark_queue_stats{} and quark-mon -M report temporary executable mprotect
+    volume measurements when QQ_MPROTECT is enabled.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1430,11 +1430,12 @@ bpf_queue_populate(struct quark_queue *qq)
 static int
 bpf_queue_update_stats(struct quark_queue *qq)
 {
-	struct bpf_queue	*bqq  = qq->queue_be;
-	struct ebpf_event_stats	*pcpu_ees;
-	u32			 zero = 0;
-	u64			 lost;
-	int			 i, num_cpus;
+	struct bpf_queue			*bqq  = qq->queue_be;
+	struct ebpf_event_stats		*pcpu_ees = NULL;
+	struct ebpf_mprotect_stats	*pcpu_mps = NULL;
+	u32				 zero = 0;
+	u64				 lost;
+	int				 i, num_cpus;
 
 	if ((num_cpus = libbpf_num_possible_cpus()) <= 0) {
 		qwarnx("bad libbpf_num_possible_cpus: %d", num_cpus);
@@ -1460,11 +1461,46 @@ bpf_queue_update_stats(struct quark_queue *qq)
 		lost += pcpu_ees[i].lost;
 	qq->stats.lost = lost;
 	free(pcpu_ees);
+	pcpu_ees = NULL;
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return (0);
+
+	if ((pcpu_mps = calloc(num_cpus, sizeof(*pcpu_mps))) == NULL) {
+		qwarn("calloc");
+		goto fail;
+	}
+
+#ifdef HAVE_STATIC_ASSERT
+	static_assert(sizeof(*pcpu_mps) % 8 == 0,
+	    "struct ebpf_mprotect_stats must be 8 byte aligned");
+#endif
+
+	if (bpf_map__lookup_elem(bqq->probes->maps.mprotect_stats, &zero,
+	    sizeof(zero), pcpu_mps, sizeof(*pcpu_mps) * num_cpus, 0) != 0) {
+		qwarn("bpf_map__lookup_elem");
+		goto fail;
+	}
+
+	bzero(&qq->stats.mprotect, sizeof(qq->stats.mprotect));
+	for (i = 0; i < num_cpus; i++) {
+		qq->stats.mprotect.hook_calls += pcpu_mps[i].hook_calls;
+		qq->stats.mprotect.effective_exec += pcpu_mps[i].effective_exec;
+		qq->stats.mprotect.new_exec += pcpu_mps[i].new_exec;
+		qq->stats.mprotect.already_exec += pcpu_mps[i].already_exec;
+		qq->stats.mprotect.writable_exec += pcpu_mps[i].writable_exec;
+		qq->stats.mprotect.anonymous += pcpu_mps[i].anonymous;
+		qq->stats.mprotect.file_backed += pcpu_mps[i].file_backed;
+		qq->stats.mprotect.submitted += pcpu_mps[i].submitted;
+		qq->stats.mprotect.reserve_failed += pcpu_mps[i].reserve_failed;
+	}
+	free(pcpu_mps);
 
 	return (0);
 
 fail:
 	free(pcpu_ees);
+	free(pcpu_mps);
 
 	return (-1);
 }

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -621,9 +621,15 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		raw->time = ev->ts;
 
 		qmprotect = &raw->mprotect.quark_mprotect;
-		qmprotect->addr = mprotect->addr;
-		qmprotect->len = mprotect->len;
-		qmprotect->prot = mprotect->prot;
+		qmprotect->vma_start = mprotect->vma_start;
+		qmprotect->vma_end = mprotect->vma_end;
+		qmprotect->prev_prot = mprotect->prev_prot;
+		qmprotect->req_prot = mprotect->req_prot;
+		qmprotect->effective_prot = mprotect->effective_prot;
+		qmprotect->inode = mprotect->inode;
+		qmprotect->dev_major = mprotect->dev_major;
+		qmprotect->dev_minor = mprotect->dev_minor;
+		qmprotect->file_backed = mprotect->file_backed;
 
 		break;
 	}
@@ -1292,8 +1298,12 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		bpf_program__set_autoload(p->progs.module_load, 1);
 
 	if (qq->flags & QQ_MPROTECT) {
-		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_enter_mprotect, 1);
-		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_mprotect, 1);
+		if (use_fentry)
+			bpf_program__set_autoload(
+			    p->progs.fentry__security_file_mprotect, 1);
+		else
+			bpf_program__set_autoload(
+			    p->progs.kprobe__security_file_mprotect, 1);
 	}
 
 	if (qq->flags & QQ_GETPID)

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -462,4 +462,17 @@ struct ebpf_event_stats {
     uint64_t dns_zero_body; // indicates that the dns body of a sk_buff was unavailable
 } __attribute__((aligned(8)));
 
+// Temporary executable mprotect volume measurements.
+struct ebpf_mprotect_stats {
+    uint64_t hook_calls;
+    uint64_t effective_exec;
+    uint64_t new_exec;
+    uint64_t already_exec;
+    uint64_t writable_exec;
+    uint64_t anonymous;
+    uint64_t file_backed;
+    uint64_t submitted;
+    uint64_t reserve_failed;
+} __attribute__((aligned(8)));
+
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -384,9 +384,15 @@ struct ebpf_process_load_module_event {
 struct ebpf_process_mprotect_event {
     struct ebpf_event_header hdr;
     struct ebpf_pid_info pids;
-    uint64_t addr;
-    uint64_t len;
-    uint64_t prot;
+    uint64_t vma_start;
+    uint64_t vma_end;
+    uint64_t prev_prot;
+    uint64_t req_prot;
+    uint64_t effective_prot;
+    uint64_t inode;
+    uint32_t dev_major;
+    uint32_t dev_minor;
+    uint32_t file_backed;
 } __attribute__((packed));
 
 enum ebpf_net_info_transport {

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -24,7 +24,17 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 
 #define S_ISUID 0004000
 #define S_ISGID 0002000
-#define PROT_EXEC 0x4
+
+#define MPROTECT_PROT_READ  0x1
+#define MPROTECT_PROT_WRITE 0x2
+#define MPROTECT_PROT_EXEC  0x4
+
+#define MPROTECT_VM_READ  (1UL << 0)
+#define MPROTECT_VM_WRITE (1UL << 1)
+#define MPROTECT_VM_EXEC  (1UL << 2)
+
+#define MPROTECT_MINORBITS 20
+#define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
 
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
@@ -451,68 +461,44 @@ int BPF_KPROBE(kprobe__arch_ptrace,
     return r;
 }
 
-SEC("tracepoint/syscalls/sys_enter_mprotect")
-int tracepoint_syscalls_sys_enter_mprotect(struct syscall_trace_enter *ctx)
+static u64 mprotect_vm_flags_to_prot(unsigned long vm_flags)
 {
-    preempt_disable();
-    if (ebpf_events_is_trusted_pid())
-        goto out;
+    u64 prot = 0;
 
-    struct mprotect_args {
-        short common_type;
-        char common_flags;
-        char common_preempt_count;
-        int common_pid;
-        int __syscall_nr;
-        unsigned long start;
-        size_t len;
-        unsigned long prot;
-    };
-    struct mprotect_args *ex_args    = (struct mprotect_args *)ctx;
-    const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    if (vm_flags & MPROTECT_VM_READ)
+        prot |= MPROTECT_PROT_READ;
+    if (vm_flags & MPROTECT_VM_WRITE)
+        prot |= MPROTECT_PROT_WRITE;
+    if (vm_flags & MPROTECT_VM_EXEC)
+        prot |= MPROTECT_PROT_EXEC;
 
-    if (is_kernel_thread(task))
-        goto out;
-
-    if (!(ex_args->prot & PROT_EXEC))
-        goto out;
-
-    struct ebpf_events_state state = {};
-    state.mprotect.addr = ex_args->start;
-    state.mprotect.len  = ex_args->len;
-    state.mprotect.prot = ex_args->prot;
-    ebpf_events_state__set(EBPF_EVENTS_STATE_MPROTECT, &state);
-
-out:
-    preempt_enable();
-    return 0;
+    return prot;
 }
 
-SEC("tracepoint/syscalls/sys_exit_mprotect")
-int tracepoint_syscalls_sys_exit_mprotect(struct syscall_trace_exit *args)
+/*
+ * security_file_mprotect() is called once for every VMA considered by
+ * mprotect(2) and pkey_mprotect(2), after personality handling has produced
+ * the effective protection and before the protection change is committed.
+ * Consequently this event describes an executable-memory attempt, not a
+ * successful syscall or an exact modified subrange.
+ */
+static int security_file_mprotect__enter(struct vm_area_struct *vma,
+                                         unsigned long req_prot,
+                                         unsigned long effective_prot)
 {
-    preempt_disable();
-
-    struct ebpf_events_state *state = ebpf_events_state__get(EBPF_EVENTS_STATE_MPROTECT);
-    if (!state)
-        goto out;
-
-    u64 addr = state->mprotect.addr;
-    u64 len  = state->mprotect.len;
-    u64 prot = state->mprotect.prot;
-    ebpf_events_state__del(EBPF_EVENTS_STATE_MPROTECT);
-
-    if (BPF_CORE_READ(args, ret) != 0)
-        goto out;
-
-    if (ebpf_events_is_trusted_pid())
+    if (ebpf_events_is_trusted_pid() || !vma)
         goto out;
 
     const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     if (is_kernel_thread(task))
         goto out;
 
-    struct ebpf_process_mprotect_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    // Filter on the kernel-adjusted protection so READ_IMPLIES_EXEC is seen.
+    if (!(effective_prot & MPROTECT_PROT_EXEC))
+        goto out;
+
+    struct ebpf_process_mprotect_event *event =
+        bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
     if (!event)
         goto out;
 
@@ -520,14 +506,68 @@ int tracepoint_syscalls_sys_exit_mprotect(struct syscall_trace_exit *args)
     event->hdr.ts   = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
 
-    event->addr = addr;
-    event->len  = len;
-    event->prot = prot;
+    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
+    event->vma_start       = BPF_CORE_READ(vma, vm_start);
+    event->vma_end         = BPF_CORE_READ(vma, vm_end);
+    event->prev_prot       = mprotect_vm_flags_to_prot(vm_flags);
+    event->req_prot        = req_prot;
+    event->effective_prot  = effective_prot;
+    event->file_backed     = 0;
+    event->inode           = 0;
+    event->dev_major       = 0;
+    event->dev_minor       = 0;
+
+    struct file *file = BPF_CORE_READ(vma, vm_file);
+    if (file) {
+        event->file_backed = 1;
+
+        struct inode *inode = BPF_CORE_READ(file, f_inode);
+        if (inode) {
+            event->inode = BPF_CORE_READ(inode, i_ino);
+
+            struct super_block *sb = BPF_CORE_READ(inode, i_sb);
+            if (sb) {
+                dev_t dev       = BPF_CORE_READ(sb, s_dev);
+                event->dev_major = (u32)dev >> MPROTECT_MINORBITS;
+                event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
+            }
+        }
+    }
 
     bpf_ringbuf_submit(event, 0);
+
 out:
-    preempt_enable();
     return 0;
+}
+
+SEC("fentry/security_file_mprotect")
+int BPF_PROG(fentry__security_file_mprotect,
+             struct vm_area_struct *vma,
+             unsigned long req_prot,
+             unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/security_file_mprotect")
+int BPF_KPROBE(kprobe__security_file_mprotect,
+               struct vm_area_struct *vma,
+               unsigned long req_prot,
+               unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
+    preempt_enable();
+
+    return r;
 }
 
 SEC("tracepoint/syscalls/sys_enter_shmget")

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -36,6 +36,13 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define MPROTECT_MINORBITS 20
 #define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
 
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, struct ebpf_mprotect_stats);
+    __uint(max_entries, 1);
+} mprotect_stats SEC(".maps");
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -486,6 +493,11 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
                                          unsigned long req_prot,
                                          unsigned long effective_prot)
 {
+    u32 zero = 0;
+    struct ebpf_mprotect_stats *stats = bpf_map_lookup_elem(&mprotect_stats, &zero);
+    if (stats)
+        stats->hook_calls++;
+
     if (ebpf_events_is_trusted_pid() || !vma)
         goto out;
 
@@ -497,19 +509,39 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     if (!(effective_prot & MPROTECT_PROT_EXEC))
         goto out;
 
+    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
+    u64 prev_prot          = mprotect_vm_flags_to_prot(vm_flags);
+    struct file *file      = BPF_CORE_READ(vma, vm_file);
+
+    if (stats) {
+        stats->effective_exec++;
+        if (prev_prot & MPROTECT_PROT_EXEC)
+            stats->already_exec++;
+        else
+            stats->new_exec++;
+        if (effective_prot & MPROTECT_PROT_WRITE)
+            stats->writable_exec++;
+        if (file)
+            stats->file_backed++;
+        else
+            stats->anonymous++;
+    }
+
     struct ebpf_process_mprotect_event *event =
         bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
+    if (!event) {
+        if (stats)
+            stats->reserve_failed++;
         goto out;
+    }
 
     event->hdr.type = EBPF_EVENT_PROCESS_MPROTECT;
     event->hdr.ts   = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
 
-    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
     event->vma_start       = BPF_CORE_READ(vma, vm_start);
     event->vma_end         = BPF_CORE_READ(vma, vm_end);
-    event->prev_prot       = mprotect_vm_flags_to_prot(vm_flags);
+    event->prev_prot       = prev_prot;
     event->req_prot        = req_prot;
     event->effective_prot  = effective_prot;
     event->file_backed     = 0;
@@ -517,7 +549,6 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     event->dev_major       = 0;
     event->dev_minor       = 0;
 
-    struct file *file = BPF_CORE_READ(vma, vm_file);
     if (file) {
         event->file_backed = 1;
 
@@ -535,6 +566,8 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     }
 
     bpf_ringbuf_submit(event, 0);
+    if (stats)
+        stats->submitted++;
 
 out:
     return 0;

--- a/elastic-ebpf/GPL/Events/State.h
+++ b/elastic-ebpf/GPL/Events/State.h
@@ -23,7 +23,6 @@ enum ebpf_events_state_op {
     EBPF_EVENTS_STATE_CHOWN          = 9,
     EBPF_EVENTS_STATE_FS_CREATE      = 10,
     EBPF_EVENTS_STATE_MEMFD_CREATE   = 11,
-    EBPF_EVENTS_STATE_MPROTECT       = 12,
 };
 
 struct ebpf_events_key {
@@ -87,12 +86,6 @@ struct ebpf_events_memfd_create_state {
     unsigned int flags;
 };
 
-struct ebpf_events_mprotect_state {
-    u64 addr;
-    u64 len;
-    u64 prot;
-};
-
 struct ebpf_events_state {
     union {
         struct ebpf_events_unlink_state unlink;
@@ -105,7 +98,6 @@ struct ebpf_events_state {
         struct ebpf_events_writev_state writev;
         struct ebpf_events_chown_state chown;
         struct ebpf_events_memfd_create_state memfd;
-        struct ebpf_events_mprotect_state mprotect;
         /* struct ebpf_events_fs_create fs_create; nada */
     };
 };

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -296,6 +296,20 @@ type Stats struct {
 	Lost               uint64
 	GarbageCollections uint64
 	Backend            int
+	Mprotect           MprotectStats
+}
+
+// MprotectStats contains cumulative executable mprotect volume measurements.
+type MprotectStats struct {
+	HookCalls     uint64
+	EffectiveExec uint64
+	NewExec       uint64
+	AlreadyExec   uint64
+	WritableExec  uint64
+	Anonymous     uint64
+	FileBacked    uint64
+	Submitted     uint64
+	ReserveFailed uint64
 }
 
 const (
@@ -475,6 +489,15 @@ func (queue *Queue) Stats() Stats {
 	stats.Lost = uint64(cStats.lost)
 	stats.GarbageCollections = uint64(cStats.garbage_collections)
 	stats.Backend = int(cStats.backend)
+	stats.Mprotect.HookCalls = uint64(cStats.mprotect.hook_calls)
+	stats.Mprotect.EffectiveExec = uint64(cStats.mprotect.effective_exec)
+	stats.Mprotect.NewExec = uint64(cStats.mprotect.new_exec)
+	stats.Mprotect.AlreadyExec = uint64(cStats.mprotect.already_exec)
+	stats.Mprotect.WritableExec = uint64(cStats.mprotect.writable_exec)
+	stats.Mprotect.Anonymous = uint64(cStats.mprotect.anonymous)
+	stats.Mprotect.FileBacked = uint64(cStats.mprotect.file_backed)
+	stats.Mprotect.Submitted = uint64(cStats.mprotect.submitted)
+	stats.Mprotect.ReserveFailed = uint64(cStats.mprotect.reserve_failed)
 
 	return stats
 }

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -146,6 +146,20 @@ type Ptrace struct {
 	Data     uint64
 }
 
+// Mprotect describes an executable protection attempt observed for one VMA.
+// The LSM check happens before the kernel commits the protection change.
+type Mprotect struct {
+	VmaStart      uint64
+	VmaEnd        uint64
+	PrevProt      uint64
+	ReqProt       uint64
+	EffectiveProt uint64
+	Inode         uint64
+	DevMajor      uint32
+	DevMinor      uint32
+	FileBacked    bool
+}
+
 type ModuleLoad struct {
 	Name       string
 	Version    string
@@ -190,6 +204,7 @@ type Event struct {
 	Packet     *Packet
 	File       *File
 	Ptrace     *Ptrace
+	Mprotect   *Mprotect
 	ModuleLoad *ModuleLoad
 	Shm        *any // ShmGet, MemFd or ShmOpen
 	Tty        *Tty
@@ -216,6 +231,7 @@ const (
 	QQ_TTY           = int(C.QQ_TTY)
 	QQ_PTRACE        = int(C.QQ_PTRACE)
 	QQ_MODULE_LOAD   = int(C.QQ_MODULE_LOAD)
+	QQ_MPROTECT      = int(C.QQ_MPROTECT)
 	QQ_ALL_BACKENDS  = int(C.QQ_ALL_BACKENDS)
 
 	// Event.events
@@ -231,6 +247,7 @@ const (
 	QUARK_EV_MODULE_LOAD      = uint64(C.QUARK_EV_MODULE_LOAD)
 	QUARK_EV_SHM              = uint64(C.QUARK_EV_SHM)
 	QUARK_EV_TTY              = uint64(C.QUARK_EV_TTY)
+	QUARK_EV_MPROTECT         = uint64(C.QUARK_EV_MPROTECT)
 
 	// EntryLeaderType
 	QUARK_ELT_UNKNOWN   = int(C.QUARK_ELT_UNKNOWN)
@@ -367,6 +384,10 @@ func (queue *Queue) GetEvent() (Event, bool) {
 	if event.Events&QUARK_EV_PTRACE != 0 {
 		ptrace := ptraceFromC(&cev.ptrace)
 		event.Ptrace = &ptrace
+	}
+	if event.Events&QUARK_EV_MPROTECT != 0 {
+		mprotect := mprotectFromC(&cev.mprotect)
+		event.Mprotect = &mprotect
 	}
 	if cev.module_load != nil {
 		ml := moduleLoadFromC(cev.module_load)
@@ -600,6 +621,22 @@ func ptraceFromC(cPtrace *C.struct_quark_ptrace) Ptrace {
 	ptrace.Data = uint64(cPtrace.data)
 
 	return ptrace
+}
+
+func mprotectFromC(cMprotect *C.struct_quark_mprotect) Mprotect {
+	var mprotect Mprotect
+
+	mprotect.VmaStart = uint64(cMprotect.vma_start)
+	mprotect.VmaEnd = uint64(cMprotect.vma_end)
+	mprotect.PrevProt = uint64(cMprotect.prev_prot)
+	mprotect.ReqProt = uint64(cMprotect.req_prot)
+	mprotect.EffectiveProt = uint64(cMprotect.effective_prot)
+	mprotect.Inode = uint64(cMprotect.inode)
+	mprotect.DevMajor = uint32(cMprotect.dev_major)
+	mprotect.DevMinor = uint32(cMprotect.dev_minor)
+	mprotect.FileBacked = cMprotect.file_backed != 0
+
+	return mprotect
 }
 
 func moduleLoadFromC(cM *C.struct_quark_module_load) ModuleLoad {

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -108,6 +108,10 @@ has been reached.
 This is used purely for internal debugging.
 .It Fl M
 Run in a simple benchmark form that only counts and display stats.
+When executable mprotect events are enabled with
+.Fl u ,
+also display cumulative hook, protection-category, submission, and ring-buffer
+reservation-failure counters.
 .It Fl N
 Enable DNS events (experimental).
 .It Fl n

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -131,7 +131,11 @@ Enable ptrace event tracing.
 Don't supress thread events, this is only useful for debugging and will likely
 be zapped in the future.
 .It Fl u
-Enable mprotect events.
+Enable executable mprotect attempt events (EBPF only).
+One event is emitted for every VMA that reaches the
+.Fn security_file_mprotect
+check with effective execute permission.
+The event does not assert that the protection change ultimately succeeded.
 .It Fl v
 Increase verbosity, can be specified multiple times for more verbosity.
 .It Fl V

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -54,6 +54,50 @@ dump_stats(struct quark_queue *qq)
 	    s.insertions, s.removals, s.aggregations,
 	    s.non_aggregations, s.lost, s.garbage_collections);
 	fputc('\n', stderr);
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return;
+
+	fprintf(stderr,
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s"
+	    "%14s",
+	    "mpro-hooks",
+	    "mpro-exec",
+	    "mpro-new-x",
+	    "mpro-old-x",
+	    "mpro-wx",
+	    "mpro-anon",
+	    "mpro-file",
+	    "mpro-sent",
+	    "mpro-rsvfail");
+	fputc('\n', stderr);
+	fprintf(stderr,
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu"
+	    "%14llu",
+	    s.mprotect.hook_calls,
+	    s.mprotect.effective_exec,
+	    s.mprotect.new_exec,
+	    s.mprotect.already_exec,
+	    s.mprotect.writable_exec,
+	    s.mprotect.anonymous,
+	    s.mprotect.file_backed,
+	    s.mprotect.submitted,
+	    s.mprotect.reserve_failed);
+	fputc('\n', stderr);
 }
 
 static const char *

--- a/quark-test.c
+++ b/quark-test.c
@@ -10,6 +10,8 @@
 #include <sys/shm.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -1383,8 +1385,10 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	const struct quark_event	*qev;
 	const struct quark_mprotect	*qmprotect;
 	void				*addr[4];
+	void				*file_addr;
 	void				*suppressed_addr;
 	const size_t			 len = 4096;
+	struct stat			 st;
 	const int			 expected[] = {
 		PROT_EXEC,
 		PROT_READ | PROT_EXEC,
@@ -1397,6 +1401,7 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 		PROT_WRITE,
 		PROT_READ | PROT_WRITE,
 	};
+	int				 fd;
 	int				 saw[nitems(expected)] = { 0 };
 	size_t				 i, j;
 	int				 seen = 0;
@@ -1411,13 +1416,13 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	if (suppressed_addr == MAP_FAILED)
 		err(1, "mmap");
 
-	/* Non-executable protections must not enter the ring buffer. */
+	/* Non-executable effective protections must not enter the ring buffer. */
 	for (i = 0; i < nitems(suppressed); i++) {
 		if (mprotect(suppressed_addr, len, suppressed[i]) == -1)
 			err(1, "mprotect");
 	}
 
-	/* Failed executable requests must not enter the ring buffer. */
+	/* Requests rejected before the LSM hook must not enter the ring buffer. */
 	if (mprotect((void *)(uintptr_t)1, len, PROT_EXEC) != -1)
 		errx(1, "unaligned mprotect unexpectedly succeeded");
 
@@ -1436,15 +1441,20 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 			continue;
 		qmprotect = &qev->mprotect;
 		for (i = 0; i < nitems(expected); i++) {
-			if (qmprotect->prot == (u64)expected[i] &&
-			    qmprotect->addr == (u64)(uintptr_t)addr[i])
+			if (qmprotect->req_prot == (u64)expected[i] &&
+			    qmprotect->vma_start <= (u64)(uintptr_t)addr[i] &&
+			    qmprotect->vma_end >=
+			    (u64)(uintptr_t)addr[i] + len)
 				break;
 		}
 		if (i == nitems(expected)) {
-			errx(1, "unexpected mprotect prot 0x%llx",
-			    (unsigned long long)qmprotect->prot);
+			errx(1, "unexpected mprotect attempt req_prot 0x%llx",
+			    (unsigned long long)qmprotect->req_prot);
 		}
-		assert(qmprotect->len == len);
+		assert(qmprotect->prev_prot == (PROT_READ | PROT_WRITE));
+		assert(qmprotect->effective_prot == (u64)expected[i]);
+		assert(!qmprotect->file_backed);
+		assert(qmprotect->inode == 0);
 		assert(!saw[i]);
 		saw[i] = 1;
 		seen++;
@@ -1453,12 +1463,71 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	for (i = 0; i < nitems(saw); i++)
 		assert(saw[i]);
 
+	/* File-backed identity is carried without resolving a pathname in BPF. */
+	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
+		err(1, "open");
+	if (fstat(fd, &st) == -1)
+		err(1, "fstat");
+	file_addr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (file_addr == MAP_FAILED)
+		err(1, "mmap");
+	if (mprotect(file_addr, len, PROT_READ | PROT_EXEC) == -1)
+		err(1, "mprotect");
+	do {
+		qev = drain_for_pid(&qq, getpid());
+	} while (!(qev->events & QUARK_EV_MPROTECT));
+	qmprotect = &qev->mprotect;
+	assert(qmprotect->vma_start <= (u64)(uintptr_t)file_addr);
+	assert(qmprotect->vma_end >= (u64)(uintptr_t)file_addr + len);
+	assert(qmprotect->prev_prot == PROT_READ);
+	assert(qmprotect->req_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->effective_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->file_backed);
+	assert(qmprotect->inode == (u64)st.st_ino);
+	assert(qmprotect->dev_major == (u32)major(st.st_dev));
+	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+
+#ifdef SYS_pkey_mprotect
+	/* The common LSM hook also observes pkey_mprotect without another probe. */
+	{
+		void *pkey_addr;
+
+		pkey_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (pkey_addr == MAP_FAILED)
+			err(1, "mmap");
+		if (syscall(SYS_pkey_mprotect, pkey_addr, len, PROT_EXEC, -1) == -1) {
+			if (errno != ENOSYS && errno != EINVAL)
+				err(1, "pkey_mprotect");
+		} else {
+			do {
+				qev = drain_for_pid(&qq, getpid());
+			} while (!(qev->events & QUARK_EV_MPROTECT));
+			qmprotect = &qev->mprotect;
+			assert(qmprotect->vma_start <= (u64)(uintptr_t)pkey_addr);
+			assert(qmprotect->vma_end >=
+			    (u64)(uintptr_t)pkey_addr + len);
+			assert(qmprotect->prev_prot ==
+			    (PROT_READ | PROT_WRITE));
+			assert(qmprotect->req_prot == PROT_EXEC);
+			assert(qmprotect->effective_prot == PROT_EXEC);
+			assert(!qmprotect->file_backed);
+		}
+		if (munmap(pkey_addr, len) == -1)
+			err(1, "munmap");
+	}
+#endif
+
 	if (munmap(suppressed_addr, len) == -1)
 		err(1, "munmap");
 	for (j = 0; j < nitems(addr); j++) {
 		if (munmap(addr[j], len) == -1)
 			err(1, "munmap");
 	}
+	if (munmap(file_addr, len) == -1)
+		err(1, "munmap");
+	if (close(fd) == -1)
+		err(1, "close");
 
 	quark_queue_close(&qq);
 

--- a/quark.c
+++ b/quark.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -2080,15 +2081,15 @@ mprotect_prot_str(u64 prot, char *buf, size_t len)
 
 	*buf = 0;
 	n = 0;
-	if (prot & 0x1) {
+	if (prot & PROT_READ) {
 		if (n + 1 < len)
 			buf[n++] = 'R';
 	}
-	if (prot & 0x2) {
+	if (prot & PROT_WRITE) {
 		if (n + 1 < len)
 			buf[n++] = 'W';
 	}
-	if (prot & 0x4) {
+	if (prot & PROT_EXEC) {
 		if (n + 1 < len)
 			buf[n++] = 'X';
 	}
@@ -2122,6 +2123,8 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 	const struct quark_ptrace	*ptrace;
 	const struct quark_module_load	*qml;
 	const struct quark_mprotect	*mprotect;
+	char				 prev_prot[4], req_prot[4];
+	char				 effective_prot[4];
 	int				 pid;
 
 	if (qev->events == QUARK_EV_BYPASS) {
@@ -2224,9 +2227,21 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		fl = "MPRO";
 
 		mprotect = &qev->mprotect;
-		mprotect_prot_str(mprotect->prot, buf, sizeof(buf));
-		PF(fl, "addr=0x%llx len=%llu prot=0x%llx (%s)\n",
-		    mprotect->addr, mprotect->len, mprotect->prot, buf);
+		mprotect_prot_str(mprotect->prev_prot, prev_prot,
+		    sizeof(prev_prot));
+		mprotect_prot_str(mprotect->req_prot, req_prot,
+		    sizeof(req_prot));
+		mprotect_prot_str(mprotect->effective_prot, effective_prot,
+		    sizeof(effective_prot));
+		PF(fl, "attempt vma=[0x%llx,0x%llx) "
+		    "prev=0x%llx (%s) req=0x%llx (%s) effective=0x%llx (%s) "
+		    "file_backed=%u inode=%llu dev=%u:%u\n",
+		    mprotect->vma_start, mprotect->vma_end,
+		    mprotect->prev_prot, prev_prot,
+		    mprotect->req_prot, req_prot,
+		    mprotect->effective_prot, effective_prot,
+		    mprotect->file_backed, mprotect->inode,
+		    mprotect->dev_major, mprotect->dev_minor);
 	}
 
 	if (qp == NULL)

--- a/quark.h
+++ b/quark.h
@@ -880,6 +880,18 @@ struct quark_sysinfo {
 	char	 *os_pretty_name;
 };
 
+struct quark_mprotect_stats {
+	u64	hook_calls;
+	u64	effective_exec;
+	u64	new_exec;
+	u64	already_exec;
+	u64	writable_exec;
+	u64	anonymous;
+	u64	file_backed;
+	u64	submitted;
+	u64	reserve_failed;
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -888,6 +900,7 @@ struct quark_queue_stats {
 	u64	lost;
 	u64	garbage_collections;
 	int	backend;	/* active backend, QQ_EBPF or QQ_KPROBE */
+	struct quark_mprotect_stats mprotect;
 	/* TODO u64	peak_nodes; */
 };
 

--- a/quark.h
+++ b/quark.h
@@ -400,10 +400,20 @@ struct quark_ptrace {
 	u64	data;
 };
 
+/*
+ * One executable attempt observed at security_file_mprotect(). The hook runs
+ * before the kernel commits the protection change and can fire once per VMA.
+ */
 struct quark_mprotect {
-	u64	addr;
-	u64	len;
-	u64	prot;
+	u64	vma_start;	/* VMA containing the attempted change */
+	u64	vma_end;
+	u64	prev_prot;	/* normalized PROT_READ/WRITE/EXEC bits */
+	u64	req_prot;	/* protection requested by userspace */
+	u64	effective_prot;	/* kernel-adjusted protection */
+	u64	inode;		/* zero for anonymous mappings */
+	u32	dev_major;	/* zero for anonymous mappings */
+	u32	dev_minor;	/* zero for anonymous mappings */
+	u32	file_backed;
 };
 
 struct raw_ptrace {

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -62,6 +62,16 @@ Process changed image, result of an exec.
 Process exited.
 .It Dv QUARK_EV_SETPROCTITLE
 Process changed its name (COMM).
+.It Dv QUARK_EV_MPROTECT
+An executable protection attempt reached the kernel's
+.Fn security_file_mprotect
+check.
+The
+.Em mprotect
+member contains the VMA bounds, normalized previous protection,
+userspace-requested and kernel-adjusted protection, and backing-file identity.
+It describes an attempt and does not assert that the protection change was
+committed.
 .El
 .Pp
 It's important to note that

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -17,13 +17,27 @@ into
 .Vt quark_queue_stats
 is defined as:
 .Bd -literal -offset indent
+struct quark_mprotect_stats {
+	u64	hook_calls;
+	u64	effective_exec;
+	u64	new_exec;
+	u64	already_exec;
+	u64	writable_exec;
+	u64	anonymous;
+	u64	file_backed;
+	u64	submitted;
+	u64	reserve_failed;
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
 	u64	aggregations;
 	u64	non_aggregations;
 	u64	lost;
+	u64	garbage_collections;
 	int	backend;
+	struct quark_mprotect_stats mprotect;
 };
 .Ed
 .Bl -tag -width "non_aggregations"
@@ -56,6 +70,12 @@ Active queue backend, either
 .Dv QQ_EBPF
 or
 .Dv QQ_KPROBE .
+.It Em mprotect
+Cumulative, per-CPU measurements collected when
+.Dv QQ_MPROTECT
+is enabled: hook calls, effective executable attempts, new and already
+executable mappings, writable-executable mappings, anonymous and file-backed
+mappings, submitted records, and failed ring-buffer reservations.
 .El
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -117,6 +117,11 @@ in
 .Em quark_events .
 Entry leader is how the process entered the system, it is disabled by default as
 it is Elastic/ECS specific.
+.It Dv QQ_MPROTECT
+Enable EBPF-only executable mprotect attempt events.
+Each event describes one VMA reaching the kernel's
+.Fn security_file_mprotect
+check and does not imply that the protection change was committed.
 .El
 .It Em max_length
 The maximum size of the internal buffering queue in number of events.


### PR DESCRIPTION
## Summary

Stacked on #367.

- replace the paired `sys_enter_mprotect` / `sys_exit_mprotect` tracepoints and per-thread state with an fentry/kprobe pair on `security_file_mprotect`
- emit one event per VMA when the kernel-adjusted protection includes execute permission, covering `mprotect`, `pkey_mprotect`, compat callers, and `READ_IMPLIES_EXEC` handling through the common hook
- expose VMA bounds, normalized previous protection, requested and effective protection, and file-backed inode/device identity
- expose the richer event through the C and Go APIs and update event dumping and documentation
- restore `t_mprotect` to the RHEL 9.3 CI invocation now that it no longer depends on the affected syscall tracepoints

## Event semantics

An event means the kernel reached `security_file_mprotect` for this VMA with effective execute permission. The hook runs before the protection change is committed, so the event is an attempt and does not claim syscall success. The VMA bounds provide context and are not necessarily the exact caller-requested subrange.

## Verification

- `git diff --check`: pass
- `gofmt -d go/quark/quark.go`: no output
- Runtime/build tests not run: implementation was prepared on a macOS host, per request.