### PR TITLE
kprobe: translate MONOTONIC to BOOTTIME event timestamps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -260,6 +260,39 @@ steps:
       machineType: n2-standard-2
       enableNestedVirtualization: true
 
+  - label: "kprobe failing on rhel 7.0 (no perf clockid)"
+    key: test_rhel_7_0_negative
+    command: "./.buildkite/runtest_distro.sh rhel 7.0 -k t_kprobe_clockid"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on rhel 7.4 (no bpf, oldest kprobe)"
+    key: test_rhel_7_4
+    command: "./.buildkite/runtest_distro.sh rhel 7.4 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
+  - label: "quark-test on rhel 7.9 (no bpf, kprobe)"
+    key: test_rhel_7_9
+    command: "./.buildkite/runtest_distro.sh rhel 7.9 -k"
+    depends_on:
+      - make_docker
+    agents:
+      image: family/core-ubuntu-2404
+      provider: gcp
+      machineType: n2-standard-2
+      enableNestedVirtualization: true
+
   - label: "quark-test on rhel 8"
     key: test_rhel_8
     command: "./.buildkite/runtest_distro.sh rhel 8"

--- a/CHANGES
+++ b/CHANGES
@@ -159,3 +159,11 @@ Changes from 0.7 to 0.8
   o The Go bindings (go/quark) learned Queue.DisableAggregation(),
     which clears every entry in the aggregation matrix. Call it after
     OpenQueue() and before the queue is consumed.
+
+Changes from 0.8 to 0.9
+~~~~~~~~~~~~~~~~~~~~~~~
+  o The KPROBE backend now translates event times from CLOCK_MONOTONIC
+    to CLOCK_BOOTTIME, matching the other backends. This means that produced
+    timestamps now include the total suspended time, same as the other backends.
+    QQ_MONOTONIC is now only set on kernels older than 4.1, where a perf
+    clock can not be selected.

--- a/CHANGES
+++ b/CHANGES
@@ -165,7 +165,9 @@ Changes from 0.8 to 0.9
   o The KPROBE backend now translates event times from CLOCK_MONOTONIC to
     CLOCK_BOOTTIME, matching the other backends. This means that produced
     timestamps now include the total suspended time, same as the other
-    backends.
+    backends. One exception: events stamped before a suspend but still
+    unread when the host resumes shift late by up to that suspend duration,
+    all other events are exact.
   o BREAKING: QQ_MONOTONIC was removed and event times are always
     CLOCK_BOOTTIME. This effectively drops support for kernels without perf
     clockid support (< 4.1 or RHEL before 7.4).

--- a/CHANGES
+++ b/CHANGES
@@ -162,8 +162,9 @@ Changes from 0.7 to 0.8
 
 Changes from 0.8 to 0.9
 ~~~~~~~~~~~~~~~~~~~~~~~
-  o The KPROBE backend now translates event times from CLOCK_MONOTONIC
-    to CLOCK_BOOTTIME, matching the other backends. This means that produced
-    timestamps now include the total suspended time, same as the other backends.
-    BREAKING: QQ_MONOTONIC was removed and event times are always
-    CLOCK_BOOTTIME now.
+  o The KPROBE backend now translates event times from CLOCK_MONOTONIC to
+    CLOCK_BOOTTIME, matching the other backends. This means that produced
+    timestamps now include the total suspended time, same as the other
+    backends.  BREAKING: QQ_MONOTONIC was removed and event times are always
+    CLOCK_BOOTTIME. This effectively drops support for kernels without perf
+    clockid support (< 4.1 or RHEL before 7.4).

--- a/CHANGES
+++ b/CHANGES
@@ -165,5 +165,5 @@ Changes from 0.8 to 0.9
   o The KPROBE backend now translates event times from CLOCK_MONOTONIC
     to CLOCK_BOOTTIME, matching the other backends. This means that produced
     timestamps now include the total suspended time, same as the other backends.
-    QQ_MONOTONIC is now only set on kernels older than 4.1, where a perf
-    clock can not be selected.
+    BREAKING: QQ_MONOTONIC was removed and event times are always
+    CLOCK_BOOTTIME now.

--- a/CHANGES
+++ b/CHANGES
@@ -165,6 +165,7 @@ Changes from 0.8 to 0.9
   o The KPROBE backend now translates event times from CLOCK_MONOTONIC to
     CLOCK_BOOTTIME, matching the other backends. This means that produced
     timestamps now include the total suspended time, same as the other
-    backends.  BREAKING: QQ_MONOTONIC was removed and event times are always
+    backends.
+  o BREAKING: QQ_MONOTONIC was removed and event times are always
     CLOCK_BOOTTIME. This effectively drops support for kernels without perf
     clockid support (< 4.1 or RHEL before 7.4).

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -88,15 +88,6 @@
           <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>.</dd>
       <dt id="QQ_KPROBE"><a class="permalink" href="#QQ_KPROBE"><code class="Dv">QQ_KPROBE</code></a></dt>
       <dd>Use the KPROBE backend.</dd>
-      <dt id="QQ_MONOTONIC"><a class="permalink" href="#QQ_MONOTONIC"><code class="Dv">QQ_MONOTONIC</code></a></dt>
-      <dd>Informational, not configuration: specifying it fails with
-          <code class="Er">EINVAL</code>. The backend that opens sets it on the
-          opened queue's <i class="Em">flags</i> when its event times are
-          CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which only the KPROBE
-          backend does. Monotonic times undercount by the total suspended time,
-          users that care about suspend must compensate. See
-          <a class="Xr" href="quark_time_to_wallclock.3.html">quark_time_to_wallclock(3)</a>
-          for the effect on wallclock translation.</dd>
       <dt id="QQ_THREAD_EVENTS"><a class="permalink" href="#QQ_THREAD_EVENTS"><code class="Dv">QQ_THREAD_EVENTS</code></a></dt>
       <dd>Include per-thread events, instead of per-process events. This option
           will be removed in the future, but it may be useful for
@@ -172,7 +163,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 14, 2026</td>
+    <td class="foot-date">August 27, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_queue_open.3.html
+++ b/docs/quark_queue_open.3.html
@@ -87,7 +87,13 @@
       <dd>Use the EBPF backend, this is the default of
           <a class="Xr" href="quark_queue_default_attr.3.html">quark_queue_default_attr(3)</a>.</dd>
       <dt id="QQ_KPROBE"><a class="permalink" href="#QQ_KPROBE"><code class="Dv">QQ_KPROBE</code></a></dt>
-      <dd>Use the KPROBE backend.</dd>
+      <dd>Use the KPROBE backend. Event times are CLOCK_MONOTONIC samples
+          translated to CLOCK_BOOTTIME, since perf can not stamp them with
+          CLOCK_BOOTTIME directly. The translation is exact, with one exception:
+          events stamped before a suspend but still unread when the host resumes
+          are translated based on resume time and shift late by up to that
+          suspend's duration. Only events in flight across the suspend are
+          affected, hosts that never suspend are always exact.</dd>
       <dt id="QQ_THREAD_EVENTS"><a class="permalink" href="#QQ_THREAD_EVENTS"><code class="Dv">QQ_THREAD_EVENTS</code></a></dt>
       <dd>Include per-thread events, instead of per-process events. This option
           will be removed in the future, but it may be useful for
@@ -163,7 +169,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 27, 2026</td>
+    <td class="foot-date">August 28, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_time_to_wallclock.3.html
+++ b/docs/quark_time_to_wallclock.3.html
@@ -54,6 +54,9 @@
     if the clock may be stepped while running. Gradual corrections (slewing)
     adjust the wallclock and the boot clock at the same rate, leaving the epoch
     untouched, only a step moves it.</p>
+<p class="Pp">On the KPROBE backend, events in flight across a suspend may carry
+    a time shifted late by up to that suspend's duration, see
+    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>.</p>
 <section class="Sh">
 <h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
@@ -89,7 +92,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 27, 2026</td>
+    <td class="foot-date">August 28, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/docs/quark_time_to_wallclock.3.html
+++ b/docs/quark_time_to_wallclock.3.html
@@ -54,17 +54,6 @@
     if the clock may be stepped while running. Gradual corrections (slewing)
     adjust the wallclock and the boot clock at the same rate, leaving the epoch
     untouched, only a step moves it.</p>
-<p class="Pp" id="flags">The KPROBE backend stamps times with a monotonic clock
-    that does not advance during suspend, relayed as
-    <code class="Dv">QQ_MONOTONIC</code> on the opened queue's
-    <a class="permalink" href="#flags"><i class="Em">flags</i></a>, see
-    <a class="Xr" href="quark_queue_open.3.html">quark_queue_open(3)</a>.
-    <code class="Nm">quark_time_to_wallclock</code> applies unchanged, but the
-    result lags the wallclock by the total suspended time, exactly as it did
-    before quark 0.8. Users that care about suspend can detect
-    <code class="Dv">QQ_MONOTONIC</code> and compensate with the difference
-    between <code class="Dv">CLOCK_BOOTTIME</code> and
-    <code class="Dv">CLOCK_MONOTONIC</code>.</p>
 <section class="Sh">
 <h1 class="Sh" id="RETURN_VALUES"><a class="permalink" href="#RETURN_VALUES">RETURN
   VALUES</a></h1>
@@ -100,7 +89,7 @@
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">August 14, 2026</td>
+    <td class="foot-date">August 27, 2026</td>
     <td class="foot-os">Linux</td>
   </tr>
 </table>

--- a/init.c
+++ b/init.c
@@ -18,6 +18,7 @@
 #include <netinet/ip.h>
 
 #include <err.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -136,9 +137,13 @@ main(int argc, char *argv[])
 				errx(1, "couldn't mount tracefs or debugfs");
 			}
 		}
-		/* No cgroup2 on kernels older than 4.5 */
-		if (mount("cgroup2", "/sys/fs/cgroup", "cgroup2", 0, NULL) == -1)
-			warn("mount /sys/fs/cgroup");
+		/* ENODEV: no cgroup2 on kernels < 4.5, continue for RHEL7 tests */
+		if (mount("cgroup2", "/sys/fs/cgroup", "cgroup2", 0, NULL) == -1) {
+			if (errno == ENODEV)
+				warn("mount /sys/fs/cgroup");
+			else
+				err(1, "mount /sys/fs/cgroup");
+		}
 
 		net_up();
 

--- a/init.c
+++ b/init.c
@@ -136,8 +136,9 @@ main(int argc, char *argv[])
 				errx(1, "couldn't mount tracefs or debugfs");
 			}
 		}
+		/* No cgroup2 on kernels older than 4.5 */
 		if (mount("cgroup2", "/sys/fs/cgroup", "cgroup2", 0, NULL) == -1)
-			err(1, "mount /sys/fs/cgroup");
+			warn("mount /sys/fs/cgroup");
 
 		net_up();
 

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -285,6 +285,12 @@ struct kprobe_queue {
 	struct sample_attr		 id_to_sample_attr[MAX_SAMPLE_ATTR];
 	/* linearizes wrapped perf records, see kprobe_queue_open() */
 	u8				*wrapped_event_buf;
+	/*
+	 * Added to sample times to translate them from CLOCK_MONOTONIC
+	 * to CLOCK_BOOTTIME, zero if the kernel doesn't do use_clockid,
+	 * see kprobe_queue_open().
+	 */
+	u64				 boot_offset;
 };
 
 static int	kprobe_queue_populate(struct quark_queue *);
@@ -564,9 +570,33 @@ perf_sample_to_raw(struct quark_queue *qq, struct perf_record_sample *sample)
 	return (raw);
 }
 
+/*
+ * The distance between CLOCK_BOOTTIME and CLOCK_MONOTONIC: total
+ * time spent suspended. The two clocks tick and slew at the same
+ * rate, so adding it to a monotonic time yields a boottime time.
+ */
+static u64
+boot_offset(void)
+{
+	struct timespec	bt, mt;
+
+	/* Read monotonic first so the difference can not go negative on
+	 * hosts that never suspended. */
+	if (clock_gettime(CLOCK_MONOTONIC, &mt) == -1 ||
+	    clock_gettime(CLOCK_BOOTTIME, &bt) == -1)
+		return (0);
+	/*
+	 * MAYBE TODO(ck): if the process gets preempted at exactly between the
+	 * two clock_gettime calls, the offset will include the preempted time.
+	 * The fix is to take a few (5-10) samples here and keep the smallest.
+	 */
+	return (TS_TO_NS(bt) - TS_TO_NS(mt));
+}
+
 static struct raw_event *
 perf_event_to_raw(struct quark_queue *qq, struct perf_event *ev)
 {
+	struct kprobe_queue		*kqq = qq->queue_be;
 	struct raw_event		*raw = NULL;
 	struct perf_sample_id		*sid = NULL;
 	ssize_t				 n;
@@ -625,7 +655,7 @@ perf_event_to_raw(struct quark_queue *qq, struct perf_event *ev)
 			raw->tid = sid->tid;
 		raw->opid = sid->pid;
 		raw->tid = sid->tid;
-		raw->time = sid->time;
+		raw->time = sid->time + kqq->boot_offset;
 		raw->cpu = sid->cpu;
 	}
 
@@ -1403,8 +1433,6 @@ kprobe_queue_open(struct quark_queue *qq)
 
 	if ((qq->flags & QQ_KPROBE) == 0)
 		return (errno = ENOTSUP, -1);
-	/* Perf stamps samples with the monotonic-ish sched clock */
-	qq->flags |= QQ_MONOTONIC;
 	qid = __atomic_fetch_add(&qids, 1, __ATOMIC_RELAXED);
 	if (kprobe_install_all(qid) == -1)
 		goto fail;
@@ -1448,6 +1476,21 @@ kprobe_queue_open(struct quark_queue *qq)
 		TAILQ_INSERT_TAIL(&kqq->perf_group_leaders, pgl, entry);
 		kqq->num_perf_group_leaders++;
 	}
+
+	/*
+	 * Samples are stamped with CLOCK_MONOTONIC and translated to
+	 * CLOCK_BOOTTIME in perf_event_to_raw() by adding boot_offset,
+	 * matching the other backends. On kernels without clockid
+	 * support (< 4.1), perf_event_open_degradable() drops use_clockid
+	 * and samples are stamped with the kernel's sched (roughly monotonic)
+	 * clock: no translation is possible, relay that as QQ_MONOTONIC
+	 * and keep boot_offset at zero.
+	 */
+	pgl = TAILQ_FIRST(&kqq->perf_group_leaders);
+	if (pgl == NULL || !pgl->attr.use_clockid)
+		qq->flags |= QQ_MONOTONIC;
+	else
+		kqq->boot_offset = boot_offset();
 
 	i = 0;
 	while ((k = all_kprobes[i++]) != NULL) {
@@ -1505,6 +1548,25 @@ kprobe_queue_populate(struct quark_queue *qq)
 
 	num_rings = kqq->num_perf_group_leaders;
 	npop = 0;
+
+	/*
+	 * Refresh the suspend time so records stamped after a resume
+	 * translate correctly. Records stamped before a suspend but read
+	 * after, are shifted late by that last suspend as we can't do better.
+	 * Only a suspend moves the offset and only forward as we ignore
+	 * anything below a 10ms threshold: it's call noise from the two
+	 * clock reads in boot_offset() and adopting it would jitter the
+	 * translation from batch to batch.
+	 */
+	if ((qq->flags & QQ_MONOTONIC) == 0) {
+		u64	off;
+
+		off = boot_offset();
+		/* 10ms is enough to filter out vDSO call (and some scheduling)
+		 * jitter but catch system suspend drift. */
+		if (off > kqq->boot_offset + MS_TO_NS(10))
+			kqq->boot_offset = off;
+	}
 
 	/*
 	 * We stop if the queue is full, or if we see all perf ring buffers

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -17,13 +17,13 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-#include <stdint.h>
 
 #include "quark.h"
 
@@ -581,11 +581,12 @@ boot_offset(void)
 	struct timespec	bt, mt;
 	u64		best = UINT64_MAX;
 	for (int i = 0; i < 3; i++) {
-	       /*
-		* Read monotonic first, so a sample can not go negative on hosts
-		* that never suspended. Taking a few samples and keeping the smallest
-		* discards any sample inflated by a preemption between the two reads.
-		*/
+		/*
+		 * Read monotonic first, so a sample can not go negative on
+		 * hosts that never suspended. Taking a few samples and
+		 * keeping the smallest discards any sample inflated by a
+		 * preemption between the two reads.
+		 */
 		if (clock_gettime(CLOCK_MONOTONIC, &mt) == -1 ||
 		    clock_gettime(CLOCK_BOOTTIME, &bt) == -1)
 			return (0);

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -789,6 +789,26 @@ again:
 		goto again;
 	}
 
+	/*
+	 * Test for missing perf clockid, which the KPROBE backend can't
+	 * work without: if the open succeeds without use_clockid,
+	 * the clock was the problem. Still fail with the original EINVAL
+	 * as we don't support any kernels without perf clockid.
+	 */
+	if (attr->use_clockid) {
+		attr->use_clockid = 0;
+		attr->clockid = 0;
+		r = perf_event_open(attr, pid, cpu, group_fd, flags);
+		attr->use_clockid = 1;
+		attr->clockid = CLOCK_MONOTONIC;
+		if (r >= 0) {
+			close(r);
+			qwarnx("kernel is missing perf clockid, if you're on RHEL7 "
+			    "update to 7.4 or newer");
+		}
+		return (errno = EINVAL, -1);
+	}
+
 	return (r);
 }
 

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -23,10 +23,11 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include "quark.h"
 
-#define PERF_MMAP_PAGES		16		/* Must be power of 2 */
+#define PERF_MMAP_PAGES		16			/* Must be power of 2 */
 #define PERF_RECORD_MAX_SIZE	(UINT16_MAX + 1)	/* header.size is u16 */
 /*
  * A perf record caps at UINT16_MAX (perf_event_header.size). The ring must be
@@ -578,18 +579,22 @@ static u64
 boot_offset(void)
 {
 	struct timespec	bt, mt;
+	u64		best = UINT64_MAX;
+	for (int i = 0; i < 3; i++) {
+	       /*
+		* Read monotonic first, so a sample can not go negative on hosts
+		* that never suspended. Taking a few samples and keeping the smallest
+		* discards any sample inflated by a preemption between the two reads.
+		*/
+		if (clock_gettime(CLOCK_MONOTONIC, &mt) == -1 ||
+		    clock_gettime(CLOCK_BOOTTIME, &bt) == -1)
+			return (0);
+		u64 off = TS_TO_NS(bt) - TS_TO_NS(mt);
+		if (off < best)
+			best = off;
+	}
 
-	/* Read monotonic first so the difference can not go negative on
-	 * hosts that never suspended. */
-	if (clock_gettime(CLOCK_MONOTONIC, &mt) == -1 ||
-	    clock_gettime(CLOCK_BOOTTIME, &bt) == -1)
-		return (0);
-	/*
-	 * MAYBE TODO(ck): if the process gets preempted at exactly between the
-	 * two clock_gettime calls, the offset will include the preempted time.
-	 * The fix is to take a few (e.g. 3) samples here and keep the smallest.
-	 */
-	return (TS_TO_NS(bt) - TS_TO_NS(mt));
+	return (best);
 }
 
 static struct raw_event *

--- a/kprobe_queue.c
+++ b/kprobe_queue.c
@@ -287,8 +287,7 @@ struct kprobe_queue {
 	u8				*wrapped_event_buf;
 	/*
 	 * Added to sample times to translate them from CLOCK_MONOTONIC
-	 * to CLOCK_BOOTTIME, zero if the kernel doesn't do use_clockid,
-	 * see kprobe_queue_open().
+	 * to CLOCK_BOOTTIME, see kprobe_queue_open().
 	 */
 	u64				 boot_offset;
 };
@@ -588,7 +587,7 @@ boot_offset(void)
 	/*
 	 * MAYBE TODO(ck): if the process gets preempted at exactly between the
 	 * two clock_gettime calls, the offset will include the preempted time.
-	 * The fix is to take a few (5-10) samples here and keep the smallest.
+	 * The fix is to take a few (e.g. 3) samples here and keep the smallest.
 	 */
 	return (TS_TO_NS(bt) - TS_TO_NS(mt));
 }
@@ -781,11 +780,6 @@ again:
 	/* start degrading until it works */
 	if (attr->comm_exec) {
 		attr->comm_exec = 0;
-		goto again;
-	}
-	if (attr->use_clockid) {
-		attr->use_clockid = 0;
-		attr->clockid = 0;
 		goto again;
 	}
 
@@ -1480,17 +1474,9 @@ kprobe_queue_open(struct quark_queue *qq)
 	/*
 	 * Samples are stamped with CLOCK_MONOTONIC and translated to
 	 * CLOCK_BOOTTIME in perf_event_to_raw() by adding boot_offset,
-	 * matching the other backends. On kernels without clockid
-	 * support (< 4.1), perf_event_open_degradable() drops use_clockid
-	 * and samples are stamped with the kernel's sched (roughly monotonic)
-	 * clock: no translation is possible, relay that as QQ_MONOTONIC
-	 * and keep boot_offset at zero.
+	 * matching the other backends.
 	 */
-	pgl = TAILQ_FIRST(&kqq->perf_group_leaders);
-	if (pgl == NULL || !pgl->attr.use_clockid)
-		qq->flags |= QQ_MONOTONIC;
-	else
-		kqq->boot_offset = boot_offset();
+	kqq->boot_offset = boot_offset();
 
 	i = 0;
 	while ((k = all_kprobes[i++]) != NULL) {
@@ -1545,6 +1531,7 @@ kprobe_queue_populate(struct quark_queue *qq)
 	struct perf_group_leader	*pgl;
 	struct perf_event		*ev;
 	struct raw_event		*raw;
+	u64				 off;
 
 	num_rings = kqq->num_perf_group_leaders;
 	npop = 0;
@@ -1558,15 +1545,9 @@ kprobe_queue_populate(struct quark_queue *qq)
 	 * clock reads in boot_offset() and adopting it would jitter the
 	 * translation from batch to batch.
 	 */
-	if ((qq->flags & QQ_MONOTONIC) == 0) {
-		u64	off;
-
-		off = boot_offset();
-		/* 10ms is enough to filter out vDSO call (and some scheduling)
-		 * jitter but catch system suspend drift. */
-		if (off > kqq->boot_offset + MS_TO_NS(10))
-			kqq->boot_offset = off;
-	}
+	off = boot_offset();
+	if (off > kqq->boot_offset + MS_TO_NS(10))
+		kqq->boot_offset = off;
 
 	/*
 	 * We stop if the queue is full, or if we see all perf ring buffers

--- a/krun-rhel.sh
+++ b/krun-rhel.sh
@@ -15,7 +15,7 @@ function usage
 	echo
 	echo "  -v           Verbose output"
 	echo "  initramfs.gz Path to initramfs image"
-	echo "  RHELVER      RHEL version (e.g. 8, 9, 8.4, 9.1)"
+	echo "  RHELVER      RHEL version (e.g. 7.9, 8, 9, 8.4, 9.1)"
 	echo "  command...   Command to run in guest"
 	echo
 	echo "Examples:"
@@ -43,7 +43,24 @@ shift 2
 [[ -f $INITRAMFS ]] || die "Initramfs not found: $INITRAMFS"
 [[ -f ./krun.sh ]] || die "Required launcher ./krun.sh is missing"
 
+# RHEL7 predates Rocky so we fetch from the CentOS vault instead.
+# The directories are keyed by point release date. Versions 7.0-7.3
+# lack perf clockid and are only useful to check that the KPROBE
+# backend fails cleanly, see t_kprobe_clockid in quark-test.
+declare -A EL7VAULT=(
+	[7.0]=7.0.1406 [7.1]=7.1.1503 [7.2]=7.2.1511 [7.3]=7.3.1611
+	[7.4]=7.4.1708 [7.5]=7.5.1804 [7.6]=7.6.1810 [7.7]=7.7.1908
+	[7.8]=7.8.2003 [7.9]=7.9.2009
+)
+
+KPKG="kernel-core"
 case $RHELVER in
+7|7.[0-9])
+	# Rocky has "major" (8,9,10) directories that point to the latest
+	# version, but CentOS doesn't.
+	if [ "$RHELVER" = "7" ]; then RHELVER=7.9; fi
+	KPKG="kernel-3\.10\.0"
+	URL="https://vault.centos.org/${EL7VAULT[$RHELVER]}/os/x86_64/Packages";;
 8|9)		URL="https://ftp.fau.de/rockylinux/$RHELVER/BaseOS/x86_64/os/Packages/k";;
 8.[34])		URL="https://dl.rockylinux.org/vault/rocky/$RHELVER/BaseOS/x86_64/os/Packages";;
 8.?|9.?|10.0)	URL="https://dl.rockylinux.org/vault/rocky/$RHELVER/BaseOS/x86_64/os/Packages/k";;
@@ -59,12 +76,19 @@ cleanup()	{ [[ -d "$TMPDIR" ]] && rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
 log "Fetching package list from $URL"
-RPMURL=$(lynx -dump -listonly "$URL"|grep kernel-core) || die "Can't fetch package list"
+RPMURL=$(lynx -dump -listonly "$URL"|grep "$KPKG") || die "Can't fetch package list"
 RPMURL=${RPMURL##* }
 RPM=$(basename "$RPMURL")
-VMLINUZ=${RPM##kernel-core-}
-VMLINUZ=${VMLINUZ%%.rpm}
-VMLINUZ=$TMPDIR/lib/modules/$VMLINUZ/vmlinuz
+if [[ $RHELVER == 7.* ]]; then
+	# el7 ships vmlinuz in /boot of the kernel package
+	VMLINUZ=${RPM##kernel-}
+	VMLINUZ=${VMLINUZ%%.rpm}
+	VMLINUZ=$TMPDIR/boot/vmlinuz-$VMLINUZ
+else
+	VMLINUZ=${RPM##kernel-core-}
+	VMLINUZ=${VMLINUZ%%.rpm}
+	VMLINUZ=$TMPDIR/lib/modules/$VMLINUZ/vmlinuz
+fi
 
 log "Downloading kernel RPM: $RPM"
 log "Target vmlinuz: $VMLINUZ"

--- a/ktest-all.sh
+++ b/ktest-all.sh
@@ -16,6 +16,7 @@ clockid_negative=(linux-3.10.0-123.el7.x86_64)
 result=""
 error_run=""
 declare -i failures=0
+mkdir -p kernel-images/{amd64,arm64}
 all_kernels="$(find kernel-images/{amd64,arm64} -type f)"
 
 function member

--- a/ktest-all.sh
+++ b/ktest-all.sh
@@ -2,16 +2,29 @@
 
 set -euo pipefail
 
-kprobe_only=(linux-3.10.0-123.el7.x86_64)
+# RHEL 7.4 (3.10.0-693) is the oldest supported kprobe kernel: it
+# backported perf clockid, which the KPROBE backend requires.
+# For KPROBE backend, test the floor (693) and the last el7 kernel (1160).
+# There's no BTF on el7, build initramfs.gz with WITH_BTFHUB=y.
+kprobe_only=(linux-3.10.0-693.el7.x86_64 linux-3.10.0-1160.el7.x86_64)
+
+# Kernels without perf clockid (< 4.1, RHEL < 7.4), where the only
+# test expected to pass is t_kprobe_clockid: it checks that the KPROBE
+# backend refuses to open and fails with EINVAL.
+clockid_negative=(linux-3.10.0-123.el7.x86_64)
+
 result=""
 error_run=""
 declare -i failures=0
 all_kernels="$(find kernel-images/{amd64,arm64} -type f)"
 
-function maybe_kflag
+function member
 {
-	for k in "${kprobe_only[@]}"; do
-		if [ "$1" = "$k" ]; then
+	local elt=$1
+	shift
+
+	for k in "$@"; do
+		if [ "$elt" = "$k" ]; then
 			return 0
 		fi
 	done
@@ -23,7 +36,9 @@ for k in $all_kernels
 do
 	kname="$(basename "$k")"
 	cmdline="./krun.sh initramfs.gz $k quark-test"
-	if maybe_kflag "$kname"; then
+	if member "$kname" "${clockid_negative[@]}"; then
+		cmdline+=" -k t_kprobe_clockid"
+	elif member "$kname" "${kprobe_only[@]}"; then
 		cmdline+=" -k"
 	fi
 	if eval "$cmdline"; then

--- a/quark-btf.c
+++ b/quark-btf.c
@@ -202,7 +202,7 @@ hub_lookup(int argc, char *argv[])
 
 	qbtf = quark_btf_open_hub(argv[0]);
 	if (qbtf == NULL)
-		errx(1, "can't match `%s` with any kernel in btfhub", optarg);
+		errx(1, "can't match `%s` with any kernel in btfhub", argv[0]);
 	printf("%s\n", qbtf->kname);
 	if (quark_verbose)
 		quark_btf_printit(qbtf, 0, NULL);

--- a/quark-test.c
+++ b/quark-test.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <asm/termbits.h>
+#include <linux/perf_event.h>
 
 #include <sys/ioctl.h>
 #include <sys/ipc.h>
@@ -11,6 +12,7 @@
 #include <sys/shm.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -70,7 +72,6 @@ struct test {
 };
 
 #define msleep(_x)	usleep((uint64_t)_x * 1000ULL)
-#define TS_TO_NS(_ts)	(((_ts)->tv_sec * NS_PER_S) + (_ts)->tv_nsec)
 
 enum {
 	SANE,
@@ -278,7 +279,7 @@ ns_clock(const struct quark_queue *qq)
 	if (clock_gettime(clk, &ts) == -1)
 		err(1, "clock_gettime");
 
-	return ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
+	return (TS_TO_NS(ts));
 }
 
 static u32
@@ -841,6 +842,33 @@ t_probe(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
+/*
+ * Return 1 if perf can stamp samples with a selectable clock, in which case
+ * the KPROBE backend translates times to CLOCK_BOOTTIME and does not relay
+ * QQ_MONOTONIC. For kernels >= 4.1.
+ */
+static int
+perf_supports_clockid(void)
+{
+	struct perf_event_attr	attr;
+	int			fd;
+
+	bzero(&attr, sizeof(attr));
+	attr.type = PERF_TYPE_SOFTWARE;
+	attr.size = sizeof(attr);
+	/* Not SW_DUMMY as it postdates centos7's kernel headers */
+	attr.config = PERF_COUNT_SW_CPU_CLOCK;
+	attr.disabled = 1;
+	attr.use_clockid = 1;
+	attr.clockid = CLOCK_MONOTONIC;
+	fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+	if (fd == -1)
+		return (0);
+	close(fd);
+
+	return (1);
+}
+
 static int
 t_monotonic(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -856,7 +884,7 @@ t_monotonic(const struct test *t, struct quark_queue_attr *qa)
 	attr = *qa;
 	if (quark_queue_open(&qq, &attr) != 0)
 		err(1, "%s: quark_queue_open", t->name);
-	if (qq.stats.backend == QQ_KPROBE)
+	if (qq.stats.backend == QQ_KPROBE && !perf_supports_clockid())
 		assert(qq.flags & QQ_MONOTONIC);
 	else
 		assert((qq.flags & QQ_MONOTONIC) == 0);
@@ -1310,15 +1338,15 @@ t_file(const struct test *t, struct quark_queue_attr *qa)
 	assert(qf->op_mask & QUARK_FILE_OP_MODIFY);
 	assert(qf->op_mask & QUARK_FILE_OP_REMOVE);
 	assert(qf->inode == st.st_ino);
-	assert(qf->atime == TS_TO_NS(&st.st_atim));
+	assert(qf->atime == TS_TO_NS(st.st_atim));
 	/*
 	 * ctime is normalized, see
 	 * inode_set_ctime_to_ts()->set_normalized_timespec64()
 	 * TODO: Figure out how to make it match at some point.
 	 */
-	/* assert(qf->ctime == TS_TO_NS(&st.st_ctim)); */
+	/* assert(qf->ctime == TS_TO_NS(st.st_ctim)); */
 	assert(qf->ctime > 0);
-	assert(qf->mtime == TS_TO_NS(&st.st_mtim));
+	assert(qf->mtime == TS_TO_NS(st.st_mtim));
 	assert(qf->mode == st.st_mode);
 	assert(qf->uid == getuid());
 	assert(qf->gid == getgid());

--- a/quark-test.c
+++ b/quark-test.c
@@ -876,14 +876,16 @@ static int
 t_kprobe_clockid(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct quark_queue	 qq;
-	int			 r;
+	int			 r, saved_errno;
 
 	r = quark_queue_open(&qq, qa);
+	/* Save it as perf_supports_clockid() clobbers errno */
+	saved_errno = errno;
 	if (perf_supports_clockid()) {
 		assert(r == 0);
 		quark_queue_close(&qq);
 	} else
-		assert(r == -1 && errno == EINVAL);
+		assert(r == -1 && saved_errno == EINVAL);
 
 	return (0);
 }

--- a/quark-test.c
+++ b/quark-test.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <asm/termbits.h>
+#include <linux/perf_event.h>
 
 #include <sys/ioctl.h>
 #include <sys/ipc.h>
@@ -11,6 +12,7 @@
 #include <sys/shm.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -834,6 +836,54 @@ t_probe(const struct test *t, struct quark_queue_attr *qa)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "%s: quark_queue_open", t->name);
 	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * Return 1 if perf can stamp samples with a selectable clock,
+ * kernels >= 4.1 and RHEL >= 7.4.
+ */
+static int
+perf_supports_clockid(void)
+{
+	struct perf_event_attr	attr;
+	int			fd;
+
+	bzero(&attr, sizeof(attr));
+	attr.type = PERF_TYPE_SOFTWARE;
+	attr.size = sizeof(attr);
+	/* Not SW_DUMMY as it postdates centos7's kernel headers */
+	attr.config = PERF_COUNT_SW_CPU_CLOCK;
+	attr.disabled = 1;
+	attr.use_clockid = 1;
+	attr.clockid = CLOCK_MONOTONIC;
+	fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+	if (fd == -1)
+		return (0);
+	close(fd);
+
+	return (1);
+}
+
+/*
+ * The KPROBE backend needs a perf clock to stamp samples with
+ * CLOCK_MONOTONIC: test that open succeeds on kernels that have
+ * it, and fails on kernels without it with EINVAL.
+ * This is the only kprobe test expected to pass on RHEL < 7.4.
+ */
+static int
+t_kprobe_clockid(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue	 qq;
+	int			 r;
+
+	r = quark_queue_open(&qq, qa);
+	if (perf_supports_clockid()) {
+		assert(r == 0);
+		quark_queue_close(&qq);
+	} else
+		assert(r == -1 && errno == EINVAL);
 
 	return (0);
 }
@@ -2827,6 +2877,7 @@ struct test all_tests[] = {
 	T_EBPF(t_probe),
 	T_KPROBE(t_probe),
 	T_NOVA(t_probe),
+	T_KPROBE(t_kprobe_clockid),
 	T_EBPF(t_os_release),
 	T_KPROBE(t_os_release),
 	T_EBPF(t_fork_exec_exit),

--- a/quark-test.c
+++ b/quark-test.c
@@ -2,7 +2,6 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <asm/termbits.h>
-#include <linux/perf_event.h>
 
 #include <sys/ioctl.h>
 #include <sys/ipc.h>
@@ -12,7 +11,6 @@
 #include <sys/shm.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -270,13 +268,11 @@ show_cursor(void)
 }
 
 static u64
-ns_clock(const struct quark_queue *qq)
+ns_clock(void)
 {
 	struct timespec ts;
-	clockid_t	clk;
 
-	clk = qq->flags & QQ_MONOTONIC ? CLOCK_MONOTONIC : CLOCK_BOOTTIME;
-	if (clock_gettime(clk, &ts) == -1)
+	if (clock_gettime(CLOCK_BOOTTIME, &ts) == -1)
 		err(1, "clock_gettime");
 
 	return (TS_TO_NS(ts));
@@ -842,57 +838,6 @@ t_probe(const struct test *t, struct quark_queue_attr *qa)
 	return (0);
 }
 
-/*
- * Return 1 if perf can stamp samples with a selectable clock, in which case
- * the KPROBE backend translates times to CLOCK_BOOTTIME and does not relay
- * QQ_MONOTONIC. For kernels >= 4.1.
- */
-static int
-perf_supports_clockid(void)
-{
-	struct perf_event_attr	attr;
-	int			fd;
-
-	bzero(&attr, sizeof(attr));
-	attr.type = PERF_TYPE_SOFTWARE;
-	attr.size = sizeof(attr);
-	/* Not SW_DUMMY as it postdates centos7's kernel headers */
-	attr.config = PERF_COUNT_SW_CPU_CLOCK;
-	attr.disabled = 1;
-	attr.use_clockid = 1;
-	attr.clockid = CLOCK_MONOTONIC;
-	fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
-	if (fd == -1)
-		return (0);
-	close(fd);
-
-	return (1);
-}
-
-static int
-t_monotonic(const struct test *t, struct quark_queue_attr *qa)
-{
-	struct quark_queue	 qq;
-	struct quark_queue_attr	 attr;
-
-	/* Informational only, refused as configuration */
-	attr = *qa;
-	attr.flags |= QQ_MONOTONIC;
-	assert(quark_queue_open(&qq, &attr) == -1 && errno == EINVAL);
-
-	/* On an open queue it relays the backend's time domain */
-	attr = *qa;
-	if (quark_queue_open(&qq, &attr) != 0)
-		err(1, "%s: quark_queue_open", t->name);
-	if (qq.stats.backend == QQ_KPROBE && !perf_supports_clockid())
-		assert(qq.flags & QQ_MONOTONIC);
-	else
-		assert((qq.flags & QQ_MONOTONIC) == 0);
-	quark_queue_close(&qq);
-
-	return (0);
-}
-
 static int
 t_os_release(const struct test *t, struct quark_queue_attr *qa)
 {
@@ -938,10 +883,10 @@ fork_exec_exit(const struct test *t, struct quark_queue_attr *qa, int relative)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_clock(&qq);
+	before = ns_clock();
 	child = fork_exec_nop1(relative, 0);
 	qev = drain_for_pid(&qq, child);
-	after = ns_clock(&qq);
+	after = ns_clock();
 
 	/* check qev.events */
 	assert(qev->events & QUARK_EV_FORK);
@@ -1307,10 +1252,10 @@ t_file(const struct test *t, struct quark_queue_attr *qa)
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "quark_queue_open");
 
-	before = ns_clock(&qq);
+	before = ns_clock();
 	if ((fd = mkstemp(path)) == -1)
 		err(1, "mkstemp");
-	after = ns_clock(&qq);
+	after = ns_clock();
 	assert(write(fd, "1", 1) == 1);
 	assert(write(fd, "2", 1) == 1);
 	assert(write(fd, "3", 1) == 1);
@@ -2882,9 +2827,6 @@ struct test all_tests[] = {
 	T_EBPF(t_probe),
 	T_KPROBE(t_probe),
 	T_NOVA(t_probe),
-	T_EBPF(t_monotonic),
-	T_KPROBE(t_monotonic),
-	T_NOVA(t_monotonic),
 	T_EBPF(t_os_release),
 	T_KPROBE(t_os_release),
 	T_EBPF(t_fork_exec_exit),

--- a/quark.c
+++ b/quark.c
@@ -302,13 +302,11 @@ raw_event_by_pidtime_cmp(struct raw_event *a, struct raw_event *b)
 }
 
 static inline u64
-now64(const struct quark_queue *qq)
+now64(void)
 {
 	struct timespec ts;
-	clockid_t	clk;
 
-	clk = qq->flags & QQ_MONOTONIC ? CLOCK_MONOTONIC : CLOCK_BOOTTIME;
-	if (clock_gettime(clk, &ts) == -1)
+	if (clock_gettime(CLOCK_BOOTTIME, &ts) == -1)
 		return (0);
 
 	return (TS_TO_NS(ts));
@@ -485,7 +483,7 @@ gc_mark(struct quark_queue *qq, struct gc_link *gc, enum gc_type type)
 	if (gc->gc_time)
 		return;
 
-	gc->gc_time = now64(qq);
+	gc->gc_time = now64();
 	gc->gc_type = type;
 	TAILQ_INSERT_TAIL(&qq->event_gc, gc, gc_entry);
 }
@@ -506,7 +504,7 @@ gc_collect(struct quark_queue *qq)
 	u64		 now;
 	int		 n;
 
-	now = now64(qq);
+	now = now64();
 	n = 0;
 	while ((gc = TAILQ_FIRST(&qq->event_gc)) != NULL) {
 		if (AGE(gc->gc_time, now) < qq->cache_grace_time)
@@ -1575,7 +1573,7 @@ kube_read_events(struct quark_queue *qq)
 	 * hammering with one syscall per event.
 	 */
 	if (!qkube->try_read) {
-		if ((now64(qq) - qkube->last_read) >= (u64)MS_TO_NS(10))
+		if ((now64() - qkube->last_read) >= (u64)MS_TO_NS(10))
 			qkube->try_read = 1;
 		else
 			return;
@@ -1588,7 +1586,7 @@ kube_read_events(struct quark_queue *qq)
 		return;
 	}
 	n = qread(qkube->fd, qkube->buf + qkube->buf_w, left_towrite);
-	qkube->last_read = now64(qq);
+	qkube->last_read = now64();
 	qkube->try_read = 0;
 	if (n == -1) {
 		if (errno == EAGAIN)
@@ -1714,7 +1712,7 @@ kube_prime(struct quark_queue *qq)
 	pfd.events = POLLIN;
 
 	qwarnx("priming kube events...");
-	deadline = now64(qq) + (u64)MS_TO_NS(3000);
+	deadline = now64() + (u64)MS_TO_NS(3000);
 	do {
 		if ((r = poll(&pfd, 1, 25)) == -1) {
 			qwarn("poll");
@@ -1729,7 +1727,7 @@ kube_prime(struct quark_queue *qq)
 		 */
 		if (qkube->fd == -1)
 			break;
-	} while (now64(qq) < deadline);
+	} while (now64() < deadline);
 
 	/*
 	 * We must have received at least the node information.
@@ -3005,7 +3003,7 @@ sproc_pid_sockets(struct quark_queue *qq,
 			continue;
 
 		qsk = socket_alloc_and_insert(qq, &ss->socket.local,
-		    &ss->socket.remote, SOCK_CONN_SCRAPE, 0, 0, pid, now64(qq));
+		    &ss->socket.remote, SOCK_CONN_SCRAPE, 0, 0, pid, now64());
 		if (qsk == NULL) {
 			qwarn("socket_alloc");
 			continue;
@@ -4205,10 +4203,6 @@ quark_queue_open(struct quark_queue *qq, struct quark_queue_attr *qa)
 		qa->max_length = 1;
 	}
 
-	/* QQ_MONOTONIC is informational, not configuration */
-	if (qa->flags & QQ_MONOTONIC)
-		return (errno = EINVAL, -1);
-
 	/* Exactly one backend must be selected */
 	backends = qa->flags & (QQ_EBPF | QQ_KPROBE | QQ_NOVA);
 	if (backends != QQ_EBPF &&
@@ -4657,7 +4651,7 @@ quark_queue_pop_raw(struct quark_queue *qq)
 	struct raw_event	*min;
 	u64			 now;
 
-	now = now64(qq);
+	now = now64();
 	min = RB_MIN(raw_event_by_time, &qq->raw_event_by_time);
 	if (min == NULL || !raw_event_expired(qq, min, now)) {
 		/* qq->idle++; */

--- a/quark.c
+++ b/quark.c
@@ -311,7 +311,7 @@ now64(const struct quark_queue *qq)
 	if (clock_gettime(clk, &ts) == -1)
 		return (0);
 
-	return ((u64)ts.tv_sec * (u64)NS_PER_S + (u64)ts.tv_nsec);
+	return (TS_TO_NS(ts));
 }
 
 static inline u64

--- a/quark.h
+++ b/quark.h
@@ -227,6 +227,10 @@ int	quark_event_to_ecs(struct quark_queue *qq,
 #define MS_TO_NS(_x)	((u64)(_x) * NS_PER_MS)
 #endif /* MS_TO_NS */
 
+#ifndef TS_TO_NS
+#define TS_TO_NS(_ts) ((u64)(_ts).tv_sec * NS_PER_S + (u64)(_ts).tv_nsec)
+#endif /* TS_TO_NS */
+
 #ifndef NS_TO_S
 #define NS_TO_S(_x)	((u64)(_x) / NS_PER_S)
 #endif /* NS_TO_S */

--- a/quark.h
+++ b/quark.h
@@ -897,11 +897,6 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
-/*
- * Informational only, not configuration: if set, event times are
- * CLOCK_MONOTONIC, else CLOCK_BOOTTIME.
- */
-#define QQ_MONOTONIC		(1 << 15)
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -97,8 +97,11 @@ Informational, not configuration: specifying it fails with
 .Er EINVAL .
 The backend that opens sets it on the opened queue's
 .Em flags
-when its event times are CLOCK_MONOTONIC instead of CLOCK_BOOTTIME, which
-only the KPROBE backend does.
+when its event times are monotonic instead of CLOCK_BOOTTIME, which
+only the KPROBE backend does, and only on kernels older than 4.1,
+where a perf clock can not be selected.
+On newer kernels the KPROBE backend translates its CLOCK_MONOTONIC
+samples to CLOCK_BOOTTIME as they are read and the flag is not set.
 Monotonic times undercount by the total suspended time, users that care
 about suspend must compensate.
 See

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -92,21 +92,6 @@ Use the EBPF backend, this is the default of
 .Xr quark_queue_default_attr 3 .
 .It Dv QQ_KPROBE
 Use the KPROBE backend.
-.It Dv QQ_MONOTONIC
-Informational, not configuration: specifying it fails with
-.Er EINVAL .
-The backend that opens sets it on the opened queue's
-.Em flags
-when its event times are monotonic instead of CLOCK_BOOTTIME, which
-only the KPROBE backend does, and only on kernels older than 4.1,
-where a perf clock can not be selected.
-On newer kernels the KPROBE backend translates its CLOCK_MONOTONIC
-samples to CLOCK_BOOTTIME as they are read and the flag is not set.
-Monotonic times undercount by the total suspended time, users that care
-about suspend must compensate.
-See
-.Xr quark_time_to_wallclock 3
-for the effect on wallclock translation.
 .It Dv QQ_THREAD_EVENTS
 Include per-thread events, instead of per-process events.
 This option will be removed in the future, but it may be useful for debugging.

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -92,6 +92,13 @@ Use the EBPF backend, this is the default of
 .Xr quark_queue_default_attr 3 .
 .It Dv QQ_KPROBE
 Use the KPROBE backend.
+Event times are CLOCK_MONOTONIC samples translated to CLOCK_BOOTTIME,
+since perf can not stamp them with CLOCK_BOOTTIME directly.
+The translation is exact, with one exception: events stamped before a
+suspend but still unread when the host resumes are translated based on
+resume time and shift late by up to that suspend's duration.
+Only events in flight across the suspend are affected, hosts that
+never suspend are always exact.
 .It Dv QQ_THREAD_EVENTS
 Include per-thread events, instead of per-process events.
 This option will be removed in the future, but it may be useful for debugging.

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -44,7 +44,8 @@ if the clock may be stepped while running.
 Gradual corrections (slewing) adjust the wallclock and the boot clock
 at the same rate, leaving the epoch untouched, only a step moves it.
 .Pp
-The KPROBE backend stamps times with a monotonic clock that does not
+On kernels older than 4.1, where a perf clock can not be selected,
+the KPROBE backend stamps times with a monotonic clock that does not
 advance during suspend, relayed as
 .Dv QQ_MONOTONIC
 on the opened queue's

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -43,24 +43,6 @@ display or storage, and keep the epoch fresh with
 if the clock may be stepped while running.
 Gradual corrections (slewing) adjust the wallclock and the boot clock
 at the same rate, leaving the epoch untouched, only a step moves it.
-.Pp
-On kernels older than 4.1, where a perf clock can not be selected,
-the KPROBE backend stamps times with a monotonic clock that does not
-advance during suspend, relayed as
-.Dv QQ_MONOTONIC
-on the opened queue's
-.Em flags ,
-see
-.Xr quark_queue_open 3 .
-.Nm
-applies unchanged, but the result lags the wallclock by the total
-suspended time, exactly as it did before quark 0.8.
-Users that care about suspend can detect
-.Dv QQ_MONOTONIC
-and compensate with the difference between
-.Dv CLOCK_BOOTTIME
-and
-.Dv CLOCK_MONOTONIC .
 .Sh RETURN VALUES
 .Fa time_since_boot
 expressed in nanoseconds since the Unix epoch.

--- a/quark_time_to_wallclock.3
+++ b/quark_time_to_wallclock.3
@@ -43,6 +43,10 @@ display or storage, and keep the epoch fresh with
 if the clock may be stepped while running.
 Gradual corrections (slewing) adjust the wallclock and the boot clock
 at the same rate, leaving the epoch untouched, only a step moves it.
+.Pp
+On the KPROBE backend, events in flight across a suspend may carry a
+time shifted late by up to that suspend's duration, see
+.Xr quark_queue_open 3 .
 .Sh RETURN VALUES
 .Fa time_since_boot
 expressed in nanoseconds since the Unix epoch.


### PR DESCRIPTION
### Summary

The kprobe timestamps are currently always monotonic and do not include system suspend time (unlike the timestamps from the other backends, which are also monotonic but do include system suspend time). 

On kernels 4.1+ or kernels that have backported perf clockid, we can do better and have quark translate MONOTONIC to BOOTTIME internally. This matches the timestamps of the other backends. Roughly-monotonic timestamps are now dropped completely as we don't need to support any targets where perf clockid isn't available.

e4e6074a469b181819003835af68e83580fd3974 introduces a breaking API change with the drop of `QQ_MONOTONIC` which isn't needed any more.

@nicholasberlin noticed that we didn't have any RHEL7 kernel tests. This PR adds passing and a single failing test for RHEL7 kernels covering all three cases:

1. Pre-7.4 (negative test, checks for clean failure)
2. 7.4 (lowest supported RHEL7 kernel)
3. 7.9 (latest RHEL7 version)
