### PR TITLE
Fix/probes ebpf ringbuf write zero init

### DIFF
--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -80,16 +80,20 @@ static int inet_csk_accept__exit(struct sock *sk)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event event = {};
-
-    if (ebpf_network_event__fill(&event, sk))
+    struct ebpf_net_event *event = get_event_buffer();
+    if (!event)
         goto out;
-    // Record this socket so we can emit a close
-    u32 tgid = event.pids.tgid;
-    (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
+    __builtin_memset(event, 0, sizeof(*event));
 
-    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED;
-    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+    if (ebpf_network_event__fill(event, sk))
+        goto out;
+
+    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED;
+    if (ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0) == 0) {
+        // Record this socket so we can emit a close
+        u32 tgid = event->pids.tgid;
+        (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
+    }
 
 out:
     return 0;
@@ -127,17 +131,20 @@ static int tcp_connect(struct sock *sk, int ret)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event event = {};
+    struct ebpf_net_event *event = get_event_buffer();
+    if (!event)
+        goto out;
+    __builtin_memset(event, 0, sizeof(*event));
 
-    if (ebpf_network_event__fill(&event, sk))
+    if (ebpf_network_event__fill(event, sk))
         goto out;
 
-    // Record this socket so we can emit a close
-    u32 tgid = event.pids.tgid;
-    (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
-
-    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED;
-    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED;
+    if (ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0) == 0) {
+        // Record this socket so we can emit a close
+        u32 tgid = event->pids.tgid;
+        (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
+    }
 
 out:
     return 0;
@@ -252,16 +259,19 @@ static int tcp_close__enter(struct sock *sk)
     if (bpf_map_delete_elem(&sk_to_tgid, &sk) != 0 && bytes_sent == 0 && bytes_received == 0)
         goto out;
 
-    struct ebpf_net_event event = {};
+    struct ebpf_net_event *event = get_event_buffer();
+    if (!event)
+        goto out;
+    __builtin_memset(event, 0, sizeof(*event));
 
-    if (ebpf_network_event__fill(&event, sk))
+    if (ebpf_network_event__fill(event, sk))
         goto out;
 
-    event.net.tcp.close.bytes_sent     = bytes_sent;
-    event.net.tcp.close.bytes_received = bytes_received;
+    event->net.tcp.close.bytes_sent     = bytes_sent;
+    event->net.tcp.close.bytes_received = bytes_received;
 
-    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_CLOSED;
-    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_CLOSED;
+    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
 
 out:
     return 0;

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -80,7 +80,7 @@ static int inet_csk_accept__exit(struct sock *sk)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event event;
+    struct ebpf_net_event event = {};
 
     if (ebpf_network_event__fill(&event, sk))
         goto out;
@@ -127,7 +127,7 @@ static int tcp_connect(struct sock *sk, int ret)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event event;
+    struct ebpf_net_event event = {};
 
     if (ebpf_network_event__fill(&event, sk))
         goto out;
@@ -252,7 +252,7 @@ static int tcp_close__enter(struct sock *sk)
     if (bpf_map_delete_elem(&sk_to_tgid, &sk) != 0 && bytes_sent == 0 && bytes_received == 0)
         goto out;
 
-    struct ebpf_net_event event;
+    struct ebpf_net_event event = {};
 
     if (ebpf_network_event__fill(&event, sk))
         goto out;

--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -80,20 +80,16 @@ static int inet_csk_accept__exit(struct sock *sk)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
-        goto out;
+    struct ebpf_net_event event;
 
-    if (ebpf_network_event__fill(event, sk)) {
-        bpf_ringbuf_discard(event, 0);
+    if (ebpf_network_event__fill(&event, sk))
         goto out;
-    }
     // Record this socket so we can emit a close
-    u32 tgid = event->pids.tgid;
+    u32 tgid = event.pids.tgid;
     (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
 
-    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED;
-    bpf_ringbuf_submit(event, 0);
+    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ACCEPTED;
+    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
 
 out:
     return 0;
@@ -131,21 +127,17 @@ static int tcp_connect(struct sock *sk, int ret)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
-        goto out;
+    struct ebpf_net_event event;
 
-    if (ebpf_network_event__fill(event, sk)) {
-        bpf_ringbuf_discard(event, 0);
+    if (ebpf_network_event__fill(&event, sk))
         goto out;
-    }
 
     // Record this socket so we can emit a close
-    u32 tgid = event->pids.tgid;
+    u32 tgid = event.pids.tgid;
     (void)bpf_map_update_elem(&sk_to_tgid, &sk, &tgid, BPF_ANY);
 
-    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED;
-    bpf_ringbuf_submit(event, 0);
+    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_ATTEMPTED;
+    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
 
 out:
     return 0;
@@ -260,20 +252,16 @@ static int tcp_close__enter(struct sock *sk)
     if (bpf_map_delete_elem(&sk_to_tgid, &sk) != 0 && bytes_sent == 0 && bytes_received == 0)
         goto out;
 
-    struct ebpf_net_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
+    struct ebpf_net_event event;
+
+    if (ebpf_network_event__fill(&event, sk))
         goto out;
 
-    if (ebpf_network_event__fill(event, sk)) {
-        bpf_ringbuf_discard(event, 0);
-        goto out;
-    }
+    event.net.tcp.close.bytes_sent     = bytes_sent;
+    event.net.tcp.close.bytes_received = bytes_received;
 
-    event->net.tcp.close.bytes_sent     = bytes_sent;
-    event->net.tcp.close.bytes_received = bytes_received;
-
-    event->hdr.type = EBPF_EVENT_NETWORK_CONNECTION_CLOSED;
-    bpf_ringbuf_submit(event, 0);
+    event.hdr.type = EBPF_EVENT_NETWORK_CONNECTION_CLOSED;
+    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
 
 out:
     return 0;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -398,19 +398,22 @@ static int ptrace_event(struct task_struct *child,
     if (child_tgid == curr_tgid)
         goto out;
 
-    struct ebpf_process_ptrace_event event = {};
+    struct ebpf_process_ptrace_event *event = get_event_buffer();
+    if (!event)
+        goto out;
+    __builtin_memset(event, 0, sizeof(*event));
 
-    event.hdr.type    = EBPF_EVENT_PROCESS_PTRACE;
-    event.hdr.ts      = bpf_ktime_get_boot_ns();
+    event->hdr.type = EBPF_EVENT_PROCESS_PTRACE;
+    event->hdr.ts   = bpf_ktime_get_boot_ns();
 
-    ebpf_pid_info__fill(&event.pids, task);
+    ebpf_pid_info__fill(&event->pids, task);
 
-    event.child_pid = child_tgid;
-    event.request   = request;
-    event.addr      = addr;
-    event.data      = data;
+    event->child_pid = child_tgid;
+    event->request   = request;
+    event->addr      = addr;
+    event->data      = data;
 
-    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
 
 out:
     return 0;
@@ -471,17 +474,20 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
     if (is_kernel_thread(task))
         goto out;
 
-    struct ebpf_process_shmget_event event = {};
+    struct ebpf_process_shmget_event *event = get_event_buffer();
+    if (!event)
+        goto out;
+    __builtin_memset(event, 0, sizeof(*event));
 
-    event.hdr.type    = EBPF_EVENT_PROCESS_SHMGET;
-    event.hdr.ts      = bpf_ktime_get_boot_ns();
-    ebpf_pid_info__fill(&event.pids, task);
+    event->hdr.type = EBPF_EVENT_PROCESS_SHMGET;
+    event->hdr.ts   = bpf_ktime_get_boot_ns();
+    ebpf_pid_info__fill(&event->pids, task);
 
-    event.key    = ex_args->key;
-    event.size   = ex_args->size;
-    event.shmflg = ex_args->shmflg;
+    event->key    = ex_args->key;
+    event->size   = ex_args->size;
+    event->shmflg = ex_args->shmflg;
 
-    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
 out:
     preempt_enable();
     return 0;
@@ -614,23 +620,26 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, suid.val) != BPF_CORE_READ(old, suid.val) ||
         BPF_CORE_READ(new, fsuid.val) != BPF_CORE_READ(old, fsuid.val)) {
 
-        struct ebpf_process_setuid_event event = {};
+        struct ebpf_process_setuid_event *event = get_event_buffer();
+        if (!event)
+            return 0;
+        __builtin_memset(event, 0, sizeof(*event));
 
-        event.hdr.type    = EBPF_EVENT_PROCESS_SETUID;
-        event.hdr.ts      = bpf_ktime_get_boot_ns();
+        event->hdr.type = EBPF_EVENT_PROCESS_SETUID;
+        event->hdr.ts   = bpf_ktime_get_boot_ns();
 
-        ebpf_pid_info__fill(&event.pids, task);
-        ebpf_cred_info__fill(&event.creds, task);
-        ebpf_ctty__fill(&event.ctty, task);
-        ebpf_comm__fill(event.comm, sizeof(event.comm), task);
-        ebpf_ns__fill(&event.ns, task);
+        ebpf_pid_info__fill(&event->pids, task);
+        ebpf_cred_info__fill(&event->creds, task);
+        ebpf_ctty__fill(&event->ctty, task);
+        ebpf_comm__fill(event->comm, sizeof(event->comm), task);
+        ebpf_ns__fill(&event->ns, task);
 
-        event.new_ruid = BPF_CORE_READ(new, uid.val);
-        event.new_euid = BPF_CORE_READ(new, euid.val);
-        event.new_rgid = BPF_CORE_READ(new, gid.val);
-        event.new_egid = BPF_CORE_READ(new, egid.val);
+        event->new_ruid = BPF_CORE_READ(new, uid.val);
+        event->new_euid = BPF_CORE_READ(new, euid.val);
+        event->new_rgid = BPF_CORE_READ(new, gid.val);
+        event->new_egid = BPF_CORE_READ(new, egid.val);
 
-        ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+        ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
     }
 
     if (BPF_CORE_READ(new, gid.val) != BPF_CORE_READ(old, gid.val) ||
@@ -638,26 +647,28 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, sgid.val) != BPF_CORE_READ(old, sgid.val) ||
         BPF_CORE_READ(new, fsgid.val) != BPF_CORE_READ(old, fsgid.val)) {
 
-        struct ebpf_process_setgid_event event = {};
+        struct ebpf_process_setgid_event *event = get_event_buffer();
+        if (!event)
+            return 0;
+        __builtin_memset(event, 0, sizeof(*event));
 
-        event.hdr.type    = EBPF_EVENT_PROCESS_SETGID;
-        event.hdr.ts      = bpf_ktime_get_boot_ns();
+        event->hdr.type = EBPF_EVENT_PROCESS_SETGID;
+        event->hdr.ts   = bpf_ktime_get_boot_ns();
 
-        ebpf_pid_info__fill(&event.pids, task);
-        ebpf_cred_info__fill(&event.creds, task);
-        ebpf_ctty__fill(&event.ctty, task);
-        ebpf_comm__fill(event.comm, sizeof(event.comm), task);
-        ebpf_ns__fill(&event.ns, task);
+        ebpf_pid_info__fill(&event->pids, task);
+        ebpf_cred_info__fill(&event->creds, task);
+        ebpf_ctty__fill(&event->ctty, task);
+        ebpf_comm__fill(event->comm, sizeof(event->comm), task);
+        ebpf_ns__fill(&event->ns, task);
 
-        event.new_rgid = BPF_CORE_READ(new, gid.val);
-        event.new_egid = BPF_CORE_READ(new, egid.val);
-        event.new_ruid = BPF_CORE_READ(new, uid.val);
-        event.new_euid = BPF_CORE_READ(new, euid.val);
+        event->new_rgid = BPF_CORE_READ(new, gid.val);
+        event->new_egid = BPF_CORE_READ(new, egid.val);
+        event->new_ruid = BPF_CORE_READ(new, uid.val);
+        event->new_euid = BPF_CORE_READ(new, euid.val);
 
-        ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
+        ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
     }
 
-out:
     return 0;
 }
 

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -398,7 +398,7 @@ static int ptrace_event(struct task_struct *child,
     if (child_tgid == curr_tgid)
         goto out;
 
-    struct ebpf_process_ptrace_event event;
+    struct ebpf_process_ptrace_event event = {};
 
     event.hdr.type    = EBPF_EVENT_PROCESS_PTRACE;
     event.hdr.ts      = bpf_ktime_get_boot_ns();
@@ -471,7 +471,7 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
     if (is_kernel_thread(task))
         goto out;
 
-    struct ebpf_process_shmget_event event;
+    struct ebpf_process_shmget_event event = {};
 
     event.hdr.type    = EBPF_EVENT_PROCESS_SHMGET;
     event.hdr.ts      = bpf_ktime_get_boot_ns();
@@ -614,7 +614,7 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, suid.val) != BPF_CORE_READ(old, suid.val) ||
         BPF_CORE_READ(new, fsuid.val) != BPF_CORE_READ(old, fsuid.val)) {
 
-        struct ebpf_process_setuid_event event;
+        struct ebpf_process_setuid_event event = {};
 
         event.hdr.type    = EBPF_EVENT_PROCESS_SETUID;
         event.hdr.ts      = bpf_ktime_get_boot_ns();
@@ -638,7 +638,7 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, sgid.val) != BPF_CORE_READ(old, sgid.val) ||
         BPF_CORE_READ(new, fsgid.val) != BPF_CORE_READ(old, fsgid.val)) {
 
-        struct ebpf_process_setgid_event event;
+        struct ebpf_process_setgid_event event = {};
 
         event.hdr.type    = EBPF_EVENT_PROCESS_SETGID;
         event.hdr.ts      = bpf_ktime_get_boot_ns();

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -398,21 +398,19 @@ static int ptrace_event(struct task_struct *child,
     if (child_tgid == curr_tgid)
         goto out;
 
-    struct ebpf_process_ptrace_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
-        goto out;
+    struct ebpf_process_ptrace_event event;
 
-    event->hdr.type    = EBPF_EVENT_PROCESS_PTRACE;
-    event->hdr.ts      = bpf_ktime_get_boot_ns();
+    event.hdr.type    = EBPF_EVENT_PROCESS_PTRACE;
+    event.hdr.ts      = bpf_ktime_get_boot_ns();
 
-    ebpf_pid_info__fill(&event->pids, task);
+    ebpf_pid_info__fill(&event.pids, task);
 
-    event->child_pid = child_tgid;
-    event->request   = request;
-    event->addr      = addr;
-    event->data      = data;
+    event.child_pid = child_tgid;
+    event.request   = request;
+    event.addr      = addr;
+    event.data      = data;
 
-    bpf_ringbuf_submit(event, 0);
+    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
 
 out:
     return 0;
@@ -473,19 +471,17 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
     if (is_kernel_thread(task))
         goto out;
 
-    struct ebpf_process_shmget_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
-        goto out;
+    struct ebpf_process_shmget_event event;
 
-    event->hdr.type    = EBPF_EVENT_PROCESS_SHMGET;
-    event->hdr.ts      = bpf_ktime_get_boot_ns();
-    ebpf_pid_info__fill(&event->pids, task);
+    event.hdr.type    = EBPF_EVENT_PROCESS_SHMGET;
+    event.hdr.ts      = bpf_ktime_get_boot_ns();
+    ebpf_pid_info__fill(&event.pids, task);
 
-    event->key    = ex_args->key;
-    event->size   = ex_args->size;
-    event->shmflg = ex_args->shmflg;
+    event.key    = ex_args->key;
+    event.size   = ex_args->size;
+    event.shmflg = ex_args->shmflg;
 
-    bpf_ringbuf_submit(event, 0);
+    ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
 out:
     preempt_enable();
     return 0;
@@ -618,28 +614,23 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, suid.val) != BPF_CORE_READ(old, suid.val) ||
         BPF_CORE_READ(new, fsuid.val) != BPF_CORE_READ(old, fsuid.val)) {
 
-        struct ebpf_process_setuid_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-        if (!event)
-            goto out;
+        struct ebpf_process_setuid_event event;
 
-        event->hdr.type    = EBPF_EVENT_PROCESS_SETUID;
-        event->hdr.ts      = bpf_ktime_get_boot_ns();
+        event.hdr.type    = EBPF_EVENT_PROCESS_SETUID;
+        event.hdr.ts      = bpf_ktime_get_boot_ns();
 
-        ebpf_pid_info__fill(&event->pids, task);
-        ebpf_cred_info__fill(&event->creds, task);
-        ebpf_ctty__fill(&event->ctty, task);
-        ebpf_comm__fill(event->comm, sizeof(event->comm), task);
-        ebpf_ns__fill(&event->ns, task);
+        ebpf_pid_info__fill(&event.pids, task);
+        ebpf_cred_info__fill(&event.creds, task);
+        ebpf_ctty__fill(&event.ctty, task);
+        ebpf_comm__fill(event.comm, sizeof(event.comm), task);
+        ebpf_ns__fill(&event.ns, task);
 
-        // The legacy kprobe/tracefs implementation reports the gid even if
-        // this is a UID change and vice-versa, so we have new_[r,e]gid fields
-        // in a uid change event and vice-versa
-        event->new_ruid = BPF_CORE_READ(new, uid.val);
-        event->new_euid = BPF_CORE_READ(new, euid.val);
-        event->new_rgid = BPF_CORE_READ(new, gid.val);
-        event->new_egid = BPF_CORE_READ(new, egid.val);
+        event.new_ruid = BPF_CORE_READ(new, uid.val);
+        event.new_euid = BPF_CORE_READ(new, euid.val);
+        event.new_rgid = BPF_CORE_READ(new, gid.val);
+        event.new_egid = BPF_CORE_READ(new, egid.val);
 
-        bpf_ringbuf_submit(event, 0);
+        ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
     }
 
     if (BPF_CORE_READ(new, gid.val) != BPF_CORE_READ(old, gid.val) ||
@@ -647,25 +638,23 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, sgid.val) != BPF_CORE_READ(old, sgid.val) ||
         BPF_CORE_READ(new, fsgid.val) != BPF_CORE_READ(old, fsgid.val)) {
 
-        struct ebpf_process_setgid_event *event = bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-        if (!event)
-            goto out;
+        struct ebpf_process_setgid_event event;
 
-        event->hdr.type    = EBPF_EVENT_PROCESS_SETGID;
-        event->hdr.ts      = bpf_ktime_get_boot_ns();
+        event.hdr.type    = EBPF_EVENT_PROCESS_SETGID;
+        event.hdr.ts      = bpf_ktime_get_boot_ns();
 
-        ebpf_pid_info__fill(&event->pids, task);
-        ebpf_cred_info__fill(&event->creds, task);
-        ebpf_ctty__fill(&event->ctty, task);
-        ebpf_comm__fill(event->comm, sizeof(event->comm), task);
-        ebpf_ns__fill(&event->ns, task);
+        ebpf_pid_info__fill(&event.pids, task);
+        ebpf_cred_info__fill(&event.creds, task);
+        ebpf_ctty__fill(&event.ctty, task);
+        ebpf_comm__fill(event.comm, sizeof(event.comm), task);
+        ebpf_ns__fill(&event.ns, task);
 
-        event->new_rgid = BPF_CORE_READ(new, gid.val);
-        event->new_egid = BPF_CORE_READ(new, egid.val);
-        event->new_ruid = BPF_CORE_READ(new, uid.val);
-        event->new_euid = BPF_CORE_READ(new, euid.val);
+        event.new_rgid = BPF_CORE_READ(new, gid.val);
+        event.new_egid = BPF_CORE_READ(new, egid.val);
+        event.new_ruid = BPF_CORE_READ(new, uid.val);
+        event.new_euid = BPF_CORE_READ(new, euid.val);
 
-        bpf_ringbuf_submit(event, 0);
+        ebpf_ringbuf_write(&ringbuf, &event, sizeof(event), 0);
     }
 
 out:


### PR DESCRIPTION
Several fixed-size network and process probe paths still called `bpf_ringbuf_reserve`/`bpf_ringbuf_submit` directly, which bypasses the lost-event accounting in `ebpf_ringbuf_write`.

This switches those paths to stack-allocated events plus `ebpf_ringbuf_write`.

Also, zeroes stack variables.

Fixes #288

## Test plan
- [x] Build/load the updated probes on a test host
- [x] Confirm network/process events still arrive and ring buffer stats look sane under load