### PR TITLE
Executable mprotect events via LSM hook, deduplicated per process life

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -178,3 +178,10 @@ Changes from 0.8 to 0.9
     previous/requested/effective protection and backing-file identity. These
     events cover mprotect(), pkey_mprotect(), and compat callers, but do not
     assert that the protection change ultimately succeeded.
+    Only the first occurrence of each protection transition (previous
+    protection, effective protection, file-backedness) is reported per process
+    life; the state resets on execve() and process exit. File-backed attempts
+    additionally carry the mount-namespace relative path in
+    quark_mprotect.path, NULL for anonymous mappings.
+  o quark_queue_stats{} got a quark_mprotect_stats member (submitted,
+    suppressed, reserve_failed), also shown by quark-mon -M.

--- a/CHANGES
+++ b/CHANGES
@@ -172,3 +172,9 @@ Changes from 0.8 to 0.9
     CLOCK_BOOTTIME. This effectively drops support for kernels without perf
     clockid support (< 4.1 or RHEL before 7.4).
   o quark_queue_stats{} got a "stalls" member.
+  o Added executable mprotect() attempt events (QUARK_EV_MPROTECT, -u on
+    quark-mon). The eBPF probe reports each VMA that reaches the
+    security_file_mprotect() check with effective execute permission, including
+    previous/requested/effective protection and backing-file identity. These
+    events cover mprotect(), pkey_mprotect(), and compat callers, but do not
+    assert that the protection change ultimately succeeded.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -630,6 +630,20 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		qmprotect->dev_major = mprotect->dev_major;
 		qmprotect->dev_minor = mprotect->dev_minor;
 		qmprotect->file_backed = mprotect->file_backed;
+		qmprotect->path = NULL;
+
+		FOR_EACH_VARLEN_FIELD(mprotect->vl_fields, field) {
+			switch (field->type) {
+			case EBPF_VL_FIELD_PATH:
+				if (field->size > 0)
+					qmprotect->path =
+					    strndup(field->data, field->size);
+				break;
+			default:
+				qwarnx("unhandled field type %d", field->type);
+				break;
+			}
+		}
 
 		break;
 	}
@@ -1440,11 +1454,12 @@ bpf_queue_populate(struct quark_queue *qq)
 static int
 bpf_queue_update_stats(struct quark_queue *qq)
 {
-	struct bpf_queue	*bqq  = qq->queue_be;
-	struct ebpf_event_stats	*pcpu_ees;
-	u32			 zero = 0;
-	u64			 lost;
-	int			 i, num_cpus;
+	struct bpf_queue			*bqq  = qq->queue_be;
+	struct ebpf_event_stats		*pcpu_ees = NULL;
+	struct ebpf_mprotect_stats	*pcpu_mps = NULL;
+	u32				 zero = 0;
+	u64				 lost;
+	int				 i, num_cpus;
 
 	if ((num_cpus = libbpf_num_possible_cpus()) <= 0) {
 		qwarnx("bad libbpf_num_possible_cpus: %d", num_cpus);
@@ -1470,11 +1485,40 @@ bpf_queue_update_stats(struct quark_queue *qq)
 		lost += pcpu_ees[i].lost;
 	qq->stats.lost = lost;
 	free(pcpu_ees);
+	pcpu_ees = NULL;
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return (0);
+
+	if ((pcpu_mps = calloc(num_cpus, sizeof(*pcpu_mps))) == NULL) {
+		qwarn("calloc");
+		goto fail;
+	}
+
+#ifdef HAVE_STATIC_ASSERT
+	static_assert(sizeof(*pcpu_mps) % 8 == 0,
+	    "struct ebpf_mprotect_stats must be 8 byte aligned");
+#endif
+
+	if (bpf_map__lookup_elem(bqq->probes->maps.mprotect_stats, &zero,
+	    sizeof(zero), pcpu_mps, sizeof(*pcpu_mps) * num_cpus, 0) != 0) {
+		qwarn("bpf_map__lookup_elem");
+		goto fail;
+	}
+
+	bzero(&qq->stats.mprotect, sizeof(qq->stats.mprotect));
+	for (i = 0; i < num_cpus; i++) {
+		qq->stats.mprotect.submitted += pcpu_mps[i].submitted;
+		qq->stats.mprotect.suppressed += pcpu_mps[i].suppressed;
+		qq->stats.mprotect.reserve_failed += pcpu_mps[i].reserve_failed;
+	}
+	free(pcpu_mps);
 
 	return (0);
 
 fail:
 	free(pcpu_ees);
+	free(pcpu_mps);
 
 	return (-1);
 }

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -609,6 +609,30 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 
 		break;
 	}
+	case EBPF_EVENT_PROCESS_MPROTECT: {
+		struct ebpf_process_mprotect_event *mprotect;
+		struct quark_mprotect *qmprotect;
+
+		mprotect = (struct ebpf_process_mprotect_event *)ev;
+		if ((raw = raw_event_alloc(RAW_MPROTECT)) == NULL)
+			goto bad;
+
+		raw->pid = mprotect->pids.tgid;
+		raw->time = ev->ts;
+
+		qmprotect = &raw->mprotect.quark_mprotect;
+		qmprotect->vma_start = mprotect->vma_start;
+		qmprotect->vma_end = mprotect->vma_end;
+		qmprotect->prev_prot = mprotect->prev_prot;
+		qmprotect->req_prot = mprotect->req_prot;
+		qmprotect->effective_prot = mprotect->effective_prot;
+		qmprotect->inode = mprotect->inode;
+		qmprotect->dev_major = mprotect->dev_major;
+		qmprotect->dev_minor = mprotect->dev_minor;
+		qmprotect->file_backed = mprotect->file_backed;
+
+		break;
+	}
 	case EBPF_EVENT_PROCESS_LOAD_MODULE: {
 		struct ebpf_process_load_module_event *module;
 		struct quark_module_load	*qml;
@@ -1282,6 +1306,15 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 
 	if (qq->flags & QQ_MODULE_LOAD)
 		bpf_program__set_autoload(p->progs.module_load, 1);
+
+	if (qq->flags & QQ_MPROTECT) {
+		if (use_fentry)
+			bpf_program__set_autoload(
+			    p->progs.fentry__security_file_mprotect, 1);
+		else
+			bpf_program__set_autoload(
+			    p->progs.kprobe__security_file_mprotect, 1);
+	}
 
 	if (qq->flags & QQ_GETPID)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -393,6 +393,9 @@ struct ebpf_process_mprotect_event {
     uint32_t dev_major;
     uint32_t dev_minor;
     uint32_t file_backed;
+
+    // Variable length fields: path (only present when file_backed)
+    struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
 enum ebpf_net_info_transport {
@@ -460,6 +463,14 @@ struct ebpf_event_stats {
     uint64_t lost;          // lost events due to a full ringbuffer
     uint64_t sent;          // events sent through the ringbuffer
     uint64_t dns_zero_body; // indicates that the dns body of a sk_buff was unavailable
+} __attribute__((aligned(8)));
+
+// Executable mprotect attempt accounting.
+struct ebpf_mprotect_stats {
+    uint64_t submitted;      // events written to the ring buffer
+    uint64_t suppressed;     // attempts deduplicated (transition already
+                             // reported for this process life)
+    uint64_t reserve_failed; // event buffer/ring buffer write failures
 } __attribute__((aligned(8)));
 
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -46,6 +46,7 @@ enum ebpf_event_type {
     EBPF_EVENT_PROCESS_LOAD_MODULE          = (1 << 19),
     EBPF_EVENT_NETWORK_DNS_PKT              = (1 << 20),
     EBPF_EVENT_PROCESS_GETPID               = (1 << 21),
+    EBPF_EVENT_PROCESS_MPROTECT             = (1 << 22),
 };
 
 struct ebpf_event_header {
@@ -378,6 +379,20 @@ struct ebpf_process_load_module_event {
     uint64_t taints;
     // Variable length fields: filename, mod version, mod srcversion
     struct ebpf_varlen_fields_start vl_fields;
+} __attribute__((packed));
+
+struct ebpf_process_mprotect_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    uint64_t vma_start;
+    uint64_t vma_end;
+    uint64_t prev_prot;
+    uint64_t req_prot;
+    uint64_t effective_prot;
+    uint64_t inode;
+    uint32_t dev_major;
+    uint32_t dev_minor;
+    uint32_t file_backed;
 } __attribute__((packed));
 
 enum ebpf_net_info_transport {

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -568,9 +568,12 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     u64  dedup_key   = mprotect_seen__key(tgid, prev_prot,
                                           effective_prot, file_backed);
     u8   dedup_val   = 1;
-    // Compare in 32 bits: before Linux 5.9 (bdb7b79b4ce8) map helpers were
-    // declared to return int, and the JIT zero-extends the 32-bit result, so
-    // a 64-bit compare against -EEXIST never matches on older kernels.
+    // Compare in 32 bits: with the JIT enabled, the verifier rewrites map
+    // helper calls into direct calls to the map ops (fixup_bpf_calls), and
+    // those returned int until Linux 6.4 (d7ba4cc900bf), leaving a
+    // zero-extended 32-bit value in r0 on older kernels. A 64-bit compare
+    // against -EEXIST never matches there. Ordinary helpers return through a
+    // u64 wrapper and are sign-extended correctly; only map helpers need this.
     if ((int)bpf_map_update_elem(&mprotect_seen, &dedup_key, &dedup_val,
                                  BPF_NOEXIST) == -EEXIST) {
         if (stats)

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -36,6 +36,51 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define MPROTECT_MINORBITS 20
 #define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
 
+#ifndef EEXIST
+#define EEXIST 17 /* uapi asm-generic/errno-base.h; not carried by vmlinux.h */
+#endif
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, struct ebpf_mprotect_stats);
+    __uint(max_entries, 1);
+} mprotect_stats SEC(".maps");
+
+/*
+ * One mprotect event per (transition, file-backedness) per process life.
+ * Key is tgid << 8 | transition id; the transition id packs the previous
+ * protection (3 bits), the effective new protection (3 bits) and whether the
+ * mapping is file backed (1 bit), so at most 128 entries per process. Entries
+ * are cleared when the process execs or dies (each program image starts
+ * fresh); LRU eviction is a safe backstop since an evicted entry only causes
+ * a duplicate event, never a lost one.
+ */
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);
+    __type(value, u8);
+    __uint(max_entries, 65536);
+} mprotect_seen SEC(".maps");
+
+#define MPROTECT_TRANSITION_MAX 128
+
+static u64 mprotect_seen__key(u32 tgid, u64 prev_prot, u64 effective_prot, u64 file_backed)
+{
+    u64 id = ((prev_prot & 0x7) << 4) | ((effective_prot & 0x7) << 1) | (file_backed & 0x1);
+    return ((u64)tgid << 8) | id;
+}
+
+static void mprotect_seen__clear(u32 tgid)
+{
+    u64 base = (u64)tgid << 8;
+
+    for (u32 i = 0; i < MPROTECT_TRANSITION_MAX; i++) {
+        u64 key = base | i;
+        bpf_map_delete_elem(&mprotect_seen, &key);
+    }
+}
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -103,6 +148,10 @@ int BPF_PROG(sched_process_exec,
     // exec is valid and something we want to capture
     if (is_kernel_thread(task))
         goto out;
+
+    // The address space is replaced on exec; reported mprotect transitions
+    // belong to the previous program image, so start fresh.
+    mprotect_seen__clear(BPF_CORE_READ(task, tgid));
 
     struct ebpf_process_exec_event *event = get_event_buffer();
     if (!event)
@@ -214,6 +263,11 @@ static int disassociate_ctty__enter(int on_exit)
 
     if (!on_exit || is_kernel_thread(task))
         return 0;
+
+    // do_exit calls disassociate_ctty(1) only when the whole thread group is
+    // dead, so this runs exactly once per process; drop its dedup state so a
+    // recycled tgid does not inherit (and suppress) old transitions.
+    mprotect_seen__clear(BPF_CORE_READ(task, tgid));
 
     event = get_event_buffer();
     if (event == NULL)
@@ -486,6 +540,9 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
                                          unsigned long req_prot,
                                          unsigned long effective_prot)
 {
+    u32 zero = 0;
+    struct ebpf_mprotect_stats *stats = bpf_map_lookup_elem(&mprotect_stats, &zero);
+
     if (ebpf_events_is_trusted_pid() || !vma)
         goto out;
 
@@ -497,19 +554,44 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     if (!(effective_prot & MPROTECT_PROT_EXEC))
         goto out;
 
-    struct ebpf_process_mprotect_event *event =
-        bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
-    if (!event)
+    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
+    u64 prev_prot          = mprotect_vm_flags_to_prot(vm_flags);
+    struct file *file      = BPF_CORE_READ(vma, vm_file);
+
+    // One event per (transition, file-backedness) per process life: claim the
+    // dedup slot first. BPF_NOEXIST resolves races between threads of the
+    // same process doing the same transition; exactly one claim wins. Only a
+    // confirmed "already reported" suppresses -- any other failure emits, so
+    // the failure mode is a duplicate event, never a lost one.
+    u64  tgid        = bpf_get_current_pid_tgid() >> 32;
+    u64  file_backed = file != NULL;
+    u64  dedup_key   = mprotect_seen__key(tgid, prev_prot,
+                                          effective_prot, file_backed);
+    u8   dedup_val   = 1;
+    // Compare in 32 bits: before Linux 5.9 (bdb7b79b4ce8) map helpers were
+    // declared to return int, and the JIT zero-extends the 32-bit result, so
+    // a 64-bit compare against -EEXIST never matches on older kernels.
+    if ((int)bpf_map_update_elem(&mprotect_seen, &dedup_key, &dedup_val,
+                                 BPF_NOEXIST) == -EEXIST) {
+        if (stats)
+            stats->suppressed++;
         goto out;
+    }
+
+    struct ebpf_process_mprotect_event *event = get_event_buffer();
+    if (!event) {
+        if (stats)
+            stats->reserve_failed++;
+        goto out;
+    }
 
     event->hdr.type = EBPF_EVENT_PROCESS_MPROTECT;
     event->hdr.ts   = bpf_ktime_get_boot_ns();
     ebpf_pid_info__fill(&event->pids, task);
 
-    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
     event->vma_start       = BPF_CORE_READ(vma, vm_start);
     event->vma_end         = BPF_CORE_READ(vma, vm_end);
-    event->prev_prot       = mprotect_vm_flags_to_prot(vm_flags);
+    event->prev_prot       = prev_prot;
     event->req_prot        = req_prot;
     event->effective_prot  = effective_prot;
     event->file_backed     = 0;
@@ -517,7 +599,8 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     event->dev_major       = 0;
     event->dev_minor       = 0;
 
-    struct file *file = BPF_CORE_READ(vma, vm_file);
+    ebpf_vl_fields__init(&event->vl_fields);
+
     if (file) {
         event->file_backed = 1;
 
@@ -532,9 +615,22 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
                 event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
             }
         }
+
+        // File-backed executable transitions are rare and high signal
+        // (library tampering, packers, memfd JITs); annotate them with the
+        // mount-namespace-relative path. Anonymous memory has no path.
+        struct ebpf_varlen_field *field =
+            ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PATH);
+        struct path p = BPF_CORE_READ(file, f_path);
+        long size     = ebpf_resolve_path_to_string(field->data, &p, task);
+        ebpf_vl_field__set_size(&event->vl_fields, field, size);
     }
 
-    bpf_ringbuf_submit(event, 0);
+    if (ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0) == 0) {
+        if (stats)
+            stats->submitted++;
+    } else if (stats)
+        stats->reserve_failed++;
 
 out:
     return 0;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -25,6 +25,17 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define S_ISUID 0004000
 #define S_ISGID 0002000
 
+#define MPROTECT_PROT_READ  0x1
+#define MPROTECT_PROT_WRITE 0x2
+#define MPROTECT_PROT_EXEC  0x4
+
+#define MPROTECT_VM_READ  (1UL << 0)
+#define MPROTECT_VM_WRITE (1UL << 1)
+#define MPROTECT_VM_EXEC  (1UL << 2)
+
+#define MPROTECT_MINORBITS 20
+#define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -445,6 +456,115 @@ int BPF_KPROBE(kprobe__arch_ptrace,
 
     preempt_disable();
     r = ptrace_event(child, request, addr, data);
+    preempt_enable();
+
+    return r;
+}
+
+static u64 mprotect_vm_flags_to_prot(unsigned long vm_flags)
+{
+    u64 prot = 0;
+
+    if (vm_flags & MPROTECT_VM_READ)
+        prot |= MPROTECT_PROT_READ;
+    if (vm_flags & MPROTECT_VM_WRITE)
+        prot |= MPROTECT_PROT_WRITE;
+    if (vm_flags & MPROTECT_VM_EXEC)
+        prot |= MPROTECT_PROT_EXEC;
+
+    return prot;
+}
+
+/*
+ * security_file_mprotect() is called once for every VMA considered by
+ * mprotect(2) and pkey_mprotect(2), after personality handling has produced
+ * the effective protection and before the protection change is committed.
+ * Consequently this event describes an executable-memory attempt, not a
+ * successful syscall or an exact modified subrange.
+ */
+static int security_file_mprotect__enter(struct vm_area_struct *vma,
+                                         unsigned long req_prot,
+                                         unsigned long effective_prot)
+{
+    if (ebpf_events_is_trusted_pid() || !vma)
+        goto out;
+
+    const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    if (is_kernel_thread(task))
+        goto out;
+
+    // Filter on the kernel-adjusted protection so READ_IMPLIES_EXEC is seen.
+    if (!(effective_prot & MPROTECT_PROT_EXEC))
+        goto out;
+
+    struct ebpf_process_mprotect_event *event =
+        bpf_ringbuf_reserve(&ringbuf, sizeof(*event), 0);
+    if (!event)
+        goto out;
+
+    event->hdr.type = EBPF_EVENT_PROCESS_MPROTECT;
+    event->hdr.ts   = bpf_ktime_get_boot_ns();
+    ebpf_pid_info__fill(&event->pids, task);
+
+    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
+    event->vma_start       = BPF_CORE_READ(vma, vm_start);
+    event->vma_end         = BPF_CORE_READ(vma, vm_end);
+    event->prev_prot       = mprotect_vm_flags_to_prot(vm_flags);
+    event->req_prot        = req_prot;
+    event->effective_prot  = effective_prot;
+    event->file_backed     = 0;
+    event->inode           = 0;
+    event->dev_major       = 0;
+    event->dev_minor       = 0;
+
+    struct file *file = BPF_CORE_READ(vma, vm_file);
+    if (file) {
+        event->file_backed = 1;
+
+        struct inode *inode = BPF_CORE_READ(file, f_inode);
+        if (inode) {
+            event->inode = BPF_CORE_READ(inode, i_ino);
+
+            struct super_block *sb = BPF_CORE_READ(inode, i_sb);
+            if (sb) {
+                dev_t dev       = BPF_CORE_READ(sb, s_dev);
+                event->dev_major = (u32)dev >> MPROTECT_MINORBITS;
+                event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
+            }
+        }
+    }
+
+    bpf_ringbuf_submit(event, 0);
+
+out:
+    return 0;
+}
+
+SEC("fentry/security_file_mprotect")
+int BPF_PROG(fentry__security_file_mprotect,
+             struct vm_area_struct *vma,
+             unsigned long req_prot,
+             unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/security_file_mprotect")
+int BPF_KPROBE(kprobe__security_file_mprotect,
+               struct vm_area_struct *vma,
+               unsigned long req_prot,
+               unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
     preempt_enable();
 
     return r;

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -195,6 +195,7 @@ type Mprotect struct {
 	DevMajor      uint32
 	DevMinor      uint32
 	FileBacked    bool
+	Path          string // mount-ns relative; empty for anonymous mappings
 }
 
 type ModuleLoad struct {
@@ -345,6 +346,14 @@ type Stats struct {
 	GarbageCollections uint64
 	Stalls             uint64
 	Backend            int
+	Mprotect           MprotectStats
+}
+
+// MprotectStats contains cumulative executable mprotect attempt accounting.
+type MprotectStats struct {
+	Submitted     uint64 // events written to the ring buffer
+	Suppressed    uint64 // deduplicated: transition already reported for that process life
+	ReserveFailed uint64 // event buffer/ring buffer write failures
 }
 
 const (
@@ -607,6 +616,9 @@ func (queue *Queue) Stats() Stats {
 	stats.GarbageCollections = uint64(cStats.garbage_collections)
 	stats.Stalls = uint64(cStats.stalls)
 	stats.Backend = int(cStats.backend)
+	stats.Mprotect.Submitted = uint64(cStats.mprotect.submitted)
+	stats.Mprotect.Suppressed = uint64(cStats.mprotect.suppressed)
+	stats.Mprotect.ReserveFailed = uint64(cStats.mprotect.reserve_failed)
 
 	return stats
 }
@@ -811,6 +823,7 @@ func mprotectFromC(cMprotect *C.struct_quark_mprotect) Mprotect {
 	mprotect.DevMajor = uint32(cMprotect.dev_major)
 	mprotect.DevMinor = uint32(cMprotect.dev_minor)
 	mprotect.FileBacked = cMprotect.file_backed != 0
+	mprotect.Path = C.GoString(cMprotect.path)
 
 	return mprotect
 }

--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -183,6 +183,20 @@ type Ptrace struct {
 	Data     uint64
 }
 
+// Mprotect describes an executable protection attempt observed for one VMA.
+// The LSM check happens before the kernel commits the protection change.
+type Mprotect struct {
+	VmaStart      uint64
+	VmaEnd        uint64
+	PrevProt      uint64
+	ReqProt       uint64
+	EffectiveProt uint64
+	Inode         uint64
+	DevMajor      uint32
+	DevMinor      uint32
+	FileBacked    bool
+}
+
 type ModuleLoad struct {
 	Name       string
 	Version    string
@@ -227,6 +241,7 @@ type Event struct {
 	Packet     *Packet
 	File       *File
 	Ptrace     *Ptrace
+	Mprotect   *Mprotect
 	ModuleLoad *ModuleLoad
 	Shm        *any // ShmGet, MemFd or ShmOpen
 	Tty        *Tty
@@ -254,6 +269,7 @@ const (
 	QQ_TTY           = int(C.QQ_TTY)
 	QQ_PTRACE        = int(C.QQ_PTRACE)
 	QQ_MODULE_LOAD   = int(C.QQ_MODULE_LOAD)
+	QQ_MPROTECT      = int(C.QQ_MPROTECT)
 
 	// Event.events
 	QUARK_EV_FORK                  = uint64(C.QUARK_EV_FORK)
@@ -269,6 +285,7 @@ const (
 	QUARK_EV_MODULE_LOAD           = uint64(C.QUARK_EV_MODULE_LOAD)
 	QUARK_EV_SHM                   = uint64(C.QUARK_EV_SHM)
 	QUARK_EV_TTY                   = uint64(C.QUARK_EV_TTY)
+	QUARK_EV_MPROTECT              = uint64(C.QUARK_EV_MPROTECT)
 
 	// EntryLeaderType
 	QUARK_ELT_UNKNOWN   = int(C.QUARK_ELT_UNKNOWN)
@@ -467,6 +484,10 @@ func (queue *Queue) GetEvent() (Event, bool) {
 	if event.Events&QUARK_EV_PTRACE != 0 {
 		ptrace := ptraceFromC(&cev.ptrace)
 		event.Ptrace = &ptrace
+	}
+	if event.Events&QUARK_EV_MPROTECT != 0 {
+		mprotect := mprotectFromC(&cev.mprotect)
+		event.Mprotect = &mprotect
 	}
 	if cev.module_load != nil {
 		ml := moduleLoadFromC(cev.module_load)
@@ -776,6 +797,22 @@ func ptraceFromC(cPtrace *C.struct_quark_ptrace) Ptrace {
 	ptrace.Data = uint64(cPtrace.data)
 
 	return ptrace
+}
+
+func mprotectFromC(cMprotect *C.struct_quark_mprotect) Mprotect {
+	var mprotect Mprotect
+
+	mprotect.VmaStart = uint64(cMprotect.vma_start)
+	mprotect.VmaEnd = uint64(cMprotect.vma_end)
+	mprotect.PrevProt = uint64(cMprotect.prev_prot)
+	mprotect.ReqProt = uint64(cMprotect.req_prot)
+	mprotect.EffectiveProt = uint64(cMprotect.effective_prot)
+	mprotect.Inode = uint64(cMprotect.inode)
+	mprotect.DevMajor = uint32(cMprotect.dev_major)
+	mprotect.DevMinor = uint32(cMprotect.dev_minor)
+	mprotect.FileBacked = cMprotect.file_backed != 0
+
+	return mprotect
 }
 
 func moduleLoadFromC(cM *C.struct_quark_module_load) ModuleLoad {

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -108,6 +108,15 @@ has been reached.
 This is used purely for internal debugging.
 .It Fl M
 Run in a simple benchmark form that only counts and display stats.
+When executable mprotect events are enabled with
+.Fl u ,
+also display the cumulative mprotect counters: events submitted
+.Pq Li mpro-sent ,
+attempts suppressed because the same protection transition was already
+reported for that process life
+.Pq Li mpro-dup ,
+and event write failures
+.Pq Li mpro-rsvfail .
 .It Fl N
 Enable DNS events (experimental).
 .It Fl n

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl BbDEeFGgHhkMNnSsTtv
+.Op Fl BbDEeFGgHhkMNnSsTtuv
 .Op Fl C Ar filename
 .Op Fl K Ar kubeconfig
 .Op Fl l Ar maxlength
@@ -130,6 +130,12 @@ Enable ptrace event tracing.
 .It Fl t
 Don't supress thread events, this is only useful for debugging and will likely
 be zapped in the future.
+.It Fl u
+Enable executable mprotect attempt events (EBPF only).
+One event is emitted for every VMA that reaches the
+.Fn security_file_mprotect
+check with effective execute permission.
+The event does not assert that the protection change ultimately succeeded.
 .It Fl v
 Increase verbosity, can be specified multiple times for more verbosity.
 .It Fl V

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -120,7 +120,7 @@ static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s -h\n", program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNnSsTtv]\n",
+	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNnSsTtuv]\n",
 	    program_invocation_short_name);
 	fprintf(stderr, "%16c [-C filename ] [-K kubeconfig] "
 	    "[-l maxlength] [-m maxnodes]\n", ' ');
@@ -188,7 +188,7 @@ main(int argc, char *argv[])
 	    !strcmp(argv[1], "help")))
 		display_man();
 
-	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsvV")) != -1) {
+	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsuvV")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -311,6 +311,9 @@ main(int argc, char *argv[])
 		}
 		case 'T':
 			qa.flags |= QQ_PTRACE;
+			break;
+		case 'u':
+			qa.flags |= QQ_MPROTECT;
 			break;
 		case 't':
 			qa.flags |= QQ_THREAD_EVENTS;

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -57,6 +57,26 @@ dump_stats(struct quark_queue *qq)
 	    s.insertions, s.removals, s.aggregations,
 	    s.non_aggregations, s.lost, s.garbage_collections, s.stalls);
 	fputc('\n', stderr);
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return;
+
+	fprintf(stderr,
+	    "%14s"
+	    "%14s"
+	    "%14s",
+	    "mpro-sent",
+	    "mpro-dup",
+	    "mpro-rsvfail");
+	fputc('\n', stderr);
+	fprintf(stderr,
+	    "%14llu"
+	    "%14llu"
+	    "%14llu",
+	    s.mprotect.submitted,
+	    s.mprotect.suppressed,
+	    s.mprotect.reserve_failed);
+	fputc('\n', stderr);
 }
 
 static const char *

--- a/quark-test.c
+++ b/quark-test.c
@@ -13,6 +13,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -1544,6 +1545,162 @@ t_shmget(const struct test *t, struct quark_queue_attr *qa)
 }
 
 static int
+t_mprotect(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	const struct quark_mprotect	*qmprotect;
+	void				*addr[4];
+	void				*file_addr;
+	void				*suppressed_addr;
+	const size_t			 len = 4096;
+	struct stat			 st;
+	const int			 expected[] = {
+		PROT_EXEC,
+		PROT_READ | PROT_EXEC,
+		PROT_WRITE | PROT_EXEC,
+		PROT_READ | PROT_WRITE | PROT_EXEC,
+	};
+	const int			 suppressed[] = {
+		PROT_NONE,
+		PROT_READ,
+		PROT_WRITE,
+		PROT_READ | PROT_WRITE,
+	};
+	int				 fd;
+	int				 saw[nitems(expected)] = { 0 };
+	size_t				 i, j;
+	int				 seen = 0;
+
+	qa->flags |= QQ_MPROTECT;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	suppressed_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+	    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (suppressed_addr == MAP_FAILED)
+		err(1, "mmap");
+
+	/* Non-executable effective protections must not enter the ring buffer. */
+	for (i = 0; i < nitems(suppressed); i++) {
+		if (mprotect(suppressed_addr, len, suppressed[i]) == -1)
+			err(1, "mprotect");
+	}
+
+	/* Requests rejected before the LSM hook must not enter the ring buffer. */
+	if (mprotect((void *)(uintptr_t)1, len, PROT_EXEC) != -1)
+		errx(1, "unaligned mprotect unexpectedly succeeded");
+
+	for (i = 0; i < nitems(expected); i++) {
+		addr[i] = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (addr[i] == MAP_FAILED)
+			err(1, "mmap");
+		if (mprotect(addr[i], len, expected[i]) == -1)
+			err(1, "mprotect");
+	}
+
+	while (seen < (int)nitems(expected)) {
+		qev = drain_for_pid(&qq, getpid());
+		if (!(qev->events & QUARK_EV_MPROTECT))
+			continue;
+		qmprotect = &qev->mprotect;
+		for (i = 0; i < nitems(expected); i++) {
+			if (qmprotect->req_prot == (u64)expected[i] &&
+			    qmprotect->vma_start <= (u64)(uintptr_t)addr[i] &&
+			    qmprotect->vma_end >=
+			    (u64)(uintptr_t)addr[i] + len)
+				break;
+		}
+		if (i == nitems(expected)) {
+			errx(1, "unexpected mprotect attempt req_prot 0x%llx",
+			    (unsigned long long)qmprotect->req_prot);
+		}
+		assert(qmprotect->prev_prot == (PROT_READ | PROT_WRITE));
+		assert(qmprotect->effective_prot == (u64)expected[i]);
+		assert(!qmprotect->file_backed);
+		assert(qmprotect->inode == 0);
+		assert(!saw[i]);
+		saw[i] = 1;
+		seen++;
+	}
+
+	for (i = 0; i < nitems(saw); i++)
+		assert(saw[i]);
+
+	/* File-backed identity is carried without resolving a pathname in BPF. */
+	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
+		err(1, "open");
+	if (fstat(fd, &st) == -1)
+		err(1, "fstat");
+	file_addr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (file_addr == MAP_FAILED)
+		err(1, "mmap");
+	if (mprotect(file_addr, len, PROT_READ | PROT_EXEC) == -1)
+		err(1, "mprotect");
+	do {
+		qev = drain_for_pid(&qq, getpid());
+	} while (!(qev->events & QUARK_EV_MPROTECT));
+	qmprotect = &qev->mprotect;
+	assert(qmprotect->vma_start <= (u64)(uintptr_t)file_addr);
+	assert(qmprotect->vma_end >= (u64)(uintptr_t)file_addr + len);
+	assert(qmprotect->prev_prot == PROT_READ);
+	assert(qmprotect->req_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->effective_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->file_backed);
+	assert(qmprotect->inode == (u64)st.st_ino);
+	assert(qmprotect->dev_major == (u32)major(st.st_dev));
+	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+
+#ifdef SYS_pkey_mprotect
+	/* The common LSM hook also observes pkey_mprotect without another probe. */
+	{
+		void *pkey_addr;
+
+		pkey_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (pkey_addr == MAP_FAILED)
+			err(1, "mmap");
+		if (syscall(SYS_pkey_mprotect, pkey_addr, len, PROT_EXEC, -1) == -1) {
+			if (errno != ENOSYS && errno != EINVAL)
+				err(1, "pkey_mprotect");
+		} else {
+			do {
+				qev = drain_for_pid(&qq, getpid());
+			} while (!(qev->events & QUARK_EV_MPROTECT));
+			qmprotect = &qev->mprotect;
+			assert(qmprotect->vma_start <= (u64)(uintptr_t)pkey_addr);
+			assert(qmprotect->vma_end >=
+			    (u64)(uintptr_t)pkey_addr + len);
+			assert(qmprotect->prev_prot ==
+			    (PROT_READ | PROT_WRITE));
+			assert(qmprotect->req_prot == PROT_EXEC);
+			assert(qmprotect->effective_prot == PROT_EXEC);
+			assert(!qmprotect->file_backed);
+		}
+		if (munmap(pkey_addr, len) == -1)
+			err(1, "munmap");
+	}
+#endif
+
+	if (munmap(suppressed_addr, len) == -1)
+		err(1, "munmap");
+	for (j = 0; j < nitems(addr); j++) {
+		if (munmap(addr[j], len) == -1)
+			err(1, "munmap");
+	}
+	if (munmap(file_addr, len) == -1)
+		err(1, "munmap");
+	if (close(fd) == -1)
+		err(1, "close");
+
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+static int
 t_shm_open(const struct test *t, struct quark_queue_attr *qa)
 {
 #ifdef NO_SHM_OPEN
@@ -2895,6 +3052,7 @@ struct test all_tests[] = {
 	T_EBPF(t_memfd),
 	T_EBPF(t_memfd_exec),
 	T_EBPF(t_shmget),
+	T_EBPF(t_mprotect),
 	T_EBPF(t_shm_open),
 	T_EBPF(t_tty_load),
 	T_EBPF(t_tty),

--- a/quark-test.c
+++ b/quark-test.c
@@ -1629,7 +1629,19 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	for (i = 0; i < nitems(saw); i++)
 		assert(saw[i]);
 
-	/* File-backed identity is carried without resolving a pathname in BPF. */
+	/*
+	 * A repeated transition must not produce a second event for the same
+	 * process life: flip addr[0] back and redo the identical RW->X change.
+	 * The file-backed event drained below doubles as the sentinel; if the
+	 * duplicate were wrongly emitted it would be drained first and the
+	 * file_backed asserts would trip.
+	 */
+	if (mprotect(addr[0], len, PROT_READ | PROT_WRITE) == -1)
+		err(1, "mprotect");
+	if (mprotect(addr[0], len, expected[0]) == -1)
+		err(1, "mprotect");
+
+	/* File-backed attempts carry identity and a mount-ns relative path. */
 	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
 		err(1, "open");
 	if (fstat(fd, &st) == -1)
@@ -1652,13 +1664,28 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	assert(qmprotect->inode == (u64)st.st_ino);
 	assert(qmprotect->dev_major == (u32)major(st.st_dev));
 	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+	{
+		char	self[PATH_MAX];
+		ssize_t	n;
+
+		n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+		if (n == -1)
+			err(1, "readlink");
+		self[n] = '\0';
+		assert(qmprotect->path != NULL);
+		assert(strcmp(qmprotect->path, self) == 0);
+	}
 
 #ifdef SYS_pkey_mprotect
 	/* The common LSM hook also observes pkey_mprotect without another probe. */
 	{
 		void *pkey_addr;
 
-		pkey_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		/*
+		 * Map read-only so this is an R->X transition: the RW->X id
+		 * was consumed by expected[0] above and would be deduplicated.
+		 */
+		pkey_addr = mmap(NULL, len, PROT_READ,
 		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 		if (pkey_addr == MAP_FAILED)
 			err(1, "mmap");
@@ -1673,8 +1700,7 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 			assert(qmprotect->vma_start <= (u64)(uintptr_t)pkey_addr);
 			assert(qmprotect->vma_end >=
 			    (u64)(uintptr_t)pkey_addr + len);
-			assert(qmprotect->prev_prot ==
-			    (PROT_READ | PROT_WRITE));
+			assert(qmprotect->prev_prot == PROT_READ);
 			assert(qmprotect->req_prot == PROT_EXEC);
 			assert(qmprotect->effective_prot == PROT_EXEC);
 			assert(!qmprotect->file_backed);

--- a/quark.c
+++ b/quark.c
@@ -233,7 +233,9 @@ raw_event_free(struct raw_event *raw)
 	case RAW_COMM:		/* nada */
 	case RAW_SOCK_CONN:	/* nada */
 	case RAW_PTRACE:	/* nada */
-	case RAW_MPROTECT:	/* nada */
+		break;
+	case RAW_MPROTECT:
+		free(raw->mprotect.quark_mprotect.path);
 		break;
 	case RAW_PACKET:
 		free(raw->packet.quark_packet);
@@ -452,6 +454,7 @@ event_storage_clear(struct quark_queue *qq)
 	free(qq->event_storage.file);
 	qq->event_storage.file = NULL;
 	bzero(&qq->event_storage.ptrace, sizeof(qq->event_storage.ptrace));
+	free(qq->event_storage.mprotect.path);
 	bzero(&qq->event_storage.mprotect, sizeof(qq->event_storage.mprotect));
 	if (qq->event_storage.module_load != NULL) {
 		free(qq->event_storage.module_load->name);
@@ -2301,6 +2304,8 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		    mprotect->effective_prot, effective_prot,
 		    mprotect->file_backed, mprotect->inode,
 		    mprotect->dev_major, mprotect->dev_minor);
+		if (mprotect->path != NULL)
+			PF(fl, "path=%s\n", mprotect->path);
 	}
 
 	if (qp == NULL)
@@ -4888,6 +4893,8 @@ raw_event_mprotect(struct quark_queue *qq, struct raw_event *raw)
 	qev->events = QUARK_EV_MPROTECT;
 	qev->process = quark_process_lookup(qq, raw->pid);
 	qev->mprotect = raw->mprotect.quark_mprotect;
+	/* Steal the path; event_storage_clear() frees it */
+	raw->mprotect.quark_mprotect.path = NULL;
 
 	return (qev);
 }

--- a/quark.c
+++ b/quark.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -192,6 +193,7 @@ raw_event_alloc(int type)
 	case RAW_PACKET:	/* caller allocates */
 	case RAW_FILE:		/* caller allocates */
 	case RAW_PTRACE:	/* nada */
+	case RAW_MPROTECT:	/* nada */
 	case RAW_MODULE_LOAD:	/* caller allocates */
 	case RAW_SHM:		/* caller allocates */
 	case RAW_TTY:		/* caller allocates */
@@ -231,6 +233,7 @@ raw_event_free(struct raw_event *raw)
 	case RAW_COMM:		/* nada */
 	case RAW_SOCK_CONN:	/* nada */
 	case RAW_PTRACE:	/* nada */
+	case RAW_MPROTECT:	/* nada */
 		break;
 	case RAW_PACKET:
 		free(raw->packet.quark_packet);
@@ -449,6 +452,7 @@ event_storage_clear(struct quark_queue *qq)
 	free(qq->event_storage.file);
 	qq->event_storage.file = NULL;
 	bzero(&qq->event_storage.ptrace, sizeof(qq->event_storage.ptrace));
+	bzero(&qq->event_storage.mprotect, sizeof(qq->event_storage.mprotect));
 	if (qq->event_storage.module_load != NULL) {
 		free(qq->event_storage.module_load->name);
 		free(qq->event_storage.module_load->version);
@@ -1788,6 +1792,8 @@ event_type_str(u64 event)
 		return "TTY";
 	case QUARK_EV_GETPID:
 		return "GETPID";
+	case QUARK_EV_MPROTECT:
+		return "MPROTECT";
 	default:
 		return "?";
 	}
@@ -2127,6 +2133,28 @@ module_taints_str(u64 taints, char *buf, size_t len)
 	buf[n] = 0;
 }
 
+static void
+mprotect_prot_str(u64 prot, char *buf, size_t len)
+{
+	size_t	n;
+
+	*buf = 0;
+	n = 0;
+	if (prot & PROT_READ) {
+		if (n + 1 < len)
+			buf[n++] = 'R';
+	}
+	if (prot & PROT_WRITE) {
+		if (n + 1 < len)
+			buf[n++] = 'W';
+	}
+	if (prot & PROT_EXEC) {
+		if (n + 1 < len)
+			buf[n++] = 'X';
+	}
+	buf[n] = 0;
+}
+
 #define P(...)						\
 	do {						\
 		if (fprintf(f, __VA_ARGS__) < 0)	\
@@ -2153,6 +2181,9 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 	const struct quark_container	*container;
 	const struct quark_ptrace	*ptrace;
 	const struct quark_module_load	*qml;
+	const struct quark_mprotect	*mprotect;
+	char				 prev_prot[4], req_prot[4];
+	char				 effective_prot[4];
 	int				 pid;
 
 	if (qev->events == QUARK_EV_BYPASS) {
@@ -2249,6 +2280,27 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		PF(fl, "name=%s version=%s srcversion=%s taints=0x%llx (%s)\n",
 		    qml->name, qml->version, qml->src_version,
 		    qml->taints, buf);
+	}
+
+	if (qev->events & QUARK_EV_MPROTECT) {
+		fl = "MPRO";
+
+		mprotect = &qev->mprotect;
+		mprotect_prot_str(mprotect->prev_prot, prev_prot,
+		    sizeof(prev_prot));
+		mprotect_prot_str(mprotect->req_prot, req_prot,
+		    sizeof(req_prot));
+		mprotect_prot_str(mprotect->effective_prot, effective_prot,
+		    sizeof(effective_prot));
+		PF(fl, "attempt vma=[0x%llx,0x%llx) "
+		    "prev=0x%llx (%s) req=0x%llx (%s) effective=0x%llx (%s) "
+		    "file_backed=%u inode=%llu dev=%u:%u\n",
+		    mprotect->vma_start, mprotect->vma_end,
+		    mprotect->prev_prot, prev_prot,
+		    mprotect->req_prot, req_prot,
+		    mprotect->effective_prot, effective_prot,
+		    mprotect->file_backed, mprotect->inode,
+		    mprotect->dev_major, mprotect->dev_minor);
 	}
 
 	if (qp == NULL)
@@ -4827,6 +4879,20 @@ raw_event_ptrace(struct quark_queue *qq, struct raw_event *raw)
 }
 
 static struct quark_event *
+raw_event_mprotect(struct quark_queue *qq, struct raw_event *raw)
+{
+	struct quark_event	*qev;
+
+	qev = &qq->event_storage;
+
+	qev->events = QUARK_EV_MPROTECT;
+	qev->process = quark_process_lookup(qq, raw->pid);
+	qev->mprotect = raw->mprotect.quark_mprotect;
+
+	return (qev);
+}
+
+static struct quark_event *
 raw_event_module_load(struct quark_queue *qq, struct raw_event *raw)
 {
 	struct quark_event	*qev;
@@ -5241,6 +5307,9 @@ quark_queue_get_event1(struct quark_queue *qq)
 			break;
 		case RAW_PTRACE:
 			qev = raw_event_ptrace(qq, raw);
+			break;
+		case RAW_MPROTECT:
+			qev = raw_event_mprotect(qq, raw);
 			break;
 		case RAW_MODULE_LOAD:
 			qev = raw_event_module_load(qq, raw);

--- a/quark.h
+++ b/quark.h
@@ -259,6 +259,7 @@ enum raw_types {
 	RAW_SHM,
 	RAW_TTY,
 	RAW_GETPID,
+	RAW_MPROTECT,
 	RAW_NUM_TYPES		/* must be last */
 };
 
@@ -406,8 +407,28 @@ struct quark_ptrace {
 	u64	data;
 };
 
+/*
+ * One executable attempt observed at security_file_mprotect(). The hook runs
+ * before the kernel commits the protection change and can fire once per VMA.
+ */
+struct quark_mprotect {
+	u64	vma_start;	/* VMA containing the attempted change */
+	u64	vma_end;
+	u64	prev_prot;	/* normalized PROT_READ/WRITE/EXEC bits */
+	u64	req_prot;	/* protection requested by userspace */
+	u64	effective_prot;	/* kernel-adjusted protection */
+	u64	inode;		/* zero for anonymous mappings */
+	u32	dev_major;	/* zero for anonymous mappings */
+	u32	dev_minor;	/* zero for anonymous mappings */
+	u32	file_backed;
+};
+
 struct raw_ptrace {
 	struct quark_ptrace quark_ptrace;
+};
+
+struct raw_mprotect {
+	struct quark_mprotect quark_mprotect;
 };
 
 struct quark_module_load {
@@ -482,6 +503,7 @@ struct raw_event {
 		struct raw_packet		packet;
 		struct raw_file			file;
 		struct raw_ptrace		ptrace;
+		struct raw_mprotect		mprotect;
 		struct raw_module_load		module_load;
 		struct raw_shm			shm;
 		struct raw_tty			tty;
@@ -518,6 +540,7 @@ struct quark_event {
 #define QUARK_EV_SHM			(1 << 12)
 #define QUARK_EV_TTY			(1 << 13)
 #define QUARK_EV_GETPID			(1 << 14)
+#define QUARK_EV_MPROTECT		(1 << 15)
 	u64				 events;
 	u64				 time;
 	const struct quark_process	*process;
@@ -526,6 +549,7 @@ struct quark_event {
 	const void			*bypass;
 	struct quark_file		*file;
 	struct quark_ptrace		 ptrace;
+	struct quark_mprotect		 mprotect;
 	struct quark_module_load	*module_load;
 	struct quark_shm		*shm;
 	struct quark_tty		*tty;
@@ -898,6 +922,7 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
+#define QQ_MPROTECT		(1 << 15)
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */

--- a/quark.h
+++ b/quark.h
@@ -421,6 +421,7 @@ struct quark_mprotect {
 	u32	dev_major;	/* zero for anonymous mappings */
 	u32	dev_minor;	/* zero for anonymous mappings */
 	u32	file_backed;
+	char   *path;		/* mount-ns relative; NULL for anonymous */
 };
 
 struct raw_ptrace {
@@ -887,6 +888,13 @@ struct quark_sysinfo {
 	char	 *os_pretty_name;
 };
 
+struct quark_mprotect_stats {
+	u64	submitted;	/* events written to the ring buffer */
+	u64	suppressed;	/* deduplicated: transition already reported
+				   for that process life */
+	u64	reserve_failed;	/* event buffer/ring buffer write failures */
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -896,6 +904,7 @@ struct quark_queue_stats {
 	u64	garbage_collections;
 	u64	stalls;     /* stalled perf rings due to corruption, only for QQ_KPROBE */
 	int	backend;    /* active backend, QQ_EBPF or QQ_KPROBE */
+	struct quark_mprotect_stats mprotect;
 	/* TODO u64    peak_nodes; */
 };
 

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -62,6 +62,16 @@ Process changed image, result of an exec.
 Process exited.
 .It Dv QUARK_EV_SETPROCTITLE
 Process changed its name (COMM).
+.It Dv QUARK_EV_MPROTECT
+An executable protection attempt reached the kernel's
+.Fn security_file_mprotect
+check.
+The
+.Em mprotect
+member contains the VMA bounds, normalized previous protection,
+userspace-requested and kernel-adjusted protection, and backing-file identity.
+It describes an attempt and does not assert that the protection change was
+committed.
 .El
 .Pp
 It's important to note that

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -17,6 +17,12 @@ into
 .Vt quark_queue_stats
 is defined as:
 .Bd -literal -offset indent
+struct quark_mprotect_stats {
+	u64	submitted;
+	u64	suppressed;
+	u64	reserve_failed;
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -26,6 +32,7 @@ struct quark_queue_stats {
 	u64	garbage_collections;
 	u64	stalls;
 	int	backend;
+	struct quark_mprotect_stats mprotect;
 };
 .Ed
 .Bl -tag -width "non_aggregations"
@@ -68,6 +75,20 @@ Active queue backend, either
 .Dv QQ_EBPF
 or
 .Dv QQ_KPROBE .
+.It Em mprotect
+Cumulative counters collected when
+.Dv QQ_MPROTECT
+is enabled:
+.Em submitted
+counts events written to the ring buffer,
+.Em suppressed
+counts attempts that were not emitted because the same protection transition
+(previous protection, effective protection, file-backedness) was already
+reported for that process life (the per-process state is dropped on
+.Xr execve 2
+and process exit), and
+.Em reserve_failed
+counts event buffer or ring buffer write failures.
 .El
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -118,6 +118,11 @@ in
 .Em quark_events .
 Entry leader is how the process entered the system, it is disabled by default as
 it is Elastic/ECS specific.
+.It Dv QQ_MPROTECT
+Enable EBPF-only executable mprotect attempt events.
+Each event describes one VMA reaching the kernel's
+.Fn security_file_mprotect
+check and does not imply that the protection change was committed.
 .El
 .It Em max_length
 The maximum size of the internal buffering queue in number of events.


### PR DESCRIPTION
## Summary

Adds executable `mprotect()` attempt events (`QUARK_EV_MPROTECT`, `quark-mon -u`), collected at the `security_file_mprotect` LSM hook and deduplicated to one event per unique protection transition per process life.

This supersedes #400 (same LSM approach, rebuilt on current main rather than on top of #367) and incorporates what we learned comparing #400 against #367 on identical GCP VMs.

### Design

- **LSM hook, per VMA**: the probe sees the previous, requested, and kernel-adjusted effective protection (so `READ_IMPLIES_EXEC` is visible) plus backing-file identity, before the change is committed. Covers `mprotect(2)`, `pkey_mprotect(2)`, and compat callers.
- **Deduplication**: an LRU map keyed by tgid plus a 7-bit transition id (prev prot, effective prot, file-backedness) is claimed with `BPF_NOEXIST`, so concurrent threads of one process race to exactly one winner. Only a confirmed "already reported" suppresses; any map failure emits — the failure mode is a duplicate event, never a lost one. State clears on `execve` and process exit; LRU eviction is a safe backstop for the same reason.
- **File-backed paths**: file-backed attempts are rare and high signal (library tampering, packers, memfd fake JITs), so they carry the mount-namespace relative path as a variable-length field. `quark_mprotect.path` is NULL for anonymous mappings.
- **Stats**: `quark_queue_stats` gains `{submitted, suppressed, reserve_failed}`, shown by `quark-mon -M`, so deployments can observe how much the dedup absorbs.

### Measurements

From a harness that runs identical deterministic workloads on two identical Ubuntu 24.04 VMs (this branch vs. the `sys_enter/exit_mprotect` tracepoint approach of #367):

| workload | executable attempts | events emitted (this PR) | events emitted (#367) |
|---|---|---|---|
| Firefox headless, 5 min deterministic browse | 24,922 | **1** (anon RW→X JIT signature) | 25,389 |
| node JIT workload | 34 | 4 | 34 |
| JVM JIT workload | 2 | 2 | 2 |
| file-backed/memfd/anon mprotect exerciser | 450 | 9 | 450 |

A throwaway instrumentation build also correlated every hook-side attempt with its syscall exit across all workloads: 100% of executable attempts seen at the LSM hook committed (e.g. Firefox 24,919/24,919 succeeded, 0 failed), so hook-side "attempt" events are not inflated by failing calls in practice.

### Tests

`t_mprotect` extended for the new semantics: repeated transitions must not re-emit (sentinel check after flipping protections back and forth), the `pkey_mprotect` case uses R→X so it is distinct from the earlier RW→X, and the file-backed event must carry the path of `/proc/self/exe`. Passes on the ebpf backend (Ubuntu 24.04, 6.14 gcp kernel).
