### PR TITLE
ebpf: add zeroed event buffer helper

### DIFF
--- a/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Network/Probe.bpf.c
@@ -80,10 +80,9 @@ static int inet_csk_accept__exit(struct sock *sk)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event *event = get_event_buffer();
+    struct ebpf_net_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)
         goto out;
-    __builtin_memset(event, 0, sizeof(*event));
 
     if (ebpf_network_event__fill(event, sk))
         goto out;
@@ -131,10 +130,9 @@ static int tcp_connect(struct sock *sk, int ret)
     if (ebpf_events_is_trusted_pid())
         goto out;
 
-    struct ebpf_net_event *event = get_event_buffer();
+    struct ebpf_net_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)
         goto out;
-    __builtin_memset(event, 0, sizeof(*event));
 
     if (ebpf_network_event__fill(event, sk))
         goto out;
@@ -259,10 +257,9 @@ static int tcp_close__enter(struct sock *sk)
     if (bpf_map_delete_elem(&sk_to_tgid, &sk) != 0 && bytes_sent == 0 && bytes_received == 0)
         goto out;
 
-    struct ebpf_net_event *event = get_event_buffer();
+    struct ebpf_net_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)
         goto out;
-    __builtin_memset(event, 0, sizeof(*event));
 
     if (ebpf_network_event__fill(event, sk))
         goto out;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -398,10 +398,9 @@ static int ptrace_event(struct task_struct *child,
     if (child_tgid == curr_tgid)
         goto out;
 
-    struct ebpf_process_ptrace_event *event = get_event_buffer();
+    struct ebpf_process_ptrace_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)
         goto out;
-    __builtin_memset(event, 0, sizeof(*event));
 
     event->hdr.type = EBPF_EVENT_PROCESS_PTRACE;
     event->hdr.ts   = bpf_ktime_get_boot_ns();
@@ -474,10 +473,9 @@ int tracepoint_syscalls_sys_enter_shmget(struct syscall_trace_enter *ctx)
     if (is_kernel_thread(task))
         goto out;
 
-    struct ebpf_process_shmget_event *event = get_event_buffer();
+    struct ebpf_process_shmget_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)
         goto out;
-    __builtin_memset(event, 0, sizeof(*event));
 
     event->hdr.type = EBPF_EVENT_PROCESS_SHMGET;
     event->hdr.ts   = bpf_ktime_get_boot_ns();
@@ -620,10 +618,9 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, suid.val) != BPF_CORE_READ(old, suid.val) ||
         BPF_CORE_READ(new, fsuid.val) != BPF_CORE_READ(old, fsuid.val)) {
 
-        struct ebpf_process_setuid_event *event = get_event_buffer();
+        struct ebpf_process_setuid_event *event = get_zeroed_event_buffer(sizeof(*event));
         if (!event)
             return 0;
-        __builtin_memset(event, 0, sizeof(*event));
 
         event->hdr.type = EBPF_EVENT_PROCESS_SETUID;
         event->hdr.ts   = bpf_ktime_get_boot_ns();
@@ -647,10 +644,9 @@ static int commit_creds__enter(struct cred *new)
         BPF_CORE_READ(new, sgid.val) != BPF_CORE_READ(old, sgid.val) ||
         BPF_CORE_READ(new, fsgid.val) != BPF_CORE_READ(old, fsgid.val)) {
 
-        struct ebpf_process_setgid_event *event = get_event_buffer();
+        struct ebpf_process_setgid_event *event = get_zeroed_event_buffer(sizeof(*event));
         if (!event)
             return 0;
-        __builtin_memset(event, 0, sizeof(*event));
 
         event->hdr.type = EBPF_EVENT_PROCESS_SETGID;
         event->hdr.ts   = bpf_ktime_get_boot_ns();

--- a/elastic-ebpf/GPL/Events/Varlen.h
+++ b/elastic-ebpf/GPL/Events/Varlen.h
@@ -66,6 +66,14 @@ static void *get_event_buffer()
     return bpf_map_lookup_elem(&event_buffer_map, &key);
 }
 
+static __always_inline void *get_zeroed_event_buffer(size_t size)
+{
+    void *buf = get_event_buffer();
+    if (buf)
+        __builtin_memset(buf, 0, size);
+    return buf;
+}
+
 struct ebpf_varlen_field *ebpf_vl_field__add(struct ebpf_varlen_fields_start *fields,
                                              enum ebpf_varlen_field_type type)
 {


### PR DESCRIPTION
## Summary

- add `get_zeroed_event_buffer()` to combine scratch-buffer lookup and zero-initialization
- use it at the seven fixed-size event call sites introduced by #403
- leave existing variable-length buffer users unchanged

Follow-up to https://github.com/elastic/quark/pull/403#discussion_r3897512808

## Testing

- compiled `bpf_probes.c` for the BPF target with Homebrew Clang 22.1.6
- `git diff --check`