### PR TITLE
ebpf: compare bpf_probe_read_kernel_str returns in 32 bits

### DIFF
--- a/elastic-ebpf/GPL/Events/Helpers.h
+++ b/elastic-ebpf/GPL/Events/Helpers.h
@@ -146,7 +146,11 @@ static bool IS_ERR_OR_NULL(const void *ptr)
 // Wrapper around bpf_probe_read_kernel_str that reads an empty string upon a read failure
 static long read_kernel_str_or_empty_str(void *dst, int size, const void *unsafe_ptr)
 {
-    long ret = bpf_probe_read_kernel_str(dst, size, unsafe_ptr);
+    // Compare in 32 bits: before Linux 5.9 (bdb7b79b4ce8) helpers were
+    // declared to return int, and the JIT zero-extends the 32-bit result, so
+    // a 64-bit compare against a negative errno never matches on older
+    // kernels.
+    int ret = bpf_probe_read_kernel_str(dst, size, unsafe_ptr);
     if (ret < 0) {
         ((char *)dst)[0] = '\0';
         return 1;

--- a/elastic-ebpf/GPL/Events/PathResolver.h
+++ b/elastic-ebpf/GPL/Events/PathResolver.h
@@ -272,7 +272,11 @@ static size_t ebpf_resolve_kernfs_node_to_string(char *buf, struct kernfs_node *
 
         buf[cur & PATH_MAX_INDEX_MASK] = '/';
         cur                            = (cur + 1) & PATH_MAX_INDEX_MASK;
-        if (bpf_probe_read_kernel_str(
+        // Compare in 32 bits ((int) cast): before Linux 5.9 (bdb7b79b4ce8)
+        // helpers were declared to return int, and the JIT zero-extends the
+        // 32-bit result, so a 64-bit `< 0` compare never matches on older
+        // kernels.
+        if ((int)bpf_probe_read_kernel_str(
                 buf + (cur & PATH_MAX_INDEX_MASK),
                 PATH_MAX - cur > KERNFS_NODE_COMPONENT_MAX_LEN ? KERNFS_NODE_COMPONENT_MAX_LEN : 0,
                 (void *)name) < 0)

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -541,7 +541,10 @@ static int emit_memfd_create_event(const char *name)
     // Variable length fields
     ebpf_vl_fields__init(&event->vl_fields);
     struct ebpf_varlen_field *field;
-    long size;
+    // Declared int, not long: before Linux 5.9 (bdb7b79b4ce8) helpers were
+    // declared to return int, and the JIT zero-extends the 32-bit result, so
+    // a 64-bit `size <= 0` check never catches failures on older kernels.
+    int size;
 
     // memfd filename
     field = ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_FILENAME);


### PR DESCRIPTION
## Summary

Kernels before 5.9 (bdb7b79b4ce8) declared BPF helpers as returning `int`, and the JIT zero-extends the 32-bit result, so 64-bit comparisons against negative errnos silently never match. #404 fixed this for the mprotect dedup `bpf_map_update_elem()` check; this PR fixes the three remaining latent instances, all around `bpf_probe_read_kernel_str()`:

- `GPL/Events/Helpers.h` `read_kernel_str_or_empty_str()`: the empty-string fallback never triggered on old kernels, so a failed read returned a bogus huge value as the string length, which many callers (module_load, symlink/rename, cgroup paths, comm) pass to `ebpf_vl_field__set_size()`.
- `GPL/Events/Process/Probe.bpf.c` `emit_memfd_create_event()`: same shape for the memfd filename read (`long size; ... if (size <= 0)`).
- `GPL/Events/PathResolver.h` `ebpf_resolve_kernfs_node_to_string()`: a failed component read was not caught, leaving garbage in the path buffer.

These only misbehave when `bpf_probe_read_kernel_str()` actually fails on a pre-5.9 kernel (rare, which is why CI never caught them). Worst case is a dropped event or garbage path, not corruption. Fix is the same pattern as #404: do the comparison in 32 bits (`int ret = ...` / `(int)` cast).

Not touched: `nova.bpf.c` has the same shape but requires `bpf_loop` (kernel 5.17+), so it cannot run on affected kernels.