### PR TITLE
Added a CPU count call and determine ring buffer size.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -172,3 +172,6 @@ Changes from 0.8 to 0.9
     CLOCK_BOOTTIME. This effectively drops support for kernels without perf
     clockid support (< 4.1 or RHEL before 7.4).
   o quark_queue_stats{} got a "stalls" member.
+  o The eBPF ring buffer is now sized at load from CPU count (512 KiB
+    per CPU, rounded up to a power of two, floored at 4 MiB and
+    capped at 64 MiB) instead of a fixed 4 MiB.

--- a/bpf_probes.c
+++ b/bpf_probes.c
@@ -6,7 +6,8 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 1 << 22); // 4 MiB
+	/* 4 MiB compile-time default; userspace resizes at load from ncpu. */
+	__uint(max_entries, 1 << 22);
 } ringbuf SEC(".maps");
 
 #include "Process/Probe.bpf.c"

--- a/bpf_probes.c
+++ b/bpf_probes.c
@@ -6,8 +6,8 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	/* 4 MiB compile-time default; userspace resizes at load from ncpu. */
-	__uint(max_entries, 1 << 22);
+	/* The size is set in userspace derived from ncpu. */
+	__uint(max_entries, 0);
 } ringbuf SEC(".maps");
 
 #include "Process/Probe.bpf.c"

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -4,7 +4,7 @@
 #include <sys/epoll.h>
 #include <sys/param.h>
 #include <sys/mount.h>
-#include <sys/sysinfo.h>
+#include <sys/resource.h>
 
 #include <assert.h>
 #include <ctype.h>
@@ -30,6 +30,7 @@ static int	bpf_queue_populate(struct quark_queue *);
 static int	bpf_queue_update_stats(struct quark_queue *);
 static void	bpf_queue_close(struct quark_queue *);
 static u32	bpf_ringbuf_size(int);
+static void	bump_memlock(void);
 
 /*
  * Shared eBPF ring buffer is sized from CPU count so large hosts can absorb
@@ -71,6 +72,28 @@ bpf_ringbuf_size(int ncpu)
 		bytes = RINGBUF_MAX_SIZE;
 
 	return ((u32)bytes);
+}
+
+static void
+bump_memlock(void)
+{
+	struct rlimit rlim;
+
+	rlim.rlim_cur = RLIM_INFINITY;
+	rlim.rlim_max = RLIM_INFINITY;
+	if (setrlimit(RLIMIT_MEMLOCK, &rlim) == 0)
+		return;
+
+	/*
+	 * Raising the hard limit needs CAP_SYS_RESOURCE; fall back to
+	 * using whatever ceiling we already have.
+	 */
+	if (getrlimit(RLIMIT_MEMLOCK, &rlim) == 0) {
+		rlim.rlim_cur = rlim.rlim_max;
+		if (setrlimit(RLIMIT_MEMLOCK, &rlim) == 0)
+			return;
+	}
+	qwarn("setrlimit RLIMIT_MEMLOCK");
 }
 
 struct quark_queue_ops queue_ops_bpf = {
@@ -1330,7 +1353,18 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	if (qq->flags & QQ_GETPID)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);
 
-	ncpu = get_nprocs_conf();
+	/*
+	 * Older kernels account BPF maps against RLIMIT_MEMLOCK. libbpf
+	 * tries to bump this itself but skips it when it (sometimes
+	 * wrongly) thinks the kernel uses memcg accounting.
+	 */
+	bump_memlock();
+
+	ncpu = libbpf_num_possible_cpus();
+	if (ncpu <= 0) {
+		qwarnx("bad libbpf_num_possible_cpus: %d", ncpu);
+		goto fail;
+	}
 	if (bpf_map__set_max_entries(p->maps.event_buffer_map, ncpu) != 0) {
 		qwarn("bpf_map__set_max_entries event_buffer_map");
 		goto fail;

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -33,11 +33,13 @@ static u32	bpf_ringbuf_size(int);
 
 /*
  * Shared eBPF ring buffer is sized from CPU count so large hosts can absorb
- * a burst of variable-length execs (argv+env). 256 KiB per CPU matches
- * EVENT_BUFFER_SIZE. Result is rounded up to a power of two (BPF ringbuf
- * requirement), never below the historical 4 MiB default, never above 64 MiB.
+ * a burst of variable-length execs (argv+env). 512 KiB per CPU is the
+ * per-CPU headroom of the historical 4 MiB default at 8 CPUs, the point
+ * at which bursty large execs did not drop. Result is rounded up to a
+ * power of two (BPF ringbuf requirement), never below 4 MiB, never above
+ * 64 MiB.
  */
-#define RINGBUF_BYTES_PER_CPU	(1U << 18)	/* 256 KiB */
+#define RINGBUF_BYTES_PER_CPU	(1U << 19)	/* 512 KiB */
 #define RINGBUF_MIN_SIZE	(1U << 22)	/* 4 MiB */
 #define RINGBUF_MAX_SIZE	(1U << 26)	/* 64 MiB */
 

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -30,6 +30,46 @@ static int	bpf_queue_populate(struct quark_queue *);
 static int	bpf_queue_update_stats(struct quark_queue *);
 static void	bpf_queue_close(struct quark_queue *);
 
+/*
+ * Shared eBPF ring buffer is sized from CPU count so large hosts can absorb
+ * a burst of variable-length execs (argv+env). 256 KiB per CPU matches
+ * EVENT_BUFFER_SIZE. Result is rounded up to a power of two (BPF ringbuf
+ * requirement), never below the historical 4 MiB default, never above 64 MiB.
+ */
+#define RINGBUF_BYTES_PER_CPU	(1U << 18)	/* 256 KiB */
+#define RINGBUF_MIN_SIZE	(1U << 22)	/* 4 MiB */
+#define RINGBUF_MAX_SIZE	(1U << 26)	/* 64 MiB */
+
+u32
+quark_bpf_ringbuf_size(int ncpu)
+{
+	u64 bytes;
+
+	if (ncpu < 1)
+		ncpu = 1;
+
+	bytes = (u64)ncpu * RINGBUF_BYTES_PER_CPU;
+
+	/* round up to the next power of two */
+	if (bytes > 1) {
+		bytes--;
+		bytes |= bytes >> 1;
+		bytes |= bytes >> 2;
+		bytes |= bytes >> 4;
+		bytes |= bytes >> 8;
+		bytes |= bytes >> 16;
+		bytes |= bytes >> 32;
+		bytes++;
+	}
+
+	if (bytes < RINGBUF_MIN_SIZE)
+		bytes = RINGBUF_MIN_SIZE;
+	if (bytes > RINGBUF_MAX_SIZE)
+		bytes = RINGBUF_MAX_SIZE;
+
+	return ((u32)bytes);
+}
+
 struct quark_queue_ops queue_ops_bpf = {
 	.open	      = bpf_queue_open,
 	.populate     = bpf_queue_populate,
@@ -1051,7 +1091,8 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	struct bpf_queue		*bqq;
 	struct bpf_probes		*p;
 	struct bpf_program		*prog;
-	int				 cgroup_fd, i, off, ringbuf_fd;
+	int				 cgroup_fd, i, ncpu, off, ringbuf_fd;
+	u32				 ringbuf_size;
 	char				*cgroup_umount;
 	struct bpf_prog_skeleton	*ps;
 	struct btf			*btf;
@@ -1286,11 +1327,18 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 	if (qq->flags & QQ_GETPID)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);
 
-	if (bpf_map__set_max_entries(p->maps.event_buffer_map,
-	    get_nprocs_conf()) != 0) {
+	ncpu = get_nprocs_conf();
+	if (bpf_map__set_max_entries(p->maps.event_buffer_map, ncpu) != 0) {
 		qwarn("bpf_map__set_max_entries event_buffer_map");
 		goto fail;
 	}
+
+	ringbuf_size = quark_bpf_ringbuf_size(ncpu);
+	if (bpf_map__set_max_entries(p->maps.ringbuf, ringbuf_size) != 0) {
+		qwarn("bpf_map__set_max_entries ringbuf");
+		goto fail;
+	}
+	qdebugx("eBPF ringbuf size %u bytes (%d cpus)", ringbuf_size, ncpu);
 
 	if (bpf_probes__load(p) != 0) {
 		qwarn("bpf_probes__load");

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -29,6 +29,7 @@ struct bpf_queue {
 static int	bpf_queue_populate(struct quark_queue *);
 static int	bpf_queue_update_stats(struct quark_queue *);
 static void	bpf_queue_close(struct quark_queue *);
+static u32	bpf_ringbuf_size(int);
 
 /*
  * Shared eBPF ring buffer is sized from CPU count so large hosts can absorb
@@ -40,8 +41,8 @@ static void	bpf_queue_close(struct quark_queue *);
 #define RINGBUF_MIN_SIZE	(1U << 22)	/* 4 MiB */
 #define RINGBUF_MAX_SIZE	(1U << 26)	/* 64 MiB */
 
-u32
-quark_bpf_ringbuf_size(int ncpu)
+static u32
+bpf_ringbuf_size(int ncpu)
 {
 	u64 bytes;
 
@@ -1333,7 +1334,7 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		goto fail;
 	}
 
-	ringbuf_size = quark_bpf_ringbuf_size(ncpu);
+	ringbuf_size = bpf_ringbuf_size(ncpu);
 	if (bpf_map__set_max_entries(p->maps.ringbuf, ringbuf_size) != 0) {
 		qwarn("bpf_map__set_max_entries ringbuf");
 		goto fail;

--- a/quark-test.c
+++ b/quark-test.c
@@ -16,6 +16,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <bpf/bpf.h>
+
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
@@ -835,6 +837,31 @@ t_probe(const struct test *t, struct quark_queue_attr *qa)
 
 	if (quark_queue_open(&qq, qa) != 0)
 		err(1, "%s: quark_queue_open", t->name);
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+/*
+ * CI boxes are small, so quark_queue_open() only allocates the 4 MiB
+ * floor. Create a 64 MiB ringbuf so RLIMIT_MEMLOCK / memcg accounting
+ * is exercised on every kernel we test.
+ */
+static int
+t_ringbuf_max(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue	 qq;
+	int			 fd;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "%s: quark_queue_open", t->name);
+
+	fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, "quark_test_ringbuf",
+	    0, 0, 1U << 26, NULL);
+	if (fd < 0)
+		err(1, "%s: bpf_map_create 64MiB ringbuf", t->name);
+	close(fd);
+
 	quark_queue_close(&qq);
 
 	return (0);
@@ -2877,6 +2904,7 @@ t_nova(const struct test *t, struct quark_queue_attr *qa)
 #define S(_x)		#_x
 struct test all_tests[] = {
 	T_EBPF(t_probe),
+	T_EBPF(t_ringbuf_max),
 	T_KPROBE(t_probe),
 	T_NOVA(t_probe),
 	T_KPROBE(t_kprobe_clockid),

--- a/quark-test.c
+++ b/quark-test.c
@@ -2075,6 +2075,30 @@ t_backend_flags(const struct test *t, struct quark_queue_attr *unused)
 }
 
 static int
+t_ringbuf_size(const struct test *t, struct quark_queue_attr *qa)
+{
+	u32 size;
+
+	assert(quark_bpf_ringbuf_size(0) == (1U << 22));	/* floor 4 MiB */
+	assert(quark_bpf_ringbuf_size(-1) == (1U << 22));
+	assert(quark_bpf_ringbuf_size(1) == (1U << 22));
+	assert(quark_bpf_ringbuf_size(16) == (1U << 22));	/* 16 * 256 KiB */
+	assert(quark_bpf_ringbuf_size(17) == (1U << 23));	/* round up 8 MiB */
+	assert(quark_bpf_ringbuf_size(32) == (1U << 23));
+	assert(quark_bpf_ringbuf_size(48) == (1U << 24));	/* 12 MiB -> 16 MiB */
+	assert(quark_bpf_ringbuf_size(64) == (1U << 24));
+	assert(quark_bpf_ringbuf_size(128) == (1U << 25));	/* 32 MiB */
+	assert(quark_bpf_ringbuf_size(256) == (1U << 26));	/* 64 MiB */
+	assert(quark_bpf_ringbuf_size(512) == (1U << 26));	/* cap */
+
+	size = quark_bpf_ringbuf_size(192);
+	assert(size == (1U << 26));				/* 48 MiB -> 64 MiB */
+	assert((size & (size - 1)) == 0);
+
+	return (0);
+}
+
+static int
 t_hanson(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct hanson	 h;
@@ -2911,6 +2935,7 @@ struct test all_tests[] = {
 	T_EBPF(t_stats),
 	T_KPROBE(t_stats),
 	T(t_backend_flags),
+	T(t_ringbuf_size),
 	T(t_hanson),
 	T(t_hanson_escape),
 	T_EBPF(t_rule_path),

--- a/quark-test.c
+++ b/quark-test.c
@@ -2075,30 +2075,6 @@ t_backend_flags(const struct test *t, struct quark_queue_attr *unused)
 }
 
 static int
-t_ringbuf_size(const struct test *t, struct quark_queue_attr *qa)
-{
-	u32 size;
-
-	assert(quark_bpf_ringbuf_size(0) == (1U << 22));	/* floor 4 MiB */
-	assert(quark_bpf_ringbuf_size(-1) == (1U << 22));
-	assert(quark_bpf_ringbuf_size(1) == (1U << 22));
-	assert(quark_bpf_ringbuf_size(16) == (1U << 22));	/* 16 * 256 KiB */
-	assert(quark_bpf_ringbuf_size(17) == (1U << 23));	/* round up 8 MiB */
-	assert(quark_bpf_ringbuf_size(32) == (1U << 23));
-	assert(quark_bpf_ringbuf_size(48) == (1U << 24));	/* 12 MiB -> 16 MiB */
-	assert(quark_bpf_ringbuf_size(64) == (1U << 24));
-	assert(quark_bpf_ringbuf_size(128) == (1U << 25));	/* 32 MiB */
-	assert(quark_bpf_ringbuf_size(256) == (1U << 26));	/* 64 MiB */
-	assert(quark_bpf_ringbuf_size(512) == (1U << 26));	/* cap */
-
-	size = quark_bpf_ringbuf_size(192);
-	assert(size == (1U << 26));				/* 48 MiB -> 64 MiB */
-	assert((size & (size - 1)) == 0);
-
-	return (0);
-}
-
-static int
 t_hanson(const struct test *t, struct quark_queue_attr *qa)
 {
 	struct hanson	 h;
@@ -2935,7 +2911,6 @@ struct test all_tests[] = {
 	T_EBPF(t_stats),
 	T_KPROBE(t_stats),
 	T(t_backend_flags),
-	T(t_ringbuf_size),
 	T(t_hanson),
 	T(t_hanson_escape),
 	T_EBPF(t_rule_path),

--- a/quark.h
+++ b/quark.h
@@ -141,7 +141,6 @@ int			btf_index_of_param(struct btf *, const char *,
 
 /* bpf_queue.c */
 int			 bpf_queue_open(struct quark_queue *);
-u32			 quark_bpf_ringbuf_size(int);
 struct bpf_probes	*quark_get_bpf_probes(struct quark_queue *);
 int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);

--- a/quark.h
+++ b/quark.h
@@ -141,6 +141,7 @@ int			btf_index_of_param(struct btf *, const char *,
 
 /* bpf_queue.c */
 int			 bpf_queue_open(struct quark_queue *);
+u32			 quark_bpf_ringbuf_size(int);
 struct bpf_probes	*quark_get_bpf_probes(struct quark_queue *);
 int			 quark_queue_trusted_pid_add(struct quark_queue *, u32);
 int			 quark_queue_trusted_pid_reset(struct quark_queue *);


### PR DESCRIPTION
Size the Linux eBPF process-event ring buffer at load from CPU count instead of the fixed 4 MiB map.

Before probes load, set max_entries to 512 KiB × ncpu, rounded up to a power of two, floored at 4 MiB and capped at 64 MiB. That keeps the per-CPU headroom the old 4 MiB default had on an 8-CPU box (a 128-CPU host gets 64 MiB). Same formula in quark (bpf_queue.c) and the Kernel/Ebpf fallback.