### PR TITLE
Collect executable mprotect attempts at LSM hook

### DIFF
--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -675,6 +675,29 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 
 		break;
 	}
+	case EBPF_EVENT_PROCESS_MPROTECT: {
+		struct ebpf_process_mprotect_event *mprotect;
+		struct quark_mprotect *qmprotect;
+
+		mprotect = (struct ebpf_process_mprotect_event *)ev;
+		if ((raw = raw_event_alloc(RAW_MPROTECT)) == NULL)
+			goto bad;
+
+		raw->pid = mprotect->pids.tgid;
+		raw->time = ev->ts;
+
+		qmprotect = &raw->mprotect.quark_mprotect;
+		qmprotect->vma_start = mprotect->vma_start;
+		qmprotect->vma_end = mprotect->vma_end;
+		qmprotect->prev_prot = mprotect->prev_prot;
+		qmprotect->req_prot = mprotect->req_prot;
+		qmprotect->effective_prot = mprotect->effective_prot;
+		qmprotect->inode = mprotect->inode;
+		qmprotect->dev_major = mprotect->dev_major;
+		qmprotect->dev_minor = mprotect->dev_minor;
+		qmprotect->file_backed = mprotect->file_backed;
+		break;
+	}
 	case EBPF_EVENT_PROCESS_LOAD_MODULE: {
 		struct ebpf_process_load_module_event *module;
 		struct quark_module_load	*qml;
@@ -1349,6 +1372,15 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 
 	if (qq->flags & QQ_MODULE_LOAD)
 		bpf_program__set_autoload(p->progs.module_load, 1);
+
+	if (qq->flags & QQ_MPROTECT) {
+		if (use_fentry)
+			bpf_program__set_autoload(
+			    p->progs.fentry__security_file_mprotect, 1);
+		else
+			bpf_program__set_autoload(
+			    p->progs.kprobe__security_file_mprotect, 1);
+	}
 
 	if (qq->flags & QQ_GETPID)
 		bpf_program__set_autoload(p->progs.tracepoint_syscalls_sys_exit_getpid, 1);

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -46,6 +46,7 @@ enum ebpf_event_type {
     EBPF_EVENT_PROCESS_LOAD_MODULE          = (1 << 19),
     EBPF_EVENT_NETWORK_DNS_PKT              = (1 << 20),
     EBPF_EVENT_PROCESS_GETPID               = (1 << 21),
+    EBPF_EVENT_PROCESS_MPROTECT             = (1 << 22),
 };
 
 struct ebpf_event_header {
@@ -378,6 +379,20 @@ struct ebpf_process_load_module_event {
     uint64_t taints;
     // Variable length fields: filename, mod version, mod srcversion
     struct ebpf_varlen_fields_start vl_fields;
+} __attribute__((packed));
+
+struct ebpf_process_mprotect_event {
+    struct ebpf_event_header hdr;
+    struct ebpf_pid_info pids;
+    uint64_t vma_start;
+    uint64_t vma_end;
+    uint64_t prev_prot;
+    uint64_t req_prot;
+    uint64_t effective_prot;
+    uint64_t inode;
+    uint32_t dev_major;
+    uint32_t dev_minor;
+    uint32_t file_backed;
 } __attribute__((packed));
 
 enum ebpf_net_info_transport {

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -514,10 +514,6 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     event->prev_prot       = prev_prot;
     event->req_prot        = req_prot;
     event->effective_prot  = effective_prot;
-    event->file_backed     = 0;
-    event->inode           = 0;
-    event->dev_major       = 0;
-    event->dev_minor       = 0;
 
     if (file) {
         event->file_backed = 1;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -25,6 +25,17 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define S_ISUID 0004000
 #define S_ISGID 0002000
 
+#define MPROTECT_PROT_READ  0x1
+#define MPROTECT_PROT_WRITE 0x2
+#define MPROTECT_PROT_EXEC  0x4
+
+#define MPROTECT_VM_READ  (1UL << 0)
+#define MPROTECT_VM_WRITE (1UL << 1)
+#define MPROTECT_VM_EXEC  (1UL << 2)
+
+#define MPROTECT_MINORBITS 20
+#define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -445,6 +456,116 @@ int BPF_KPROBE(kprobe__arch_ptrace,
 
     preempt_disable();
     r = ptrace_event(child, request, addr, data);
+    preempt_enable();
+
+    return r;
+}
+
+static u64 mprotect_vm_flags_to_prot(unsigned long vm_flags)
+{
+    u64 prot = 0;
+
+    if (vm_flags & MPROTECT_VM_READ)
+        prot |= MPROTECT_PROT_READ;
+    if (vm_flags & MPROTECT_VM_WRITE)
+        prot |= MPROTECT_PROT_WRITE;
+    if (vm_flags & MPROTECT_VM_EXEC)
+        prot |= MPROTECT_PROT_EXEC;
+
+    return prot;
+}
+
+/*
+ * security_file_mprotect() is called once for every VMA considered by
+ * mprotect(2) and pkey_mprotect(2), after personality handling has produced
+ * the effective protection and before the protection change is committed.
+ * Consequently this event describes an executable-memory attempt, not a
+ * successful syscall or an exact modified subrange.
+ */
+static int security_file_mprotect__enter(struct vm_area_struct *vma,
+                                         unsigned long req_prot,
+                                         unsigned long effective_prot)
+{
+    if (ebpf_events_is_trusted_pid() || !vma)
+        goto out;
+
+    const struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    if (is_kernel_thread(task))
+        goto out;
+
+    // Filter on the kernel-adjusted protection so READ_IMPLIES_EXEC is seen.
+    if (!(effective_prot & MPROTECT_PROT_EXEC))
+        goto out;
+
+    unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
+    u64 prev_prot          = mprotect_vm_flags_to_prot(vm_flags);
+    struct file *file      = BPF_CORE_READ(vma, vm_file);
+
+    struct ebpf_process_mprotect_event *event = get_zeroed_event_buffer(sizeof(*event));
+    if (!event)
+        goto out;
+
+    event->hdr.type = EBPF_EVENT_PROCESS_MPROTECT;
+    event->hdr.ts   = bpf_ktime_get_boot_ns();
+    ebpf_pid_info__fill(&event->pids, task);
+
+    event->vma_start       = BPF_CORE_READ(vma, vm_start);
+    event->vma_end         = BPF_CORE_READ(vma, vm_end);
+    event->prev_prot       = prev_prot;
+    event->req_prot        = req_prot;
+    event->effective_prot  = effective_prot;
+    event->file_backed     = 0;
+    event->inode           = 0;
+    event->dev_major       = 0;
+    event->dev_minor       = 0;
+
+    if (file) {
+        event->file_backed = 1;
+
+        struct inode *inode = BPF_CORE_READ(file, f_inode);
+        if (inode) {
+            event->inode = BPF_CORE_READ(inode, i_ino);
+
+            struct super_block *sb = BPF_CORE_READ(inode, i_sb);
+            if (sb) {
+                dev_t dev       = BPF_CORE_READ(sb, s_dev);
+                event->dev_major = (u32)dev >> MPROTECT_MINORBITS;
+                event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
+            }
+        }
+    }
+
+    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
+
+out:
+    return 0;
+}
+
+SEC("fentry/security_file_mprotect")
+int BPF_PROG(fentry__security_file_mprotect,
+             struct vm_area_struct *vma,
+             unsigned long req_prot,
+             unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
+    preempt_enable();
+
+    return r;
+}
+
+SEC("kprobe/security_file_mprotect")
+int BPF_KPROBE(kprobe__security_file_mprotect,
+               struct vm_area_struct *vma,
+               unsigned long req_prot,
+               unsigned long effective_prot)
+{
+    int r;
+
+    preempt_disable();
+    r = security_file_mprotect__enter(vma, req_prot, effective_prot);
     preempt_enable();
 
     return r;

--- a/quark-test.c
+++ b/quark-test.c
@@ -13,6 +13,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -1571,6 +1572,162 @@ t_shmget(const struct test *t, struct quark_queue_attr *qa)
 }
 
 static int
+t_mprotect(const struct test *t, struct quark_queue_attr *qa)
+{
+	struct quark_queue		 qq;
+	const struct quark_event	*qev;
+	const struct quark_mprotect	*qmprotect;
+	void				*addr[4];
+	void				*file_addr;
+	void				*suppressed_addr;
+	const size_t			 len = 4096;
+	struct stat			 st;
+	const int			 expected[] = {
+		PROT_EXEC,
+		PROT_READ | PROT_EXEC,
+		PROT_WRITE | PROT_EXEC,
+		PROT_READ | PROT_WRITE | PROT_EXEC,
+	};
+	const int			 suppressed[] = {
+		PROT_NONE,
+		PROT_READ,
+		PROT_WRITE,
+		PROT_READ | PROT_WRITE,
+	};
+	int				 fd;
+	int				 saw[nitems(expected)] = { 0 };
+	size_t				 i, j;
+	int				 seen = 0;
+
+	qa->flags |= QQ_MPROTECT;
+
+	if (quark_queue_open(&qq, qa) != 0)
+		err(1, "quark_queue_open");
+
+	suppressed_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+	    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (suppressed_addr == MAP_FAILED)
+		err(1, "mmap");
+
+	/* Non-executable effective protections must not enter the ring buffer. */
+	for (i = 0; i < nitems(suppressed); i++) {
+		if (mprotect(suppressed_addr, len, suppressed[i]) == -1)
+			err(1, "mprotect");
+	}
+
+	/* Requests rejected before the LSM hook must not enter the ring buffer. */
+	if (mprotect((void *)(uintptr_t)1, len, PROT_EXEC) != -1)
+		errx(1, "unaligned mprotect unexpectedly succeeded");
+
+	for (i = 0; i < nitems(expected); i++) {
+		addr[i] = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (addr[i] == MAP_FAILED)
+			err(1, "mmap");
+		if (mprotect(addr[i], len, expected[i]) == -1)
+			err(1, "mprotect");
+	}
+
+	while (seen < (int)nitems(expected)) {
+		qev = drain_for_pid(&qq, getpid());
+		if (!(qev->events & QUARK_EV_MPROTECT))
+			continue;
+		qmprotect = &qev->mprotect;
+		for (i = 0; i < nitems(expected); i++) {
+			if (qmprotect->req_prot == (u64)expected[i] &&
+			    qmprotect->vma_start <= (u64)(uintptr_t)addr[i] &&
+			    qmprotect->vma_end >=
+			    (u64)(uintptr_t)addr[i] + len)
+				break;
+		}
+		if (i == nitems(expected)) {
+			errx(1, "unexpected mprotect attempt req_prot 0x%llx",
+			    (unsigned long long)qmprotect->req_prot);
+		}
+		assert(qmprotect->prev_prot == (PROT_READ | PROT_WRITE));
+		assert(qmprotect->effective_prot == (u64)expected[i]);
+		assert(!qmprotect->file_backed);
+		assert(qmprotect->inode == 0);
+		assert(!saw[i]);
+		saw[i] = 1;
+		seen++;
+	}
+
+	for (i = 0; i < nitems(saw); i++)
+		assert(saw[i]);
+
+	/* File-backed identity is carried without resolving a pathname in BPF. */
+	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
+		err(1, "open");
+	if (fstat(fd, &st) == -1)
+		err(1, "fstat");
+	file_addr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (file_addr == MAP_FAILED)
+		err(1, "mmap");
+	if (mprotect(file_addr, len, PROT_READ | PROT_EXEC) == -1)
+		err(1, "mprotect");
+	do {
+		qev = drain_for_pid(&qq, getpid());
+	} while (!(qev->events & QUARK_EV_MPROTECT));
+	qmprotect = &qev->mprotect;
+	assert(qmprotect->vma_start <= (u64)(uintptr_t)file_addr);
+	assert(qmprotect->vma_end >= (u64)(uintptr_t)file_addr + len);
+	assert(qmprotect->prev_prot == PROT_READ);
+	assert(qmprotect->req_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->effective_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->file_backed);
+	assert(qmprotect->inode == (u64)st.st_ino);
+	assert(qmprotect->dev_major == (u32)major(st.st_dev));
+	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+
+#ifdef SYS_pkey_mprotect
+	/* The common LSM hook also observes pkey_mprotect without another probe. */
+	{
+		void *pkey_addr;
+
+		pkey_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (pkey_addr == MAP_FAILED)
+			err(1, "mmap");
+		if (syscall(SYS_pkey_mprotect, pkey_addr, len, PROT_EXEC, -1) == -1) {
+			if (errno != ENOSYS && errno != EINVAL)
+				err(1, "pkey_mprotect");
+		} else {
+			do {
+				qev = drain_for_pid(&qq, getpid());
+			} while (!(qev->events & QUARK_EV_MPROTECT));
+			qmprotect = &qev->mprotect;
+			assert(qmprotect->vma_start <= (u64)(uintptr_t)pkey_addr);
+			assert(qmprotect->vma_end >=
+			    (u64)(uintptr_t)pkey_addr + len);
+			assert(qmprotect->prev_prot ==
+			    (PROT_READ | PROT_WRITE));
+			assert(qmprotect->req_prot == PROT_EXEC);
+			assert(qmprotect->effective_prot == PROT_EXEC);
+			assert(!qmprotect->file_backed);
+		}
+		if (munmap(pkey_addr, len) == -1)
+			err(1, "munmap");
+	}
+#endif
+
+	if (munmap(suppressed_addr, len) == -1)
+		err(1, "munmap");
+	for (j = 0; j < nitems(addr); j++) {
+		if (munmap(addr[j], len) == -1)
+			err(1, "munmap");
+	}
+	if (munmap(file_addr, len) == -1)
+		err(1, "munmap");
+	if (close(fd) == -1)
+		err(1, "close");
+
+	quark_queue_close(&qq);
+
+	return (0);
+}
+
+static int
 t_shm_open(const struct test *t, struct quark_queue_attr *qa)
 {
 #ifdef NO_SHM_OPEN
@@ -2923,6 +3080,7 @@ struct test all_tests[] = {
 	T_EBPF(t_memfd),
 	T_EBPF(t_memfd_exec),
 	T_EBPF(t_shmget),
+	T_EBPF(t_mprotect),
 	T_EBPF(t_shm_open),
 	T_EBPF(t_tty_load),
 	T_EBPF(t_tty),

--- a/quark.c
+++ b/quark.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024-2026 Elastic NV */
 
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -192,6 +193,7 @@ raw_event_alloc(int type)
 	case RAW_PACKET:	/* caller allocates */
 	case RAW_FILE:		/* caller allocates */
 	case RAW_PTRACE:	/* nada */
+	case RAW_MPROTECT:	/* nada */
 	case RAW_MODULE_LOAD:	/* caller allocates */
 	case RAW_SHM:		/* caller allocates */
 	case RAW_TTY:		/* caller allocates */
@@ -231,6 +233,7 @@ raw_event_free(struct raw_event *raw)
 	case RAW_COMM:		/* nada */
 	case RAW_SOCK_CONN:	/* nada */
 	case RAW_PTRACE:	/* nada */
+	case RAW_MPROTECT:	/* nada */
 		break;
 	case RAW_PACKET:
 		free(raw->packet.quark_packet);
@@ -449,6 +452,7 @@ event_storage_clear(struct quark_queue *qq)
 	free(qq->event_storage.file);
 	qq->event_storage.file = NULL;
 	bzero(&qq->event_storage.ptrace, sizeof(qq->event_storage.ptrace));
+	bzero(&qq->event_storage.mprotect, sizeof(qq->event_storage.mprotect));
 	if (qq->event_storage.module_load != NULL) {
 		free(qq->event_storage.module_load->name);
 		free(qq->event_storage.module_load->version);
@@ -1788,6 +1792,8 @@ event_type_str(u64 event)
 		return "TTY";
 	case QUARK_EV_GETPID:
 		return "GETPID";
+	case QUARK_EV_MPROTECT:
+		return "MPROTECT";
 	default:
 		return "?";
 	}
@@ -2127,6 +2133,28 @@ module_taints_str(u64 taints, char *buf, size_t len)
 	buf[n] = 0;
 }
 
+static void
+mprotect_prot_str(u64 prot, char *buf, size_t len)
+{
+	size_t	n;
+
+	*buf = 0;
+	n = 0;
+	if (prot & PROT_READ) {
+		if (n + 1 < len)
+			buf[n++] = 'R';
+	}
+	if (prot & PROT_WRITE) {
+		if (n + 1 < len)
+			buf[n++] = 'W';
+	}
+	if (prot & PROT_EXEC) {
+		if (n + 1 < len)
+			buf[n++] = 'X';
+	}
+	buf[n] = 0;
+}
+
 #define P(...)						\
 	do {						\
 		if (fprintf(f, __VA_ARGS__) < 0)	\
@@ -2153,6 +2181,9 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 	const struct quark_container	*container;
 	const struct quark_ptrace	*ptrace;
 	const struct quark_module_load	*qml;
+	const struct quark_mprotect	*mprotect;
+	char				 prev_prot[4], req_prot[4];
+	char				 effective_prot[4];
 	int				 pid;
 
 	if (qev->events == QUARK_EV_BYPASS) {
@@ -2249,6 +2280,27 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		PF(fl, "name=%s version=%s srcversion=%s taints=0x%llx (%s)\n",
 		    qml->name, qml->version, qml->src_version,
 		    qml->taints, buf);
+	}
+
+	if (qev->events & QUARK_EV_MPROTECT) {
+		fl = "MPRO";
+
+		mprotect = &qev->mprotect;
+		mprotect_prot_str(mprotect->prev_prot, prev_prot,
+		    sizeof(prev_prot));
+		mprotect_prot_str(mprotect->req_prot, req_prot,
+		    sizeof(req_prot));
+		mprotect_prot_str(mprotect->effective_prot, effective_prot,
+		    sizeof(effective_prot));
+		PF(fl, "attempt vma=[0x%llx,0x%llx) "
+		    "prev=0x%llx (%s) req=0x%llx (%s) effective=0x%llx (%s) "
+		    "file_backed=%u inode=%llu dev=%u:%u\n",
+		    mprotect->vma_start, mprotect->vma_end,
+		    mprotect->prev_prot, prev_prot,
+		    mprotect->req_prot, req_prot,
+		    mprotect->effective_prot, effective_prot,
+		    mprotect->file_backed, mprotect->inode,
+		    mprotect->dev_major, mprotect->dev_minor);
 	}
 
 	if (qp == NULL)
@@ -4827,6 +4879,20 @@ raw_event_ptrace(struct quark_queue *qq, struct raw_event *raw)
 }
 
 static struct quark_event *
+raw_event_mprotect(struct quark_queue *qq, struct raw_event *raw)
+{
+	struct quark_event	*qev;
+
+	qev = &qq->event_storage;
+
+	qev->events = QUARK_EV_MPROTECT;
+	qev->process = quark_process_lookup(qq, raw->pid);
+	qev->mprotect = raw->mprotect.quark_mprotect;
+
+	return (qev);
+}
+
+static struct quark_event *
 raw_event_module_load(struct quark_queue *qq, struct raw_event *raw)
 {
 	struct quark_event	*qev;
@@ -5241,6 +5307,9 @@ quark_queue_get_event1(struct quark_queue *qq)
 			break;
 		case RAW_PTRACE:
 			qev = raw_event_ptrace(qq, raw);
+			break;
+		case RAW_MPROTECT:
+			qev = raw_event_mprotect(qq, raw);
 			break;
 		case RAW_MODULE_LOAD:
 			qev = raw_event_module_load(qq, raw);

--- a/quark.h
+++ b/quark.h
@@ -259,6 +259,7 @@ enum raw_types {
 	RAW_SHM,
 	RAW_TTY,
 	RAW_GETPID,
+	RAW_MPROTECT,
 	RAW_NUM_TYPES		/* must be last */
 };
 
@@ -406,8 +407,28 @@ struct quark_ptrace {
 	u64	data;
 };
 
+/*
+ * One executable attempt observed at security_file_mprotect(). The hook runs
+ * before the kernel commits the protection change and can fire once per VMA.
+ */
+struct quark_mprotect {
+	u64	vma_start;	/* VMA containing the attempted change */
+	u64	vma_end;
+	u64	prev_prot;	/* normalized PROT_READ/WRITE/EXEC bits */
+	u64	req_prot;	/* protection requested by userspace */
+	u64	effective_prot;	/* kernel-adjusted protection */
+	u64	inode;		/* zero for anonymous mappings */
+	u32	dev_major;	/* zero for anonymous mappings */
+	u32	dev_minor;	/* zero for anonymous mappings */
+	u32	file_backed;
+};
+
 struct raw_ptrace {
 	struct quark_ptrace quark_ptrace;
+};
+
+struct raw_mprotect {
+	struct quark_mprotect quark_mprotect;
 };
 
 struct quark_module_load {
@@ -482,6 +503,7 @@ struct raw_event {
 		struct raw_packet		packet;
 		struct raw_file			file;
 		struct raw_ptrace		ptrace;
+		struct raw_mprotect		mprotect;
 		struct raw_module_load		module_load;
 		struct raw_shm			shm;
 		struct raw_tty			tty;
@@ -518,6 +540,8 @@ struct quark_event {
 #define QUARK_EV_SHM			(1 << 12)
 #define QUARK_EV_TTY			(1 << 13)
 #define QUARK_EV_GETPID			(1 << 14)
+/* Experimental: not yet deduplicated, don't use */
+#define QUARK_EV_MPROTECT		(1 << 15)
 	u64				 events;
 	u64				 time;
 	const struct quark_process	*process;
@@ -526,6 +550,7 @@ struct quark_event {
 	const void			*bypass;
 	struct quark_file		*file;
 	struct quark_ptrace		 ptrace;
+	struct quark_mprotect		 mprotect;
 	struct quark_module_load	*module_load;
 	struct quark_shm		*shm;
 	struct quark_tty		*tty;
@@ -898,6 +923,8 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
+/* Experimental: not yet deduplicated, don't use */
+#define QQ_MPROTECT		(1 << 15)
 	int			 flags;
 	int			 max_length;
 	int			 cache_grace_time;	/* in ms */


### PR DESCRIPTION
Part 1 of 4 of the executable `mprotect()` event work, split out of #404 (which superseded #400) so each piece can be reviewed on its own. The stack, bottom-up, each PR based on the one before it:

1. this PR: core LSM event, private
2. #410 deduplicate per process life, make public (`quark-mon -u`, manual pages, CHANGES)
3. #412 backing-file path on file-backed events
4. #413 Go bindings

## Summary

Adds `QUARK_EV_MPROTECT` and `QQ_MPROTECT`. The eBPF probe reports each VMA that reaches the `security_file_mprotect` LSM hook with effective execute permission, carrying the previous, requested and kernel-adjusted effective protection (so `READ_IMPLIES_EXEC` is visible) plus backing-file identity (inode, dev). It covers `mprotect(2)`, `pkey_mprotect(2)` and compat callers. The hook runs before the change is committed, so an event is an attempt, not a completed change.

This PR is deliberately private in the `QQ_GETPID` sense: the flags exist in `quark.h`, marked experimental, so `t_mprotect` can drive the probe, but there is no `quark-mon` flag, manual page or CHANGES entry. Those land with the deduplication in #410, so `main` never carries a public, per-call noisy mprotect event. Measurements motivating the deduplication are in #410.

Rebuilt from #404 on top of the zeroed event buffer helper (#405); the fixed-size event uses `get_zeroed_event_buffer()` like the other fixed-size events. `QQ_MPROTECT` takes bit 15, freed by the `QQ_MONOTONIC` removal.

## Tests

`t_mprotect` (ebpf backend): non-executable protections and a rejected unaligned call must not emit; the four anonymous RW→{X, RX, WX, RWX} transitions each emit exactly once with the expected previous, requested and effective protection; the file-backed event carries the inode and dev of `/proc/self/exe`; `pkey_mprotect` is observed through the same hook. Passes locally on Ubuntu 6.8 (fentry).
