### PR TITLE
Deduplicate mprotect events per process life and make them public

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -175,3 +175,12 @@ Changes from 0.8 to 0.9
   o The eBPF ring buffer is now sized at load from CPU count (512 KiB
     per CPU, rounded up to a power of two, floored at 4 MiB and
     capped at 64 MiB) instead of a fixed 4 MiB.
+  o Added executable mprotect() attempt events (QUARK_EV_MPROTECT, -u on
+    quark-mon). The eBPF probe reports each VMA that reaches the
+    security_file_mprotect() check with effective execute permission, including
+    previous/requested/effective protection and backing-file identity. These
+    events cover mprotect(), pkey_mprotect(), and compat callers, but do not
+    assert that the protection change ultimately succeeded.
+    Only the first occurrence of each protection transition (previous
+    protection, effective protection, file-backedness) is reported per process
+    life; the state resets on execve() and process exit.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -43,6 +43,8 @@ static void	bump_memlock(void);
 #define RINGBUF_BYTES_PER_CPU	(1U << 19)	/* 512 KiB */
 #define RINGBUF_MIN_SIZE	(1U << 22)	/* 4 MiB */
 #define RINGBUF_MAX_SIZE	(1U << 26)	/* 64 MiB */
+/* Processes with a reported executable mprotect transition, see probes */
+#define MPROTECT_SEEN_MAX_ENTRIES	16384
 
 static u32
 bpf_ringbuf_size(int ncpu)
@@ -1380,6 +1382,20 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 		else
 			bpf_program__set_autoload(
 			    p->progs.kprobe__security_file_mprotect, 1);
+		/*
+		 * Turns on the dedup bookkeeping in the always loaded exec
+		 * and exit probes; the map is only sized (and created) here,
+		 * so it costs nothing when the feature is off.
+		 */
+		p->rodata->mprotect_enabled = 1;
+		if (bpf_map__set_max_entries(p->maps.mprotect_seen,
+		    MPROTECT_SEEN_MAX_ENTRIES) != 0) {
+			qwarn("bpf_map__set_max_entries mprotect_seen");
+			goto fail;
+		}
+	} else if (bpf_map__set_autocreate(p->maps.mprotect_seen, 0) != 0) {
+		qwarn("bpf_map__set_autocreate mprotect_seen");
+		goto fail;
 	}
 
 	if (qq->flags & QQ_GETPID)

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -36,6 +36,92 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define MPROTECT_MINORBITS 20
 #define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
 
+#ifndef EEXIST
+#define EEXIST 17 /* uapi asm-generic/errno-base.h; not carried by vmlinux.h */
+#endif
+
+// Set from userspace when QQ_MPROTECT is enabled. Everything that touches
+// mprotect_seen from the always loaded exec and exit probes is behind this
+// flag, so with the feature off the verifier prunes it and the map is not
+// even created.
+const volatile bool mprotect_enabled = false;
+
+/*
+ * Executable mprotect transitions already reported for a process life, one
+ * entry per tgid. A transition id packs the previous protection (3 bits), the
+ * effective new protection (3 bits) and whether the mapping is file backed
+ * (1 bit), so all 128 fit a two word bitmap. The entry is dropped when the
+ * process execs or dies (each program image starts fresh); LRU eviction is a
+ * safe backstop since an evicted entry only causes a duplicate event, never a
+ * lost one. Sized from userspace, see bpf_queue_open1().
+ */
+struct mprotect_seen_bits {
+    u64 bits[2];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u32);
+    __type(value, struct mprotect_seen_bits);
+    __uint(max_entries, 0);
+} mprotect_seen SEC(".maps");
+
+static u32 mprotect_transition_id(u64 prev_prot, u64 effective_prot, u64 file_backed)
+{
+    return ((prev_prot & 0x7) << 4) | ((effective_prot & 0x7) << 1) | (file_backed & 0x1);
+}
+
+// Returns true if the transition was already reported for this process life.
+// The first transition of a life creates the entry with BPF_NOEXIST so
+// concurrent threads racing for it get exactly one winner. Only a confirmed
+// "already reported" suppresses -- any other failure reports, so the failure
+// mode is a duplicate event, never a lost one.
+static bool mprotect_seen__test_and_set(u32 tgid, u32 id)
+{
+    u32 word = (id >> 6) & 1;
+    u64 bit  = 1ULL << (id & 63);
+
+    struct mprotect_seen_bits *seen = bpf_map_lookup_elem(&mprotect_seen, &tgid);
+    if (seen == NULL) {
+        // Constant stack offsets on purpose: indexing the stack copy by word
+        // is a variable offset stack access, which kernels before 5.13 reject.
+        struct mprotect_seen_bits fresh = {
+            .bits = { word ? 0 : bit, word ? bit : 0 },
+        };
+
+        // Compare in 32 bits: with the JIT enabled, the verifier rewrites map
+        // helper calls into direct calls to the map ops (fixup_bpf_calls), and
+        // those returned int until Linux 6.4 (d7ba4cc900bf), leaving a
+        // zero-extended 32-bit value in r0 on older kernels. A 64-bit compare
+        // against -EEXIST never matches there. Ordinary helpers return through
+        // a u64 wrapper and are sign-extended correctly; only map helpers need
+        // this.
+        if ((int)bpf_map_update_elem(&mprotect_seen, &tgid, &fresh, BPF_NOEXIST) != -EEXIST)
+            return false;
+        // Lost the race for the entry, test the bit in the winner's.
+        seen = bpf_map_lookup_elem(&mprotect_seen, &tgid);
+        if (seen == NULL)
+            return false;
+    }
+
+    if (seen->bits[word] & bit)
+        return true;
+    // Plain read-test-write: an atomic or needs Linux 5.12 and -mcpu=v3. Two
+    // threads of one process racing on the same transition can both get here
+    // and both report, a duplicate, never a lost event.
+    seen->bits[word] |= bit;
+
+    return false;
+}
+
+static void mprotect_seen__clear(u32 tgid)
+{
+    if (!mprotect_enabled)
+        return;
+
+    bpf_map_delete_elem(&mprotect_seen, &tgid);
+}
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -103,6 +189,10 @@ int BPF_PROG(sched_process_exec,
     // exec is valid and something we want to capture
     if (is_kernel_thread(task))
         goto out;
+
+    // The address space is replaced on exec; reported mprotect transitions
+    // belong to the previous program image, so start fresh.
+    mprotect_seen__clear(BPF_CORE_READ(task, tgid));
 
     struct ebpf_process_exec_event *event = get_event_buffer();
     if (!event)
@@ -214,6 +304,11 @@ static int disassociate_ctty__enter(int on_exit)
 
     if (!on_exit || is_kernel_thread(task))
         return 0;
+
+    // do_exit calls disassociate_ctty(1) only when the whole thread group is
+    // dead, so this runs exactly once per process; drop its dedup state so a
+    // recycled tgid does not inherit (and suppress) old transitions.
+    mprotect_seen__clear(BPF_CORE_READ(task, tgid));
 
     event = get_event_buffer();
     if (event == NULL)
@@ -500,6 +595,12 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     unsigned long vm_flags = BPF_CORE_READ(vma, vm_flags);
     u64 prev_prot          = mprotect_vm_flags_to_prot(vm_flags);
     struct file *file      = BPF_CORE_READ(vma, vm_file);
+
+    // One event per (transition, file-backedness) per process life.
+    u32 tgid = bpf_get_current_pid_tgid() >> 32;
+    if (mprotect_seen__test_and_set(tgid, mprotect_transition_id(prev_prot, effective_prot,
+                                                                 file != NULL)))
+        goto out;
 
     struct ebpf_process_mprotect_event *event = get_zeroed_event_buffer(sizeof(*event));
     if (!event)

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -36,10 +36,6 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define MPROTECT_MINORBITS 20
 #define MPROTECT_MINORMASK ((1U << MPROTECT_MINORBITS) - 1)
 
-#ifndef EEXIST
-#define EEXIST 17 /* uapi asm-generic/errno-base.h; not carried by vmlinux.h */
-#endif
-
 // Set from userspace when QQ_MPROTECT is enabled. Everything that touches
 // mprotect_seen from the always loaded exec and exit probes is behind this
 // flag, so with the feature off the verifier prunes it and the map is not
@@ -49,67 +45,47 @@ const volatile bool mprotect_enabled = false;
 /*
  * Executable mprotect transitions already reported for a process life, one
  * entry per tgid. A transition id packs the previous protection (3 bits), the
- * effective new protection (3 bits) and whether the mapping is file backed
- * (1 bit), so all 128 fit a two word bitmap. The entry is dropped when the
- * process execs or dies (each program image starts fresh); LRU eviction is a
- * safe backstop since an evicted entry only causes a duplicate event, never a
- * lost one. Sized from userspace, see bpf_queue_open1().
+ * read/write bits of the effective new protection (2 bits, execute is always
+ * set by the time we get here) and whether the mapping is file backed (1 bit),
+ * so all 64 fit one word. The entry is dropped when the process execs or dies
+ * (each program image starts fresh); LRU eviction is a safe backstop since an
+ * evicted entry only causes a duplicate event, never a lost one. Sized from
+ * userspace, see bpf_queue_open1().
  */
-struct mprotect_seen_bits {
-    u64 bits[2];
-};
-
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, u32);
-    __type(value, struct mprotect_seen_bits);
+    __type(value, u64);
     __uint(max_entries, 0);
 } mprotect_seen SEC(".maps");
 
 static u32 mprotect_transition_id(u64 prev_prot, u64 effective_prot, u64 file_backed)
 {
-    return ((prev_prot & 0x7) << 4) | ((effective_prot & 0x7) << 1) | (file_backed & 0x1);
+    return ((prev_prot & 0x7) << 3) | ((effective_prot & 0x3) << 1) | (file_backed & 0x1);
 }
 
 // Returns true if the transition was already reported for this process life.
-// The first transition of a life creates the entry with BPF_NOEXIST so
-// concurrent threads racing for it get exactly one winner. Only a confirmed
-// "already reported" suppresses -- any other failure reports, so the failure
-// mode is a duplicate event, never a lost one.
+// Best effort: the bit is claimed with a plain read-test-write since an atomic
+// or needs Linux 5.12 and -mcpu=v3, and the entry is created with BPF_NOEXIST
+// so a racing thread can't clobber bits already set. Two threads of one
+// process racing on the same transition can both report, and any map failure
+// reports, so the failure mode is a duplicate event, never a lost one.
 static bool mprotect_seen__test_and_set(u32 tgid, u32 id)
 {
-    u32 word = (id >> 6) & 1;
-    u64 bit  = 1ULL << (id & 63);
+    u64  bit  = 1ULL << (id & 63);
+    u64 *seen = bpf_map_lookup_elem(&mprotect_seen, &tgid);
 
-    struct mprotect_seen_bits *seen = bpf_map_lookup_elem(&mprotect_seen, &tgid);
     if (seen == NULL) {
-        // Constant stack offsets on purpose: indexing the stack copy by word
-        // is a variable offset stack access, which kernels before 5.13 reject.
-        struct mprotect_seen_bits fresh = {
-            .bits = { word ? 0 : bit, word ? bit : 0 },
-        };
+        u64 zero = 0;
 
-        // Compare in 32 bits: with the JIT enabled, the verifier rewrites map
-        // helper calls into direct calls to the map ops (fixup_bpf_calls), and
-        // those returned int until Linux 6.4 (d7ba4cc900bf), leaving a
-        // zero-extended 32-bit value in r0 on older kernels. A 64-bit compare
-        // against -EEXIST never matches there. Ordinary helpers return through
-        // a u64 wrapper and are sign-extended correctly; only map helpers need
-        // this.
-        if ((int)bpf_map_update_elem(&mprotect_seen, &tgid, &fresh, BPF_NOEXIST) != -EEXIST)
-            return false;
-        // Lost the race for the entry, test the bit in the winner's.
+        bpf_map_update_elem(&mprotect_seen, &tgid, &zero, BPF_NOEXIST);
         seen = bpf_map_lookup_elem(&mprotect_seen, &tgid);
         if (seen == NULL)
             return false;
     }
-
-    if (seen->bits[word] & bit)
+    if (*seen & bit)
         return true;
-    // Plain read-test-write: an atomic or needs Linux 5.12 and -mcpu=v3. Two
-    // threads of one process racing on the same transition can both get here
-    // and both report, a duplicate, never a lost event.
-    seen->bits[word] |= bit;
+    *seen |= bit;
 
     return false;
 }

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -6,7 +6,7 @@
 .Nd monitor and print quark events
 .Sh SYNOPSIS
 .Nm quark-mon
-.Op Fl BbDEeFGgHhkMNnSsTtv
+.Op Fl BbDEeFGgHhkMNnSsTtuv
 .Op Fl C Ar filename
 .Op Fl K Ar kubeconfig
 .Op Fl l Ar maxlength
@@ -130,6 +130,12 @@ Enable ptrace event tracing.
 .It Fl t
 Don't supress thread events, this is only useful for debugging and will likely
 be zapped in the future.
+.It Fl u
+Enable executable mprotect attempt events (EBPF only).
+One event is emitted for every VMA that reaches the
+.Fn security_file_mprotect
+check with effective execute permission.
+The event does not assert that the protection change ultimately succeeded.
 .It Fl v
 Increase verbosity, can be specified multiple times for more verbosity.
 .It Fl V

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -120,7 +120,7 @@ static void
 usage(void)
 {
 	fprintf(stderr, "usage: %s -h\n", program_invocation_short_name);
-	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNnSsTtv]\n",
+	fprintf(stderr, "usage: %s [-BbDeFGgHhkLMNnSsTtuv]\n",
 	    program_invocation_short_name);
 	fprintf(stderr, "%16c [-C filename ] [-K kubeconfig] "
 	    "[-l maxlength] [-m maxnodes]\n", ' ');
@@ -188,7 +188,7 @@ main(int argc, char *argv[])
 	    !strcmp(argv[1], "help")))
 		display_man();
 
-	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsvV")) != -1) {
+	while ((ch = getopt(argc, argv, "BbC:DEeFGgHhK:kLl:Mm:NnP:Ttr:SsuvV")) != -1) {
 		const char *errstr;
 
 		switch (ch) {
@@ -311,6 +311,9 @@ main(int argc, char *argv[])
 		}
 		case 'T':
 			qa.flags |= QQ_PTRACE;
+			break;
+		case 'u':
+			qa.flags |= QQ_MPROTECT;
 			break;
 		case 't':
 			qa.flags |= QQ_THREAD_EVENTS;

--- a/quark-test.c
+++ b/quark-test.c
@@ -1656,6 +1656,18 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	for (i = 0; i < nitems(saw); i++)
 		assert(saw[i]);
 
+	/*
+	 * A repeated transition must not produce a second event for the same
+	 * process life: flip addr[0] back and redo the identical RW->X change.
+	 * The file-backed event drained below doubles as the sentinel; if the
+	 * duplicate were wrongly emitted it would be drained first and the
+	 * file_backed asserts would trip.
+	 */
+	if (mprotect(addr[0], len, PROT_READ | PROT_WRITE) == -1)
+		err(1, "mprotect");
+	if (mprotect(addr[0], len, expected[0]) == -1)
+		err(1, "mprotect");
+
 	/* File-backed identity is carried without resolving a pathname in BPF. */
 	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
 		err(1, "open");
@@ -1685,7 +1697,11 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	{
 		void *pkey_addr;
 
-		pkey_addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		/*
+		 * Map read-only so this is an R->X transition: the RW->X id
+		 * was consumed by expected[0] above and would be deduplicated.
+		 */
+		pkey_addr = mmap(NULL, len, PROT_READ,
 		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 		if (pkey_addr == MAP_FAILED)
 			err(1, "mmap");
@@ -1700,8 +1716,7 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 			assert(qmprotect->vma_start <= (u64)(uintptr_t)pkey_addr);
 			assert(qmprotect->vma_end >=
 			    (u64)(uintptr_t)pkey_addr + len);
-			assert(qmprotect->prev_prot ==
-			    (PROT_READ | PROT_WRITE));
+			assert(qmprotect->prev_prot == PROT_READ);
 			assert(qmprotect->req_prot == PROT_EXEC);
 			assert(qmprotect->effective_prot == PROT_EXEC);
 			assert(!qmprotect->file_backed);

--- a/quark.h
+++ b/quark.h
@@ -540,7 +540,6 @@ struct quark_event {
 #define QUARK_EV_SHM			(1 << 12)
 #define QUARK_EV_TTY			(1 << 13)
 #define QUARK_EV_GETPID			(1 << 14)
-/* Experimental: not yet deduplicated, don't use */
 #define QUARK_EV_MPROTECT		(1 << 15)
 	u64				 events;
 	u64				 time;
@@ -923,7 +922,6 @@ struct quark_queue_attr {
 #define QQ_MODULE_LOAD		(1 << 12)
 #define QQ_GETPID		(1 << 13)
 #define QQ_NOVA			(1 << 14)
-/* Experimental: not yet deduplicated, don't use */
 #define QQ_MPROTECT		(1 << 15)
 	int			 flags;
 	int			 max_length;

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -62,6 +62,16 @@ Process changed image, result of an exec.
 Process exited.
 .It Dv QUARK_EV_SETPROCTITLE
 Process changed its name (COMM).
+.It Dv QUARK_EV_MPROTECT
+An executable protection attempt reached the kernel's
+.Fn security_file_mprotect
+check.
+The
+.Em mprotect
+member contains the VMA bounds, normalized previous protection,
+userspace-requested and kernel-adjusted protection, and backing-file identity.
+It describes an attempt and does not assert that the protection change was
+committed.
 .El
 .Pp
 It's important to note that

--- a/quark_queue_open.3
+++ b/quark_queue_open.3
@@ -118,6 +118,11 @@ in
 .Em quark_events .
 Entry leader is how the process entered the system, it is disabled by default as
 it is Elastic/ECS specific.
+.It Dv QQ_MPROTECT
+Enable EBPF-only executable mprotect attempt events.
+Each event describes one VMA reaching the kernel's
+.Fn security_file_mprotect
+check and does not imply that the protection change was committed.
 .El
 .It Em max_length
 The maximum size of the internal buffering queue in number of events.


### PR DESCRIPTION
Part 2 of 4 of the executable `mprotect()` event work, split out of #404 (which superseded #400) so each piece can be reviewed on its own. The stack, bottom-up, each PR based on the one before it:

1. #409 core LSM event, private
2. this PR: deduplicate per process life, make public (`quark-mon -u`, manual pages, CHANGES)
3. #412 backing-file path on file-backed events
4. #413 Go bindings

## Summary

One event per unique protection transition per process life. An LRU map keyed by tgid holds a one-word bitmap of the 64 possible transitions: previous protection (3 bits), read/write bits of the effective new protection (2 bits, execute is always set by the time the dedup runs) and file-backedness (1 bit). The entry is created empty with `BPF_NOEXIST` so a racing thread can't clobber bits already set, and every transition then tests and sets its bit with a plain read-modify-write (an atomic or needs Linux 5.12 and `-mcpu=v3`). Best effort by design: two threads of one process racing on the same transition can both report, and any map failure reports, so the failure mode is a duplicate event, never a lost one. The entry is dropped on `execve` (new program image) and on process exit (tgid reuse), one delete each; LRU eviction is a safe backstop for the same reason.

The feature costs nothing when `QQ_MPROTECT` is off: the exec and exit bookkeeping sits behind a rodata flag the verifier prunes, and the map, declared with zero entries, is sized from userspace only when enabled (16384 processes, about 1 MB) and otherwise not created at all, following the pattern #407 set for the ring buffer.

With duplicates gone the event is fit for consumption, so this PR also makes it public: the experimental markers on `QQ_MPROTECT`/`QUARK_EV_MPROTECT` go away, `quark-mon` gets `-u`, `quark_queue_open(3)` and `quark_queue_get_event(3)` document the flag and event, and CHANGES gets its entry.

The second commit is @christos68k's simplification of the dedup (one word instead of two, no `-EEXIST` compare), cherry-picked from his draft branch.

## Measurements

Carried over from #404. From a harness that runs identical deterministic workloads on two identical Ubuntu 24.04 GCP VMs (this approach vs. the `sys_enter/exit_mprotect` tracepoint approach of #367):

| workload | executable attempts | events emitted (LSM hook + dedup) | events emitted (#367) |
|---|---|---|---|
| Firefox headless, 5 min deterministic browse | 24,922 | **1** (anon RW→X JIT signature) | 25,389 |
| node JIT workload | 34 | 4 | 34 |
| JVM JIT workload | 2 | 2 | 2 |
| file-backed/memfd/anon mprotect exerciser | 450 | 9 | 450 |

A throwaway instrumentation build also correlated every hook-side attempt with its syscall exit across all workloads: 100% of executable attempts seen at the LSM hook committed (e.g. Firefox 24,919/24,919 succeeded, 0 failed), so hook-side "attempt" events are not inflated by failing calls in practice.

## Tests

`t_mprotect`: a repeated RW→X transition on the same mapping must not re-emit (the file-backed event drained afterwards doubles as the sentinel), and the `pkey_mprotect` case now uses R→X so it is not deduplicated against the earlier RW→X. Passes locally on 6.8 (Ubuntu), 5.14 (RHEL 9.3) and 5.8.15 (Fedora 33), and the full suite passes on 6.8, which also covers the disabled path since every other ebpf test loads the exec and exit probes with the map not created.
