### PR TITLE
Add mprotect deduplication counters to quark_queue_stats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -181,3 +181,5 @@ Changes from 0.8 to 0.9
     Only the first occurrence of each protection transition (previous
     protection, effective protection, file-backedness) is reported per process
     life; the state resets on execve() and process exit.
+  o quark_queue_stats{} got a quark_mprotect_stats member (submitted,
+    suppressed, reserve_failed), also shown by quark-mon -M.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -1439,11 +1439,12 @@ bpf_queue_populate(struct quark_queue *qq)
 static int
 bpf_queue_update_stats(struct quark_queue *qq)
 {
-	struct bpf_queue	*bqq  = qq->queue_be;
-	struct ebpf_event_stats	*pcpu_ees;
-	u32			 zero = 0;
-	u64			 lost;
-	int			 i, num_cpus;
+	struct bpf_queue			*bqq  = qq->queue_be;
+	struct ebpf_event_stats		*pcpu_ees = NULL;
+	struct ebpf_mprotect_stats	*pcpu_mps = NULL;
+	u32				 zero = 0;
+	u64				 lost;
+	int				 i, num_cpus;
 
 	if ((num_cpus = libbpf_num_possible_cpus()) <= 0) {
 		qwarnx("bad libbpf_num_possible_cpus: %d", num_cpus);
@@ -1469,11 +1470,40 @@ bpf_queue_update_stats(struct quark_queue *qq)
 		lost += pcpu_ees[i].lost;
 	qq->stats.lost = lost;
 	free(pcpu_ees);
+	pcpu_ees = NULL;
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return (0);
+
+	if ((pcpu_mps = calloc(num_cpus, sizeof(*pcpu_mps))) == NULL) {
+		qwarn("calloc");
+		goto fail;
+	}
+
+#ifdef HAVE_STATIC_ASSERT
+	static_assert(sizeof(*pcpu_mps) % 8 == 0,
+	    "struct ebpf_mprotect_stats must be 8 byte aligned");
+#endif
+
+	if (bpf_map__lookup_elem(bqq->probes->maps.mprotect_stats, &zero,
+	    sizeof(zero), pcpu_mps, sizeof(*pcpu_mps) * num_cpus, 0) != 0) {
+		qwarn("bpf_map__lookup_elem");
+		goto fail;
+	}
+
+	bzero(&qq->stats.mprotect, sizeof(qq->stats.mprotect));
+	for (i = 0; i < num_cpus; i++) {
+		qq->stats.mprotect.submitted += pcpu_mps[i].submitted;
+		qq->stats.mprotect.suppressed += pcpu_mps[i].suppressed;
+		qq->stats.mprotect.reserve_failed += pcpu_mps[i].reserve_failed;
+	}
+	free(pcpu_mps);
 
 	return (0);
 
 fail:
 	free(pcpu_ees);
+	free(pcpu_mps);
 
 	return (-1);
 }

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -462,4 +462,12 @@ struct ebpf_event_stats {
     uint64_t dns_zero_body; // indicates that the dns body of a sk_buff was unavailable
 } __attribute__((aligned(8)));
 
+// Executable mprotect attempt accounting.
+struct ebpf_mprotect_stats {
+    uint64_t submitted;      // events written to the ring buffer
+    uint64_t suppressed;     // attempts deduplicated (transition already
+                             // reported for this process life)
+    uint64_t reserve_failed; // event buffer/ring buffer write failures
+} __attribute__((aligned(8)));
+
 #endif // EBPF_EVENTPROBE_EBPFEVENTPROTO_H

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -40,6 +40,13 @@ DECL_FIELD_OFFSET(iov_iter, __iov);
 #define EEXIST 17 /* uapi asm-generic/errno-base.h; not carried by vmlinux.h */
 #endif
 
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, struct ebpf_mprotect_stats);
+    __uint(max_entries, 1);
+} mprotect_stats SEC(".maps");
+
 /*
  * One mprotect event per (transition, file-backedness) per process life.
  * Key is tgid << 8 | transition id; the transition id packs the previous
@@ -533,6 +540,9 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
                                          unsigned long req_prot,
                                          unsigned long effective_prot)
 {
+    u32 zero = 0;
+    struct ebpf_mprotect_stats *stats = bpf_map_lookup_elem(&mprotect_stats, &zero);
+
     if (ebpf_events_is_trusted_pid() || !vma)
         goto out;
 
@@ -565,12 +575,18 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     // against -EEXIST never matches there. Ordinary helpers return through a
     // u64 wrapper and are sign-extended correctly; only map helpers need this.
     if ((int)bpf_map_update_elem(&mprotect_seen, &dedup_key, &dedup_val,
-                                 BPF_NOEXIST) == -EEXIST)
+                                 BPF_NOEXIST) == -EEXIST) {
+        if (stats)
+            stats->suppressed++;
         goto out;
+    }
 
     struct ebpf_process_mprotect_event *event = get_zeroed_event_buffer(sizeof(*event));
-    if (!event)
+    if (!event) {
+        if (stats)
+            stats->reserve_failed++;
         goto out;
+    }
 
     event->hdr.type = EBPF_EVENT_PROCESS_MPROTECT;
     event->hdr.ts   = bpf_ktime_get_boot_ns();
@@ -602,7 +618,11 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
         }
     }
 
-    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
+    if (ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0) == 0) {
+        if (stats)
+            stats->submitted++;
+    } else if (stats)
+        stats->reserve_failed++;
 
 out:
     return 0;

--- a/quark-mon.8
+++ b/quark-mon.8
@@ -108,6 +108,15 @@ has been reached.
 This is used purely for internal debugging.
 .It Fl M
 Run in a simple benchmark form that only counts and display stats.
+When executable mprotect events are enabled with
+.Fl u ,
+also display the cumulative mprotect counters: events submitted
+.Pq Li mpro-sent ,
+attempts suppressed because the same protection transition was already
+reported for that process life
+.Pq Li mpro-dup ,
+and event write failures
+.Pq Li mpro-rsvfail .
 .It Fl N
 Enable DNS events (experimental).
 .It Fl n

--- a/quark-mon.c
+++ b/quark-mon.c
@@ -57,6 +57,26 @@ dump_stats(struct quark_queue *qq)
 	    s.insertions, s.removals, s.aggregations,
 	    s.non_aggregations, s.lost, s.garbage_collections, s.stalls);
 	fputc('\n', stderr);
+
+	if (!(qq->flags & QQ_MPROTECT))
+		return;
+
+	fprintf(stderr,
+	    "%14s"
+	    "%14s"
+	    "%14s",
+	    "mpro-sent",
+	    "mpro-dup",
+	    "mpro-rsvfail");
+	fputc('\n', stderr);
+	fprintf(stderr,
+	    "%14llu"
+	    "%14llu"
+	    "%14llu",
+	    s.mprotect.submitted,
+	    s.mprotect.suppressed,
+	    s.mprotect.reserve_failed);
+	fputc('\n', stderr);
 }
 
 static const char *

--- a/quark-test.c
+++ b/quark-test.c
@@ -1555,6 +1555,7 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	void				*suppressed_addr;
 	const size_t			 len = 4096;
 	struct stat			 st;
+	struct quark_queue_stats	 stats;
 	const int			 expected[] = {
 		PROT_EXEC,
 		PROT_READ | PROT_EXEC,
@@ -1664,6 +1665,15 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	assert(qmprotect->inode == (u64)st.st_ino);
 	assert(qmprotect->dev_major == (u32)major(st.st_dev));
 	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+
+	/*
+	 * The counters must reflect the above: at least the four anonymous
+	 * transitions plus the file-backed one were submitted, and the repeated
+	 * RW->X transition was suppressed.
+	 */
+	quark_queue_get_stats(&qq, &stats);
+	assert(stats.mprotect.submitted >= nitems(expected) + 1);
+	assert(stats.mprotect.suppressed >= 1);
 
 #ifdef SYS_pkey_mprotect
 	/* The common LSM hook also observes pkey_mprotect without another probe. */

--- a/quark.h
+++ b/quark.h
@@ -887,6 +887,13 @@ struct quark_sysinfo {
 	char	 *os_pretty_name;
 };
 
+struct quark_mprotect_stats {
+	u64	submitted;	/* events written to the ring buffer */
+	u64	suppressed;	/* deduplicated: transition already reported
+				   for that process life */
+	u64	reserve_failed;	/* event buffer/ring buffer write failures */
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -896,6 +903,7 @@ struct quark_queue_stats {
 	u64	garbage_collections;
 	u64	stalls;     /* stalled perf rings due to corruption, only for QQ_KPROBE */
 	int	backend;    /* active backend, QQ_EBPF or QQ_KPROBE */
+	struct quark_mprotect_stats mprotect;
 	/* TODO u64    peak_nodes; */
 };
 

--- a/quark_queue_get_stats.3
+++ b/quark_queue_get_stats.3
@@ -17,6 +17,12 @@ into
 .Vt quark_queue_stats
 is defined as:
 .Bd -literal -offset indent
+struct quark_mprotect_stats {
+	u64	submitted;
+	u64	suppressed;
+	u64	reserve_failed;
+};
+
 struct quark_queue_stats {
 	u64	insertions;
 	u64	removals;
@@ -26,6 +32,7 @@ struct quark_queue_stats {
 	u64	garbage_collections;
 	u64	stalls;
 	int	backend;
+	struct quark_mprotect_stats mprotect;
 };
 .Ed
 .Bl -tag -width "non_aggregations"
@@ -68,6 +75,20 @@ Active queue backend, either
 .Dv QQ_EBPF
 or
 .Dv QQ_KPROBE .
+.It Em mprotect
+Cumulative counters collected when
+.Dv QQ_MPROTECT
+is enabled:
+.Em submitted
+counts events written to the ring buffer,
+.Em suppressed
+counts attempts that were not emitted because the same protection transition
+(previous protection, effective protection, file-backedness) was already
+reported for that process life (the per-process state is dropped on
+.Xr execve 2
+and process exit), and
+.Em reserve_failed
+counts event buffer or ring buffer write failures.
 .El
 .Sh SEE ALSO
 .Xr quark_event_dump 3 ,


### PR DESCRIPTION
Part 3 of 5 of the executable `mprotect()` event work, split out of #404 (which superseded #400) so each piece can be reviewed on its own. The stack, bottom-up, each PR based on the one before it:

1. #409 core LSM event, private
2. #410 deduplicate per process life, make public (`quark-mon -u`, manual pages, CHANGES)
3. this PR: deduplication counters in `quark_queue_stats`
4. #412 backing-file path on file-backed events
5. #413 Go bindings

## Summary

`quark_queue_stats{}` gains a `quark_mprotect_stats` member with `submitted`, `suppressed` and `reserve_failed`, fed by a per-CPU array the probe bumps on every ring buffer write, dedup suppression and buffer failure. It is read through `quark_queue_get_stats(3)` and shown by `quark-mon -M` when `-u` is set, so deployments can observe how much the deduplication absorbs.

## Tests

`t_mprotect` now asserts that the counters reflect the transitions it drove: at least the four anonymous submissions plus the file-backed one, and at least one suppression from the repeated RW→X. This assertion is new relative to #404, which did not exercise the counters. Passes locally on Ubuntu 6.8 (fentry).
