### PR TITLE
Carry the backing-file path on file-backed mprotect events

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -183,4 +183,6 @@ Changes from 0.8 to 0.9
     assert that the protection change ultimately succeeded.
     Only the first occurrence of each protection transition (previous
     protection, effective protection, file-backedness) is reported per process
-    life; the state resets on execve() and process exit.
+    life; the state resets on execve() and process exit. File-backed attempts
+    additionally carry the mount-namespace relative path in
+    quark_mprotect.path, NULL for anonymous mappings.

--- a/CHANGES
+++ b/CHANGES
@@ -185,4 +185,6 @@ Changes from 0.8 to 0.9
     protection, effective protection, file-backedness) is reported per process
     life; the state resets on execve() and process exit. File-backed attempts
     additionally carry the mount-namespace relative path in
-    quark_mprotect.path, NULL for anonymous mappings.
+    quark_mprotect.path (NULL for anonymous mappings) and are deduplicated per
+    file within the process life rather than per process, so a process making
+    a second file executable the same way is reported again.

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -698,6 +698,21 @@ ebpf_events_to_raw(struct quark_queue *qq, struct ebpf_event_header *ev)
 		qmprotect->dev_major = mprotect->dev_major;
 		qmprotect->dev_minor = mprotect->dev_minor;
 		qmprotect->file_backed = mprotect->file_backed;
+		qmprotect->path = NULL;
+
+		FOR_EACH_VARLEN_FIELD(mprotect->vl_fields, field) {
+			switch (field->type) {
+			case EBPF_VL_FIELD_PATH:
+				if (field->size > 0)
+					qmprotect->path =
+					    strndup(field->data, field->size);
+				break;
+			default:
+				qwarnx("unhandled field type %d", field->type);
+				break;
+			}
+		}
+
 		break;
 	}
 	case EBPF_EVENT_PROCESS_LOAD_MODULE: {

--- a/bpf_queue.c
+++ b/bpf_queue.c
@@ -43,8 +43,9 @@ static void	bump_memlock(void);
 #define RINGBUF_BYTES_PER_CPU	(1U << 19)	/* 512 KiB */
 #define RINGBUF_MIN_SIZE	(1U << 22)	/* 4 MiB */
 #define RINGBUF_MAX_SIZE	(1U << 26)	/* 64 MiB */
-/* Processes with a reported executable mprotect transition, see probes */
+/* Processes and files with a reported executable mprotect transition */
 #define MPROTECT_SEEN_MAX_ENTRIES	16384
+#define MPROTECT_FILE_SEEN_MAX_ENTRIES	16384
 
 static u32
 bpf_ringbuf_size(int ncpu)
@@ -1408,9 +1409,20 @@ bpf_queue_open1(struct quark_queue *qq, int use_fentry)
 			qwarn("bpf_map__set_max_entries mprotect_seen");
 			goto fail;
 		}
-	} else if (bpf_map__set_autocreate(p->maps.mprotect_seen, 0) != 0) {
-		qwarn("bpf_map__set_autocreate mprotect_seen");
-		goto fail;
+		if (bpf_map__set_max_entries(p->maps.mprotect_file_seen,
+		    MPROTECT_FILE_SEEN_MAX_ENTRIES) != 0) {
+			qwarn("bpf_map__set_max_entries mprotect_file_seen");
+			goto fail;
+		}
+	} else {
+		if (bpf_map__set_autocreate(p->maps.mprotect_seen, 0) != 0) {
+			qwarn("bpf_map__set_autocreate mprotect_seen");
+			goto fail;
+		}
+		if (bpf_map__set_autocreate(p->maps.mprotect_file_seen, 0) != 0) {
+			qwarn("bpf_map__set_autocreate mprotect_file_seen");
+			goto fail;
+		}
 	}
 
 	if (qq->flags & QQ_GETPID)

--- a/elastic-ebpf/GPL/Events/EbpfEventProto.h
+++ b/elastic-ebpf/GPL/Events/EbpfEventProto.h
@@ -393,6 +393,9 @@ struct ebpf_process_mprotect_event {
     uint32_t dev_major;
     uint32_t dev_minor;
     uint32_t file_backed;
+
+    // Variable length fields: path (only present when file_backed)
+    struct ebpf_varlen_fields_start vl_fields;
 } __attribute__((packed));
 
 enum ebpf_net_info_transport {

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -131,16 +131,24 @@ struct {
     __uint(max_entries, 0);
 } mprotect_file_seen SEC(".maps");
 
-// The exec generation of the process. self_exec_id is u64 since Linux 5.7,
-// which every kernel this ring buffer backend loads on has, but read it by its
-// relocated size anyway; the targets are little endian so a narrower field
-// lands in the low bytes.
+// The exec generation of the process. self_exec_id is u64 since Linux 5.7 and
+// u32 before, so read it by its relocated size; the targets are little endian
+// so a narrower field lands in the low bytes. RHEL 8 (4.18) backported the
+// widening under kABI and the live field only exists in the task_struct_rh
+// extension there, see vmlinux_extra.h; a kernel with neither yields zero and
+// falls back to start_time alone.
 static u64 mprotect_exec_id(const struct task_struct *task)
 {
     const struct task_struct *leader = BPF_CORE_READ(task, group_leader);
     u64                       exec_id = 0;
 
-    bpf_core_read(&exec_id, bpf_core_field_size(leader->self_exec_id), &leader->self_exec_id);
+    if (bpf_core_field_exists(leader->self_exec_id)) {
+        bpf_core_read(&exec_id, bpf_core_field_size(leader->self_exec_id),
+                      &leader->self_exec_id);
+    } else if (bpf_core_field_exists(struct task_struct___el8, task_struct_rh)) {
+        exec_id = BPF_CORE_READ((const struct task_struct___el8 *)leader, task_struct_rh,
+                                self_exec_id);
+    }
 
     return exec_id;
 }

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -592,6 +592,8 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     event->req_prot        = req_prot;
     event->effective_prot  = effective_prot;
 
+    ebpf_vl_fields__init(&event->vl_fields);
+
     if (file) {
         event->file_backed = 1;
 
@@ -606,9 +608,18 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
                 event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
             }
         }
+
+        // File-backed executable transitions are rare and high signal
+        // (library tampering, packers, memfd JITs); annotate them with the
+        // mount-namespace-relative path. Anonymous memory has no path.
+        struct ebpf_varlen_field *field =
+            ebpf_vl_field__add(&event->vl_fields, EBPF_VL_FIELD_PATH);
+        struct path p = BPF_CORE_READ(file, f_path);
+        long size     = ebpf_resolve_path_to_string(field->data, &p, task);
+        ebpf_vl_field__set_size(&event->vl_fields, field, size);
     }
 
-    ebpf_ringbuf_write(&ringbuf, event, sizeof(*event), 0);
+    ebpf_ringbuf_write(&ringbuf, event, EVENT_SIZE(event), 0);
 
 out:
     return 0;

--- a/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
+++ b/elastic-ebpf/GPL/Events/Process/Probe.bpf.c
@@ -98,6 +98,86 @@ static void mprotect_seen__clear(u32 tgid)
     bpf_map_delete_elem(&mprotect_seen, &tgid);
 }
 
+/*
+ * File-backed transitions are deduplicated per file instead: one entry per
+ * (tgid, device, inode) with the transitions already reported for that file,
+ * so making a second file executable the same way is reported again. The
+ * value carries the process start time and self_exec_id, which the kernel
+ * bumps on every exec and never reuses within a process life; an entry left
+ * behind by a dead process (recycled tgid) or by a previous program image no
+ * longer matches and is simply claimed anew, so a stale entry never suppresses
+ * and this map needs no exec or exit clearing. (The mm pointer would not do:
+ * it is freed at exec and can come straight back from the slab two images
+ * later.) LRU eviction takes care of the leftovers and at worst costs a
+ * duplicate. Only referenced from the mprotect probes, sized from userspace,
+ * see bpf_queue_open1().
+ */
+struct mprotect_file_key {
+    u32 tgid;
+    u32 dev;
+    u64 inode;
+};
+
+struct mprotect_file_seen {
+    u64 start_time_ns;
+    u64 exec_id;
+    u64 bits;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct mprotect_file_key);
+    __type(value, struct mprotect_file_seen);
+    __uint(max_entries, 0);
+} mprotect_file_seen SEC(".maps");
+
+// The exec generation of the process. self_exec_id is u64 since Linux 5.7,
+// which every kernel this ring buffer backend loads on has, but read it by its
+// relocated size anyway; the targets are little endian so a narrower field
+// lands in the low bytes.
+static u64 mprotect_exec_id(const struct task_struct *task)
+{
+    const struct task_struct *leader = BPF_CORE_READ(task, group_leader);
+    u64                       exec_id = 0;
+
+    bpf_core_read(&exec_id, bpf_core_field_size(leader->self_exec_id), &leader->self_exec_id);
+
+    return exec_id;
+}
+
+// Same contract as mprotect_seen__test_and_set(), per file. Best effort with
+// the same plain read-test-write, and a lost race on a fresh or stale entry
+// overwrites it, so the failure mode is a duplicate event, never a lost one.
+static bool mprotect_file_seen__test_and_set(const struct task_struct *task, u32 tgid, u32 dev,
+                                             u64 inode, u32 id)
+{
+    struct mprotect_file_key key = {
+        .tgid  = tgid,
+        .dev   = dev,
+        .inode = inode,
+    };
+    u64 start_time_ns = BPF_CORE_READ(task, group_leader, start_time);
+    u64 exec_id       = mprotect_exec_id(task);
+    u64 bit           = 1ULL << (id & 63);
+
+    struct mprotect_file_seen *seen = bpf_map_lookup_elem(&mprotect_file_seen, &key);
+    if (seen == NULL || seen->start_time_ns != start_time_ns || seen->exec_id != exec_id) {
+        struct mprotect_file_seen fresh = {
+            .start_time_ns = start_time_ns,
+            .exec_id       = exec_id,
+            .bits          = bit,
+        };
+
+        bpf_map_update_elem(&mprotect_file_seen, &key, &fresh, BPF_ANY);
+        return false;
+    }
+    if (seen->bits & bit)
+        return true;
+    seen->bits |= bit;
+
+    return false;
+}
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(sched_process_fork, const struct task_struct *parent, const struct task_struct *child)
 {
@@ -572,10 +652,25 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
     u64 prev_prot          = mprotect_vm_flags_to_prot(vm_flags);
     struct file *file      = BPF_CORE_READ(vma, vm_file);
 
-    // One event per (transition, file-backedness) per process life.
+    u64 inode = 0;
+    u32 dev   = 0;
+    if (file) {
+        struct inode *ino = BPF_CORE_READ(file, f_inode);
+        if (ino) {
+            inode = BPF_CORE_READ(ino, i_ino);
+
+            struct super_block *sb = BPF_CORE_READ(ino, i_sb);
+            if (sb)
+                dev = BPF_CORE_READ(sb, s_dev);
+        }
+    }
+
+    // One event per transition per program image for anonymous mappings, per
+    // transition per file for file-backed ones.
     u32 tgid = bpf_get_current_pid_tgid() >> 32;
-    if (mprotect_seen__test_and_set(tgid, mprotect_transition_id(prev_prot, effective_prot,
-                                                                 file != NULL)))
+    u32 id   = mprotect_transition_id(prev_prot, effective_prot, file != NULL);
+    if (file ? mprotect_file_seen__test_and_set(task, tgid, dev, inode, id)
+             : mprotect_seen__test_and_set(tgid, id))
         goto out;
 
     struct ebpf_process_mprotect_event *event = get_zeroed_event_buffer(sizeof(*event));
@@ -596,18 +691,9 @@ static int security_file_mprotect__enter(struct vm_area_struct *vma,
 
     if (file) {
         event->file_backed = 1;
-
-        struct inode *inode = BPF_CORE_READ(file, f_inode);
-        if (inode) {
-            event->inode = BPF_CORE_READ(inode, i_ino);
-
-            struct super_block *sb = BPF_CORE_READ(inode, i_sb);
-            if (sb) {
-                dev_t dev       = BPF_CORE_READ(sb, s_dev);
-                event->dev_major = (u32)dev >> MPROTECT_MINORBITS;
-                event->dev_minor = (u32)dev & MPROTECT_MINORMASK;
-            }
-        }
+        event->inode       = inode;
+        event->dev_major   = dev >> MPROTECT_MINORBITS;
+        event->dev_minor   = dev & MPROTECT_MINORMASK;
 
         // File-backed executable transitions are rare and high signal
         // (library tampering, packers, memfd JITs); annotate them with the

--- a/elastic-ebpf/GPL/Events/vmlinux_extra.h
+++ b/elastic-ebpf/GPL/Events/vmlinux_extra.h
@@ -237,4 +237,19 @@ struct inode___6_11 {
 	void			*i_private; /* fs or device private pointer */
 };
 
+/*
+ * RHEL 8 (4.18) backported the 5.7 widening of self_exec_id to u64 under
+ * kABI: the live field moved into the task_struct_rh extension, reached
+ * through task_struct.task_struct_rh, while task_struct keeps a dead
+ * rh_reserved_self_exec_id. Partial definitions, CO-RE matches by name.
+ */
+struct task_struct_rh___el8 {
+	u64			parent_exec_id;
+	u64			self_exec_id;
+};
+
+struct task_struct___el8 {
+	struct task_struct_rh___el8	*task_struct_rh;
+};
+
 #endif	/* _VMLINUX_EXTRA_H_ */

--- a/quark-test.c
+++ b/quark-test.c
@@ -1579,9 +1579,12 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	const struct quark_mprotect	*qmprotect;
 	void				*addr[4];
 	void				*file_addr;
+	void				*file2_addr;
 	void				*suppressed_addr;
 	const size_t			 len = 4096;
-	struct stat			 st;
+	struct stat			 st, st2;
+	const char			*true_path;
+	int				 fd2;
 	const int			 expected[] = {
 		PROT_EXEC,
 		PROT_READ | PROT_EXEC,
@@ -1703,6 +1706,46 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 		assert(strcmp(qmprotect->path, self) == 0);
 	}
 
+	/*
+	 * File-backed transitions are deduplicated per file. Redo the same
+	 * R->RX on the first file, which must not be reported, then do it on
+	 * a second file, which must. The second file's event doubles as the
+	 * sentinel: if the repeat were wrongly emitted it would be drained
+	 * first and the identity asserts would trip.
+	 */
+	if (mprotect(file_addr, len, PROT_READ) == -1)
+		err(1, "mprotect");
+	if (mprotect(file_addr, len, PROT_READ | PROT_EXEC) == -1)
+		err(1, "mprotect");
+	if (stat("/usr/bin/true", &st2) == 0)
+		true_path = "/usr/bin/true";
+	else if (stat("/bin/true", &st2) == 0)
+		true_path = "/bin/true";
+	else
+		err(1, "no true binary");
+	assert(st2.st_ino != st.st_ino || st2.st_dev != st.st_dev);
+	if ((fd2 = open(true_path, O_RDONLY)) == -1)
+		err(1, "open");
+	file2_addr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd2, 0);
+	if (file2_addr == MAP_FAILED)
+		err(1, "mmap");
+	if (mprotect(file2_addr, len, PROT_READ | PROT_EXEC) == -1)
+		err(1, "mprotect");
+	do {
+		qev = drain_for_pid(&qq, getpid());
+	} while (!(qev->events & QUARK_EV_MPROTECT));
+	qmprotect = &qev->mprotect;
+	assert(qmprotect->vma_start <= (u64)(uintptr_t)file2_addr);
+	assert(qmprotect->vma_end >= (u64)(uintptr_t)file2_addr + len);
+	assert(qmprotect->prev_prot == PROT_READ);
+	assert(qmprotect->effective_prot == (PROT_READ | PROT_EXEC));
+	assert(qmprotect->file_backed);
+	assert(qmprotect->inode == (u64)st2.st_ino);
+	assert(qmprotect->dev_major == (u32)major(st2.st_dev));
+	assert(qmprotect->dev_minor == (u32)minor(st2.st_dev));
+	assert(qmprotect->path != NULL);
+	assert(strcmp(qmprotect->path, true_path) == 0);
+
 #ifdef SYS_pkey_mprotect
 	/* The common LSM hook also observes pkey_mprotect without another probe. */
 	{
@@ -1746,6 +1789,10 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	if (munmap(file_addr, len) == -1)
 		err(1, "munmap");
 	if (close(fd) == -1)
+		err(1, "close");
+	if (munmap(file2_addr, len) == -1)
+		err(1, "munmap");
+	if (close(fd2) == -1)
 		err(1, "close");
 
 	quark_queue_close(&qq);

--- a/quark-test.c
+++ b/quark-test.c
@@ -1668,7 +1668,7 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	if (mprotect(addr[0], len, expected[0]) == -1)
 		err(1, "mprotect");
 
-	/* File-backed identity is carried without resolving a pathname in BPF. */
+	/* File-backed attempts carry identity and a mount-ns relative path. */
 	if ((fd = open("/proc/self/exe", O_RDONLY)) == -1)
 		err(1, "open");
 	if (fstat(fd, &st) == -1)
@@ -1691,6 +1691,17 @@ t_mprotect(const struct test *t, struct quark_queue_attr *qa)
 	assert(qmprotect->inode == (u64)st.st_ino);
 	assert(qmprotect->dev_major == (u32)major(st.st_dev));
 	assert(qmprotect->dev_minor == (u32)minor(st.st_dev));
+	{
+		char	self[PATH_MAX];
+		ssize_t	n;
+
+		n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+		if (n == -1)
+			err(1, "readlink");
+		self[n] = '\0';
+		assert(qmprotect->path != NULL);
+		assert(strcmp(qmprotect->path, self) == 0);
+	}
 
 #ifdef SYS_pkey_mprotect
 	/* The common LSM hook also observes pkey_mprotect without another probe. */

--- a/quark.c
+++ b/quark.c
@@ -233,7 +233,9 @@ raw_event_free(struct raw_event *raw)
 	case RAW_COMM:		/* nada */
 	case RAW_SOCK_CONN:	/* nada */
 	case RAW_PTRACE:	/* nada */
-	case RAW_MPROTECT:	/* nada */
+		break;
+	case RAW_MPROTECT:
+		free(raw->mprotect.quark_mprotect.path);
 		break;
 	case RAW_PACKET:
 		free(raw->packet.quark_packet);
@@ -452,6 +454,7 @@ event_storage_clear(struct quark_queue *qq)
 	free(qq->event_storage.file);
 	qq->event_storage.file = NULL;
 	bzero(&qq->event_storage.ptrace, sizeof(qq->event_storage.ptrace));
+	free(qq->event_storage.mprotect.path);
 	bzero(&qq->event_storage.mprotect, sizeof(qq->event_storage.mprotect));
 	if (qq->event_storage.module_load != NULL) {
 		free(qq->event_storage.module_load->name);
@@ -2301,6 +2304,8 @@ quark_event_dump(const struct quark_event *qev, FILE *f)
 		    mprotect->effective_prot, effective_prot,
 		    mprotect->file_backed, mprotect->inode,
 		    mprotect->dev_major, mprotect->dev_minor);
+		if (mprotect->path != NULL)
+			PF(fl, "path=%s\n", mprotect->path);
 	}
 
 	if (qp == NULL)
@@ -4888,6 +4893,8 @@ raw_event_mprotect(struct quark_queue *qq, struct raw_event *raw)
 	qev->events = QUARK_EV_MPROTECT;
 	qev->process = quark_process_lookup(qq, raw->pid);
 	qev->mprotect = raw->mprotect.quark_mprotect;
+	/* Steal the path; event_storage_clear() frees it */
+	raw->mprotect.quark_mprotect.path = NULL;
 
 	return (qev);
 }

--- a/quark.h
+++ b/quark.h
@@ -421,6 +421,7 @@ struct quark_mprotect {
 	u32	dev_major;	/* zero for anonymous mappings */
 	u32	dev_minor;	/* zero for anonymous mappings */
 	u32	file_backed;
+	char   *path;		/* mount-ns relative; NULL for anonymous */
 };
 
 struct raw_ptrace {

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -70,6 +70,11 @@ The
 .Em mprotect
 member contains the VMA bounds, normalized previous protection,
 userspace-requested and kernel-adjusted protection, and backing-file identity.
+For file-backed mappings,
+.Em path
+is the mount-namespace relative path of the backing file; it is
+.Dv NULL
+for anonymous mappings.
 It describes an attempt and does not assert that the protection change was
 committed.
 .El

--- a/quark_queue_get_event.3
+++ b/quark_queue_get_event.3
@@ -75,6 +75,9 @@ For file-backed mappings,
 is the mount-namespace relative path of the backing file; it is
 .Dv NULL
 for anonymous mappings.
+Anonymous attempts are reported once per protection transition per process
+life, file-backed attempts once per protection transition per file per process
+life.
 It describes an attempt and does not assert that the protection change was
 committed.
 .El


### PR DESCRIPTION
Part 3 of 4 of the executable `mprotect()` event work, split out of #404 (which superseded #400) so each piece can be reviewed on its own. The stack, bottom-up, each PR based on the one before it:

1. #409 core LSM event, private
2. #410 deduplicate per process life, make public (`quark-mon -u`, manual pages, CHANGES)
3. this PR: backing-file path on file-backed events
4. #413 Go bindings

## Summary

File-backed executable attempts are rare and high signal (library tampering, packers, memfd fake JITs), so they now carry the mount-namespace relative path resolved from the VMA's file, as a variable-length field. The event keeps the zeroed fixed-size buffer (so the file identity fields stay zero for anonymous mappings, #409 dropped the explicit zeroing for that reason) and appends the variable-length tail after it. Anonymous mappings carry no path: `quark_mprotect.path` is `NULL`. The path is owned by the event storage and freed on the next `quark_queue_get_event(3)`.

**Second commit: per-file deduplication.** With the transition alone as the key, a process that makes two different files executable the same way (say RX→RWX on two libraries) reported only the first, which is the very case the file-backed event exists for (raised by @christos68k; per-file semantics chosen with @Aegrah for the lower false-negative rate). File-backed transitions now go through a second LRU map keyed by tgid, device and inode, so each file is reported once per transition per program image (per file per process life, the key includes the tgid) while anonymous mappings keep the per-process bitmap from #410. The value carries the process start time and `self_exec_id`, which the kernel bumps on every exec and never reuses within a process life: an entry left by a dead process (recycled tgid) or a previous program image no longer matches and is claimed anew, so a stale entry never suppresses and the map needs no exec or exit clearing. (The `mm` pointer would not do: it is freed at exec and can come straight back from the slab two images later.) LRU eviction handles leftovers and at worst costs a duplicate. Sized from userspace (16384 files, about 1.5 MB) and not created when `QQ_MPROTECT` is off. The volume argument stays intact: anonymous JIT churn is still collapsed per process, and the file-backed count is bounded by the number of distinct files a process makes executable.

**Third commit** is @christos68k's fix for RHEL 8: that kernel keeps kABI by renaming the original u32 `self_exec_id` and moving the live u64 counter into `task_struct_rh`, so the read goes through `bpf_core_field_exists` guards with `___el8` partial types in vmlinux_extra.h (cherry-picked from his draft branch).

## Tests

`t_mprotect` checks that the file-backed event carries the path of `/proc/self/exe`, that a repeated R→RX on that file is not reported, and that the same R→RX on a second file (`true`) is reported with that file's inode, device and path. Passes locally on 6.8, 5.14 (RHEL 9.3), 5.8.15 and RHEL 8's 4.18.0-553; the full `quark-test` suite was also run on 6.8 and on the RHEL 8 kernel at this stage.
