### PR TITLE
go: expose mprotect events

### DIFF
--- a/go/quark/quark.go
+++ b/go/quark/quark.go
@@ -183,6 +183,21 @@ type Ptrace struct {
 	Data     uint64
 }
 
+// Mprotect describes an executable protection attempt observed for one VMA.
+// The LSM check happens before the kernel commits the protection change.
+type Mprotect struct {
+	VmaStart      uint64
+	VmaEnd        uint64
+	PrevProt      uint64
+	ReqProt       uint64
+	EffectiveProt uint64
+	Inode         uint64
+	DevMajor      uint32
+	DevMinor      uint32
+	FileBacked    bool
+	Path          string // mount-ns relative; empty for anonymous mappings
+}
+
 type ModuleLoad struct {
 	Name       string
 	Version    string
@@ -227,6 +242,7 @@ type Event struct {
 	Packet     *Packet
 	File       *File
 	Ptrace     *Ptrace
+	Mprotect   *Mprotect
 	ModuleLoad *ModuleLoad
 	Shm        *any // ShmGet, MemFd or ShmOpen
 	Tty        *Tty
@@ -254,6 +270,7 @@ const (
 	QQ_TTY           = int(C.QQ_TTY)
 	QQ_PTRACE        = int(C.QQ_PTRACE)
 	QQ_MODULE_LOAD   = int(C.QQ_MODULE_LOAD)
+	QQ_MPROTECT      = int(C.QQ_MPROTECT)
 
 	// Event.events
 	QUARK_EV_FORK                  = uint64(C.QUARK_EV_FORK)
@@ -269,6 +286,7 @@ const (
 	QUARK_EV_MODULE_LOAD           = uint64(C.QUARK_EV_MODULE_LOAD)
 	QUARK_EV_SHM                   = uint64(C.QUARK_EV_SHM)
 	QUARK_EV_TTY                   = uint64(C.QUARK_EV_TTY)
+	QUARK_EV_MPROTECT              = uint64(C.QUARK_EV_MPROTECT)
 
 	// EntryLeaderType
 	QUARK_ELT_UNKNOWN   = int(C.QUARK_ELT_UNKNOWN)
@@ -467,6 +485,10 @@ func (queue *Queue) GetEvent() (Event, bool) {
 	if event.Events&QUARK_EV_PTRACE != 0 {
 		ptrace := ptraceFromC(&cev.ptrace)
 		event.Ptrace = &ptrace
+	}
+	if event.Events&QUARK_EV_MPROTECT != 0 {
+		mprotect := mprotectFromC(&cev.mprotect)
+		event.Mprotect = &mprotect
 	}
 	if cev.module_load != nil {
 		ml := moduleLoadFromC(cev.module_load)
@@ -776,6 +798,23 @@ func ptraceFromC(cPtrace *C.struct_quark_ptrace) Ptrace {
 	ptrace.Data = uint64(cPtrace.data)
 
 	return ptrace
+}
+
+func mprotectFromC(cMprotect *C.struct_quark_mprotect) Mprotect {
+	var mprotect Mprotect
+
+	mprotect.VmaStart = uint64(cMprotect.vma_start)
+	mprotect.VmaEnd = uint64(cMprotect.vma_end)
+	mprotect.PrevProt = uint64(cMprotect.prev_prot)
+	mprotect.ReqProt = uint64(cMprotect.req_prot)
+	mprotect.EffectiveProt = uint64(cMprotect.effective_prot)
+	mprotect.Inode = uint64(cMprotect.inode)
+	mprotect.DevMajor = uint32(cMprotect.dev_major)
+	mprotect.DevMinor = uint32(cMprotect.dev_minor)
+	mprotect.FileBacked = cMprotect.file_backed != 0
+	mprotect.Path = C.GoString(cMprotect.path)
+
+	return mprotect
 }
 
 func moduleLoadFromC(cM *C.struct_quark_module_load) ModuleLoad {


### PR DESCRIPTION
Part 4 of 4 of the executable `mprotect()` event work, split out of #404 (which superseded #400) so each piece can be reviewed on its own. The stack, bottom-up, each PR based on the one before it:

1. #409 core LSM event, private
2. #410 deduplicate per process life, make public (`quark-mon -u`, manual pages, CHANGES)
3. #412 backing-file path on file-backed events
4. this PR: Go bindings

## Summary

Go bindings for the mprotect events: `Mprotect` on `Event` mirroring `struct quark_mprotect` (`Path` is the empty string for anonymous mappings), and the `QQ_MPROTECT` and `QUARK_EV_MPROTECT` constants.

Compile-checked with `make quark-go-test` and `go vet`; the Go test binary needs a root box or the VM initramfs with glibc to run.
